### PR TITLE
feat(go-workflow): add address-review skill and CI watch

### DIFF
--- a/plugins/go-workflow/commands/address-review.md
+++ b/plugins/go-workflow/commands/address-review.md
@@ -1,0 +1,303 @@
+---
+argument-hint: "[PR-number]"
+description: "Address PR review comments, make fixes, reply, and resolve"
+model: claude-opus-4-5-20251101
+allowed-tools: ["Bash", "Read", "Glob", "Grep", "Edit", "Write", "Task", "AskUserQuestion"]
+---
+
+# Address PR Review Comments
+
+**If `$ARGUMENTS` is empty or not provided:**
+
+Auto-detect PR from current branch:
+
+```bash
+gh pr view --json number --jq '.number' 2>/dev/null
+```
+
+If no PR found, display usage and ask:
+
+**Usage:** `/address-review [PR-number]`
+
+**Example:** `/address-review 123` or just `/address-review` on a PR branch
+
+Ask the user: "No PR found for current branch. What PR number would you like to address?"
+
+---
+
+**If PR number is available (from `$ARGUMENTS` or auto-detected):**
+
+## Security Validation
+
+Validate input is numeric:
+!if [ -n "$ARGUMENTS" ] && ! echo "$ARGUMENTS" | grep -qE '^[0-9]+$'; then echo "Error: PR number must be numeric"; exit 1; fi
+
+## Loop Initialization
+
+Initialize persistent loop to ensure work continues until complete:
+!`"${CLAUDE_PLUGIN_ROOT}/scripts/setup-loop.sh" "address-review-${ARGUMENTS:-auto}" "COMPLETE"`
+
+## Context
+
+- PR details: !`PR_NUM="${ARGUMENTS:-$(gh pr view --json number --jq '.number' 2>/dev/null)}"; gh pr view "$PR_NUM" --json title,state,body,headRefName,baseRefName 2>/dev/null || echo "PR not found"`
+- Current branch: !`git branch --show-current`
+- Default branch: !`git remote show origin 2>/dev/null | grep 'HEAD branch' | sed 's/.*: //' || echo "main"`
+- PR number: !`echo "${ARGUMENTS:-$(gh pr view --json number --jq '.number' 2>/dev/null)}"`
+
+---
+
+## Branch Protection
+
+**CRITICAL:** Verify you are NOT on `main`, `master`, or the default branch.
+
+If the current branch is `main`, `master`, or matches the default branch:
+1. **STOP** - Do not make changes on the main branch
+2. **Check out the PR branch first**:
+   ```bash
+   gh pr checkout "$PR_NUM"
+   ```
+3. Then continue with the workflow
+
+---
+
+## Step 1: Get PR Number
+
+Set PR_NUM for use throughout:
+
+```bash
+PR_NUM="${ARGUMENTS:-$(gh pr view --json number --jq '.number')}"
+echo "Working on PR #$PR_NUM"
+```
+
+---
+
+## Step 2: Fetch Unresolved Review Threads
+
+Query all unresolved review threads with full comment details using GraphQL:
+
+```bash
+OWNER=$(gh repo view --json owner --jq '.owner.login')
+REPO=$(gh repo view --json name --jq '.name')
+
+gh api graphql -f query='
+  query($owner: String!, $repo: String!, $pr: Int!) {
+    repository(owner: $owner, name: $repo) {
+      pullRequest(number: $pr) {
+        reviewThreads(first: 100) {
+          nodes {
+            id
+            isResolved
+            path
+            line
+            comments(first: 50) {
+              nodes {
+                body
+                author { login }
+                createdAt
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+' -f owner="$OWNER" -f repo="$REPO" -F pr="$PR_NUM"
+```
+
+---
+
+## Step 3: Display and Analyze Comments
+
+Parse the GraphQL response and display each unresolved thread:
+
+**For each unresolved thread, note:**
+- Thread ID (needed for resolution later)
+- File path and line number
+- Comment body (the requested change)
+- Author
+
+If there are **no unresolved threads**, inform the user and exit:
+
+```
+<done>COMPLETE</done>
+```
+
+---
+
+## Step 4: Address Each Comment
+
+For each unresolved review comment:
+
+### 4a. Understand the Request
+
+Read the comment carefully. Determine what change is being requested:
+- Code style fix?
+- Logic change?
+- Documentation update?
+- Test addition?
+- Refactoring?
+
+### 4b. Locate the Code
+
+Use the file path and line number from the thread to find the relevant code:
+
+```bash
+# Read the file around the commented line
+```
+
+### 4c. Make the Fix
+
+Edit the code to address the feedback. Follow these principles:
+- Make the **minimal change** that addresses the comment
+- Follow existing code patterns
+- Don't introduce unrelated changes
+
+### 4d. Track the Fix
+
+Keep a mental note of:
+- Thread ID
+- What was fixed
+- Brief explanation for the reply
+
+---
+
+## Step 5: Commit and Push All Fixes
+
+After addressing all comments, bundle changes into a single commit:
+
+```bash
+git add -A
+git commit -m "address review comments
+
+- [brief summary of each fix]"
+git push
+```
+
+---
+
+## Step 6: Watch CI
+
+After pushing, watch CI and fix any failures:
+
+```bash
+gh pr checks "$PR_NUM" --watch
+```
+
+### If CI fails:
+
+1. Get failure details:
+   ```bash
+   gh pr checks "$PR_NUM" --json name,state,description
+   ```
+
+2. Analyze the failure (test errors, lint issues, build failures)
+
+3. Fix the issue
+
+4. Commit and push:
+   ```bash
+   git add -A
+   git commit -m "fix: address CI failure"
+   git push
+   ```
+
+5. Return to watching CI:
+   ```bash
+   gh pr checks "$PR_NUM" --watch
+   ```
+
+**Do not proceed to Step 7 until all CI checks pass.**
+
+---
+
+## Step 7: Reply to Each Comment
+
+For each addressed comment, post a reply explaining the fix:
+
+```bash
+gh pr comment "$PR_NUM" --body "Fixed in latest commit: [brief explanation of what was changed]"
+```
+
+**Reply guidelines:**
+- Keep replies brief and professional
+- Reference the specific change made
+- Don't be defensive or argumentative
+
+---
+
+## Step 8: Resolve All Review Threads
+
+**CRITICAL:** Only resolve threads after CI passes and fixes are pushed.
+
+For each thread ID collected in Step 3, resolve it via GraphQL:
+
+```bash
+gh api graphql -f query='
+  mutation($threadId: ID!) {
+    resolveReviewThread(input: {threadId: $threadId}) {
+      thread { isResolved }
+    }
+  }
+' -f threadId="THREAD_ID_HERE"
+```
+
+**Repeat for each unresolved thread.**
+
+---
+
+## Step 9: Verify Completion
+
+Confirm all threads are resolved:
+
+```bash
+OWNER=$(gh repo view --json owner --jq '.owner.login')
+REPO=$(gh repo view --json name --jq '.name')
+
+gh api graphql -f query='
+  query($owner: String!, $repo: String!, $pr: Int!) {
+    repository(owner: $owner, name: $repo) {
+      pullRequest(number: $pr) {
+        reviewThreads(first: 100) {
+          nodes {
+            isResolved
+          }
+        }
+      }
+    }
+  }
+' -f owner="$OWNER" -f repo="$REPO" -F pr="$PR_NUM" | jq '.data.repository.pullRequest.reviewThreads.nodes | map(select(.isResolved == false)) | length'
+```
+
+If count is 0, all threads are resolved.
+
+Confirm CI is passing:
+
+```bash
+gh pr checks "$PR_NUM"
+```
+
+---
+
+## Completion Criteria
+
+**DO NOT output `<done>COMPLETE</done>` until ALL of these conditions are TRUE:**
+
+1. All review comments have been addressed with code changes
+2. Changes are committed and pushed
+3. CI checks pass (`gh pr checks` shows all green)
+4. Replies have been posted to each comment
+5. All review threads are resolved (verified via GraphQL query)
+
+**When ALL criteria are met, output exactly:**
+
+```
+<done>COMPLETE</done>
+```
+
+This signals the loop to exit.
+
+---
+
+**Safety note:** If you've iterated 15+ times without success, document what's blocking progress and ask the user for guidance.
+
+Use extended thinking for complex analysis.

