### PR TITLE
feat(go-workflow): enforce TDD rigor, add security scan and pre-PR review

### DIFF
--- a/plugins/go-workflow/commands/start-issue.md
+++ b/plugins/go-workflow/commands/start-issue.md
@@ -22,8 +22,10 @@ This command starts work on a GitHub issue, automatically detecting whether it's
 1. Fetch issue details, labels, and comments
 2. Optionally create a git worktree for isolated work
 3. Auto-detect issue type (bug vs feature)
-4. For bugs: Check duplicates → TDD red-green → verify → security review → PR → `fix/` branch
-5. For features: Plan approach → TDD red-green → verify → security review → PR → `feat/` branch
+4. Create `fix/` or `feat/` branch (or use worktree branch)
+5. For bugs: Check duplicates → TDD red-green → verify → security review
+6. For features: Plan approach → TDD red-green → verify → security review
+7. Commit, push, and create PR
 
 Ask the user: "What issue number would you like to work on?"
 


### PR DESCRIPTION
## Summary

- Enforce explicit red-green TDD verification in both bug and feature workflows (run tests, confirm failure/pass before proceeding)
- Reorder feature workflow to true TDD: write tests first (red), then implement (green)
- Replace vague "verify" step with detailed checklist (go build, go test, golangci-lint, build logs)
- Add security review step: govulncheck + common Go vulnerability scan
- Add optional pre-PR code review step suggesting `/codex review`

Closes #15

## Test plan

- [ ] Run `/start-issue` on a bug issue and verify the red-green TDD steps enforce test failure/pass verification
- [ ] Run `/start-issue` on a feature issue and verify tests-first ordering with explicit verification
- [ ] Confirm the verify step checklist includes all four checks (build, test, lint, logs)
- [ ] Confirm security review step appears in both workflows
- [ ] Confirm pre-PR code review step appears in both workflows
- [ ] Verify step numbering is consistent (bug: 1-10, feature: 1-11)

🤖 Generated with [Claude Code](https://claude.com/claude-code)