### PR TITLE
fix(go-workflow): add HARD STOP to enforce worktree question

### DIFF
--- a/plugins/go-workflow/commands/start-issue.md
+++ b/plugins/go-workflow/commands/start-issue.md
@@ -52,18 +52,28 @@ Initialize persistent loop to ensure work continues until complete:
 
 ---
 
-## Step 0: Worktree Setup (Optional)
+## **HARD STOP** - Worktree Decision Required
 
-Ask the user if they want to work in an isolated worktree:
+**You MUST use AskUserQuestion NOW before doing anything else.**
 
-"Would you like to create a worktree for isolated work on this issue?"
+Do not:
+- Analyze the issue beyond the context already gathered
+- Launch Task or Explore agents
+- Enter plan mode
+- Start any implementation work
 
-| Option | Description |
-|--------|-------------|
-| Yes, create worktree | Create isolated worktree and switch to it |
-| No, work in current directory | Stay here and create a branch |
+Use AskUserQuestion with this exact configuration:
 
-**If user chooses worktree:**
+- **Question:** "Would you like to create a worktree for isolated work on issue #$ARGUMENTS?"
+- **Options:**
+  1. "Yes, create worktree" - Create isolated worktree and switch to it
+  2. "No, work in current directory" - Stay here and create a branch
+
+**WAIT for the user's response. Do not proceed until they answer.**
+
+---
+
+## If user chose "Yes, create worktree":
 
 **CRITICAL: When executing bash commands below, use backticks (\`) for command substitution, NOT $(). Claude Code has a bug that mangles $() syntax.**
 
@@ -133,6 +143,14 @@ Ask the user if they want to work in an isolated worktree:
    **WARNING:** If you edit files or run commands without changing to the worktree first, you will modify the wrong codebase.
 
 **Note:** When using a worktree, the branch is already created as `issue-<num>-<title>`. Skip the "Create Branch" step in the workflows below.
+
+Continue to **Step 1: Detect Issue Type** below.
+
+---
+
+## If user chose "No, work in current directory":
+
+Continue to **Step 1: Detect Issue Type** below. You will create a branch in the appropriate workflow step.
 
 ---
 


### PR DESCRIPTION
## Summary

- Add HARD STOP marker to force worktree question before any exploration
- Use explicit imperative language: "You MUST use AskUserQuestion NOW"
- Restructure command to gate all subsequent work on user response

## Problem

When running `/start-issue`, Claude was skipping the worktree setup question and immediately launching Explore agents due to its default "Explore-Plan-Code-Commit" agentic behavior.

## Solution

Uses the "HARD STOP" pattern documented in Claude Code best practices to force a mandatory pause. The explicit prohibitions prevent Claude from:
- Analyzing the issue beyond gathered context
- Launching Task or Explore agents
- Entering plan mode
- Starting implementation work

## Test plan

- [ ] Run `/go-workflow:start-issue <num>` on a test issue
- [ ] Verify Claude asks the worktree question FIRST (before any exploration)
- [ ] Verify Claude does NOT launch Explore/Task agents before asking
- [ ] Verify worktree is created (or not) based on user's choice

🤖 Generated with [Claude Code](https://claude.ai/code)
