### PR TITLE
Auto-enter plan mode in /start-issue

### DIFF
--- a/plugins/go-workflow/commands/start-issue.md
+++ b/plugins/go-workflow/commands/start-issue.md
@@ -2,7 +2,7 @@
 argument-hint: "<issue-number>"
 description: "Start working on a GitHub issue (auto-detects bug vs feature)"
 model: claude-opus-4-6
-allowed-tools: ["Bash", "Read", "Glob", "Grep", "Edit", "Write", "AskUserQuestion"]
+allowed-tools: ["Bash", "Read", "Glob", "Grep", "Edit", "Write", "AskUserQuestion", "EnterPlanMode"]
 ---
 
 # Start Issue
@@ -33,6 +33,14 @@ Ask the user: "What issue number would you like to work on?"
 
 **If `$ARGUMENTS` is provided:**
 
+## Plan Mode Check
+
+**FIRST ACTION — before anything else:**
+
+If you are NOT currently in plan mode (no "Plan mode is active" in your system context), call the `EnterPlanMode` tool now. This ensures a proper plan is created and approved before implementation begins.
+
+If you ARE already in plan mode, continue with the workflow below.
+
 ## Security Validation
 
 First, validate input is numeric (prevent command injection):
@@ -60,7 +68,6 @@ Initialize persistent loop to ensure work continues until complete:
 Do not:
 - Analyze the issue beyond the context already gathered
 - Launch Task or Explore agents
-- Enter plan mode
 - Start any implementation work
 
 Use AskUserQuestion with this exact configuration:


### PR DESCRIPTION
## Summary

- Add a **Plan Mode Check** as the first action in `/start-issue` when an issue number is provided
- Claude now calls `EnterPlanMode` before any other work, ensuring a proper plan is created and approved before implementation begins
- Users can decline plan mode to continue with the normal workflow

## Changes

- Added `EnterPlanMode` to `allowed-tools` frontmatter
- Added Plan Mode Check section immediately after `$ARGUMENTS` provided block, before Security Validation
- Removed conflicting "do not enter plan mode" instruction from the HARD STOP section

## Test plan

- [ ] Run `/start-issue <num>` when NOT in plan mode → should prompt to enter plan mode
- [ ] Run `/start-issue <num>` when already in plan mode → should skip the check and proceed
- [ ] Decline plan mode when prompted → should continue with normal workflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)