### PR TITLE
Update model references to claude-opus-4-6

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,7 +34,7 @@ plugins/
 **Commands** (`commands/*.md`): Define slash commands with YAML frontmatter specifying:
 - `argument-hint`: Placeholder shown in command help
 - `description`: Short description for command list
-- `model`: Optional model override (e.g., `claude-opus-4-5-20251101`)
+- `model`: Optional model override (e.g., `claude-opus-4-6`)
 - `allowed-tools`: Tool restrictions for the command
 
 **Skills** (`skills/*/SKILL.md`): Auto-invoked behaviors with YAML frontmatter specifying:

--- a/plugins/go-dev/commands/explain.md
+++ b/plugins/go-dev/commands/explain.md
@@ -1,7 +1,7 @@
 ---
 argument-hint: "<file|function|package>"
 description: "Deep-dive explanation of Go code with diagrams"
-model: claude-opus-4-5-20251101
+model: claude-opus-4-6
 allowed-tools: ["Read", "Glob", "Grep", "AskUserQuestion"]
 ---
 

--- a/plugins/go-dev/commands/lint-fix.md
+++ b/plugins/go-dev/commands/lint-fix.md
@@ -1,7 +1,7 @@
 ---
 argument-hint: "[path] [--check]"
 description: "Auto-fix Go linting issues with golangci-lint"
-model: claude-opus-4-5-20251101
+model: claude-opus-4-6
 allowed-tools: ["Bash", "Read", "Write", "Edit", "Glob", "Grep", "AskUserQuestion"]
 ---
 

--- a/plugins/go-dev/commands/test-gen.md
+++ b/plugins/go-dev/commands/test-gen.md
@@ -1,7 +1,7 @@
 ---
 argument-hint: "<file|function>"
 description: "Generate comprehensive Go tests with table-driven patterns"
-model: claude-opus-4-5-20251101
+model: claude-opus-4-6
 allowed-tools: ["Bash", "Read", "Write", "Glob", "Grep", "AskUserQuestion"]
 ---
 

--- a/plugins/go-web/commands/convert-to-go-project.md
+++ b/plugins/go-web/commands/convert-to-go-project.md
@@ -1,7 +1,7 @@
 ---
 argument-hint: "[target-directory]"
 description: "Convert an existing project to the Go + Templ + HTMX + Tailwind stack"
-model: claude-opus-4-5-20251101
+model: claude-opus-4-6
 allowed-tools: ["Bash", "Read", "Write", "Edit", "Glob", "Grep", "AskUserQuestion"]
 ---
 

--- a/plugins/go-web/commands/create-go-project.md
+++ b/plugins/go-web/commands/create-go-project.md
@@ -1,7 +1,7 @@
 ---
 argument-hint: "<project-name>"
 description: "Create a new Go web project with Templ, HTMX, Tailwind, and sqlc"
-model: claude-opus-4-5-20251101
+model: claude-opus-4-6
 allowed-tools: ["Bash", "Read", "Write", "Edit", "Glob", "Grep", "AskUserQuestion"]
 ---
 

--- a/plugins/go-workflow/commands/address-review.md
+++ b/plugins/go-workflow/commands/address-review.md
@@ -1,7 +1,7 @@
 ---
 argument-hint: "[PR-number]"
 description: "Address PR review comments, make fixes, reply, and resolve"
-model: claude-opus-4-5-20251101
+model: claude-opus-4-6
 allowed-tools: ["Bash", "Read", "Glob", "Grep", "Edit", "Write", "Task", "AskUserQuestion"]
 ---
 

--- a/plugins/go-workflow/commands/start-issue.md
+++ b/plugins/go-workflow/commands/start-issue.md
@@ -1,7 +1,7 @@
 ---
 argument-hint: "<issue-number>"
 description: "Start working on a GitHub issue (auto-detects bug vs feature)"
-model: claude-opus-4-5-20251101
+model: claude-opus-4-6
 allowed-tools: ["Bash", "Read", "Glob", "Grep", "Edit", "Write", "AskUserQuestion"]
 ---
 

--- a/plugins/llm-tools/commands/convert.md
+++ b/plugins/llm-tools/commands/convert.md
@@ -1,7 +1,7 @@
 ---
 argument-hint: "<from> <to> [file]"
 description: "Convert between formats, languages, and data structures"
-model: claude-opus-4-5-20251101
+model: claude-opus-4-6
 allowed-tools: ["Bash", "Read", "Write", "Edit", "Glob", "Grep", "AskUserQuestion"]
 ---
 

--- a/plugins/llm-tools/commands/llm-compare.md
+++ b/plugins/llm-tools/commands/llm-compare.md
@@ -1,7 +1,7 @@
 ---
 argument-hint: "<prompt>"
 description: "Compare responses from multiple LLMs"
-model: claude-opus-4-5-20251101
+model: claude-opus-4-6
 allowed-tools: ["Bash", "Read", "AskUserQuestion"]
 ---
 

--- a/plugins/tailwind/commands/audit.md
+++ b/plugins/tailwind/commands/audit.md
@@ -1,7 +1,7 @@
 ---
 argument-hint: "[path] [--fix]"
 description: "Audit Tailwind CSS usage for best practices and consistency"
-model: claude-opus-4-5-20251101
+model: claude-opus-4-6
 allowed-tools: ["Bash", "Read", "Write", "Edit", "Glob", "Grep", "AskUserQuestion", "mcp__tailwindcss__search_tailwind_docs", "mcp__tailwindcss__get_tailwind_utilities", "mcp__tailwindcss__convert_css_to_tailwind"]
 ---
 

--- a/plugins/tailwind/commands/migrate.md
+++ b/plugins/tailwind/commands/migrate.md
@@ -1,7 +1,7 @@
 ---
 argument-hint: "[--check]"
 description: "Migrate Tailwind CSS v3 configuration to v4 CSS-based config"
-model: claude-opus-4-5-20251101
+model: claude-opus-4-6
 allowed-tools: ["Bash", "Read", "Write", "Edit", "Glob", "Grep", "AskUserQuestion", "mcp__tailwindcss__search_tailwind_docs", "mcp__tailwindcss__get_tailwind_config_guide"]
 ---
 


### PR DESCRIPTION
## Summary
- Replace `claude-opus-4-5-20251101` with `claude-opus-4-6` across all 11 command files and CLAUDE.md documentation
- Claude Opus 4.6 was released Feb 5, 2026; the new model ID drops the dated suffix

## Test plan
- [x] `grep -r "claude-opus-4-5" .` returns zero results
- [x] `grep -r "claude-opus-4-6" .` returns 12 matches (11 commands + 1 doc)
- [ ] Verify commands work with new model ID after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)