--- a/plugins/go-workflow/commands/commit.md
+++ b/plugins/go-workflow/commands/commit.md
@@ -1,6 +1,6 @@
 ---
 description: "Create a git commit with auto-generated message"
-allowed-tools: ["Bash(git add:*)", "Bash(git status:*)", "Bash(git commit:*)", "Bash(git diff:*)", "Bash(git log:*)"]
+allowed-tools: ["Bash(git add:*)", "Bash(git status:*)", "Bash(git commit:*)", "Bash(git diff:*)", "Bash(git log:*)", "Bash(git branch:*)", "Bash(git checkout:*)", "Bash(git remote:*)", "AskUserQuestion"]
 model: haiku
 ---
 
@@ -11,7 +11,26 @@ model: haiku
 - Current git status: !`git status`
 - Current git diff (staged and unstaged changes): !`git diff HEAD`
 - Current branch: !`git branch --show-current`
+- Default branch: !`git remote show origin 2>/dev/null | grep 'HEAD branch' | sed 's/.*: //' || echo "main"`
 - Recent commits (for style matching): !`git log --oneline -10`
+
+## Branch Protection
+
+**CRITICAL:** Check if you are on `main`, `master`, or the default branch.
+
+If the current branch is `main`, `master`, or matches the default branch:
+1. **STOP** - Do not commit directly to the main branch
+2. **Inform the user**: "You are on the main branch. Creating a feature branch is recommended."
+3. **Ask the user** using AskUserQuestion:
+   - "You're on the main branch. How would you like to proceed?"
+   - Options:
+     - "Create feature branch" - Create a new branch first, then commit
+     - "Commit to main anyway" - Only if user explicitly wants this
+
+If the user chooses "Create feature branch":
+- Analyze the changes to suggest a branch name
+- Create branch: `git checkout -b <type>/<short-description>`
+- Then proceed with the commit
 
 ## Your Task
 

