### PR TITLE
feat(llm-tools): update codex command for gpt-5.3-codex

### DIFF
--- a/plugins/llm-tools/commands/codex.md
+++ b/plugins/llm-tools/commands/codex.md
@@ -29,9 +29,9 @@ This command delegates tasks to OpenAI Codex CLI for autonomous execution.
 
 | Model | Best For |
 |-------|----------|
-| `gpt-5.2-codex` | Newest frontier model, best overall (default) |
+| `gpt-5.3-codex` | Newest frontier model, best overall (default) |
+| `gpt-5.2-codex` | Previous generation frontier model |
 | `gpt-5.1-codex-max` | Complex, long-running tasks (can run 24+ hours) |
-| `gpt-5.1-codex` | Fast, balanced performance |
 | `gpt-5.1-codex-mini` | Simple tasks, cost-efficient |
 
 Ask the user: "What would you like Codex to do?"
@@ -172,12 +172,12 @@ Ask the user which model to use:
 
 | Model | Best For |
 |-------|----------|
-| gpt-5.2-codex | Newest frontier model, best overall |
+| gpt-5.3-codex | Newest frontier model, best overall |
+| gpt-5.2-codex | Previous generation frontier model |
 | gpt-5.1-codex-max | Complex, long-running tasks (can run 24+ hours) |
-| gpt-5.1-codex | Fast, balanced performance |
 | gpt-5.1-codex-mini | Simple tasks, cost-efficient |
 
-Default: `gpt-5.2-codex`
+Default: `gpt-5.3-codex`
 
 ### R3. Run Codex Review
 
@@ -349,12 +349,12 @@ Ask the user which model to use:
 
 | Model | Best For |
 |-------|----------|
-| gpt-5.2-codex | Newest frontier model, best overall |
+| gpt-5.3-codex | Newest frontier model, best overall |
+| gpt-5.2-codex | Previous generation frontier model |
 | gpt-5.1-codex-max | Complex, long-running tasks (can run 24+ hours) |
-| gpt-5.1-codex | Fast, balanced performance |
 | gpt-5.1-codex-mini | Simple tasks, cost-efficient |
 
-Default: `gpt-5.2-codex`
+Default: `gpt-5.3-codex`
 
 ### 2. Include Session Context (Optional)
 


### PR DESCRIPTION
## Summary

- Update `/codex` command to use `gpt-5.3-codex` as the default model (released 2026-02-05)
- Move `gpt-5.2-codex` to "Previous generation frontier model" in all model tables
- Remove standalone `gpt-5.1-codex` entry (5.1-max and 5.1-mini variants remain)

Closes #13

🤖 Generated with [Claude Code](https://claude.com/claude-code)