--- a/plugins/go-workflow/commands/start-issue.md
+++ b/plugins/go-workflow/commands/start-issue.md
@@ -154,6 +154,18 @@ Continue to **Step 1: Detect Issue Type** below. You will create a branch in the
 
 ---
 
+## Branch Protection Check
+
+**CRITICAL:** Before starting any work, verify you will NOT commit to main/master.
+
+This workflow creates feature branches (`fix/` or `feat/`). If you are currently on `main`, `master`, or the default branch:
+- **If worktree was created**: You should already be on the `issue-<num>-<title>` branch
+- **If working in current directory**: A branch will be created in Step 3 (Bug) or Step 4 (Feature)
+
+**NEVER commit directly to main/master.** Always ensure a feature branch exists before making any code changes.
+
+---
+
 ## Step 1: Detect Issue Type
 
 Analyze the issue to determine if it's a **bug fix** or **new feature**:
@@ -218,8 +230,15 @@ When searching for root cause:
 
 ### 3. Create Branch (skip if worktree was created)
 
+**REQUIRED unless using a worktree.** Never commit to main/master.
+
 ```bash
 git checkout -b "fix/$ARGUMENTS-<short-desc>"
+```
+
+Verify you are on the new branch before proceeding:
+```bash
+git branch --show-current
 ```
 
 ### 4. TDD: Write Failing Test (Red)
@@ -237,6 +256,18 @@ Run the full test suite, linting, and type checking.
 ### 7. Submit
 
 Commit, push, and create a PR referencing the issue.
+
+### 8. Watch CI
+
+After creating the PR, watch CI and fix any failures:
+
+1. Run: `gh pr checks --watch`
+2. If checks fail:
+   - Get failure details: `gh pr checks --json name,state,description`
+   - Analyze and fix the failing check (test, lint, build)
+   - Commit and push the fix
+   - Return to step 1
+3. Continue only when all checks pass
 
 ---
 
@@ -270,8 +301,15 @@ Before coding, outline:
 
 ### 4. Create Branch (skip if worktree was created)
 
+**REQUIRED unless using a worktree.** Never commit to main/master.
+
 ```bash
 git checkout -b "feat/$ARGUMENTS-<short-desc>"
+```
+
+Verify you are on the new branch before proceeding:
+```bash
+git branch --show-current
 ```
 
 ### 5. Implement Feature
@@ -293,6 +331,18 @@ Run the full test suite, linting, and type checking.
 
 Commit, push, and create a PR referencing the issue.
 
+### 9. Watch CI
+
+After creating the PR, watch CI and fix any failures:
+
+1. Run: `gh pr checks --watch`
+2. If checks fail:
+   - Get failure details: `gh pr checks --json name,state,description`
+   - Analyze and fix the failing check (test, lint, build)
+   - Commit and push the fix
+   - Return to step 1
+3. Continue only when all checks pass
+
 ---
 
 ## Completion Criteria
@@ -305,6 +355,7 @@ Commit, push, and create a PR referencing the issue.
 4. Changes are committed with a proper commit message
 5. Changes are pushed to the remote branch
 6. PR is created and the PR URL is displayed
+7. CI checks pass (`gh pr checks` shows all green)
 
 **When ALL criteria are met, output exactly:**
 


### PR DESCRIPTION
## Summary

- Add new /address-review command to handle PR review comments automatically
- Add branch protection to /commit to prevent accidental commits to main
- Add CI watch functionality to /start-issue to ensure CI passes before completion

## Changes

### New: /address-review skill
Addresses PR review comments in a complete workflow:
1. Auto-detects PR from current branch or accepts PR number as argument
2. Fetches unresolved review threads via GitHub GraphQL API
3. Addresses each comment by analyzing the request and making code fixes
4. Commits and pushes all fixes in a single commit
5. Watches CI and fixes failures until all checks pass
6. Replies to each comment explaining the fix
7. Resolves all review threads via GraphQL mutation
8. Verifies completion (all threads resolved, CI green)

### Updated: /commit command
- Added branch protection check
- If on main/master/default branch, stops and asks user via AskUserQuestion
- Options: Create feature branch or Commit to main anyway

### Updated: /start-issue command
- Added explicit Branch Protection Check section
- Strengthened Create Branch steps with verification
- Added CI watch steps to both Bug Fix (Step 8) and Feature (Step 9) workflows
- Added CI checks pass to completion criteria

## Test plan

- [ ] Test /address-review on a PR with unresolved review comments
- [ ] Verify /commit asks before committing to main
- [ ] Verify /start-issue watches CI and does not complete until green