### PR TITLE
feat(go-workflow): add post-fix verification to /address-review

### DIFF
--- a/plugins/go-workflow/commands/start-issue.md
+++ b/plugins/go-workflow/commands/start-issue.md
@@ -286,10 +286,7 @@ Run the full verification checklist. **All must pass before proceeding:**
 - **Build**: `go build ./...` — confirm compilation succeeds
 - **All tests**: `go test ./...` — confirm ALL tests pass (not just the new one)
 - **Lint**: `golangci-lint run` (if available) — confirm no lint issues
-- **Build logs**: Check for auto-build/dev-server errors if running:
-  - Air (Go): check `./tmp/air-combined.log` or path in `.air.toml`
-  - Node/Vite/Webpack: check terminal/build output
-  - Other: scan for common log locations
+- **Build logs**: If a dev server is running (Air, Vite, Webpack, etc.), check its log output for errors
 
 If any step fails, fix the issue and re-run until all green.
 
@@ -409,10 +406,7 @@ Run the full verification checklist. **All must pass before proceeding:**
 - **Build**: `go build ./...` — confirm compilation succeeds
 - **All tests**: `go test ./...` — confirm ALL tests pass (not just the new ones)
 - **Lint**: `golangci-lint run` (if available) — confirm no lint issues
-- **Build logs**: Check for auto-build/dev-server errors if running:
-  - Air (Go): check `./tmp/air-combined.log` or path in `.air.toml`
-  - Node/Vite/Webpack: check terminal/build output
-  - Other: scan for common log locations
+- **Build logs**: If a dev server is running (Air, Vite, Webpack, etc.), check its log output for errors
 
 If any step fails, fix the issue and re-run until all green.
 


### PR DESCRIPTION
## Summary
- Add local verification step (build, test, lint) after making fixes but before pushing, so issues are caught locally instead of waiting for CI round-trips
- Add fix-against-feedback validation (Step 4d) to ensure each change addresses the reviewer's actual intent, not just a mechanical edit
- Generalize dev-server log references in both `/address-review` and `/start-issue` to avoid hardcoded paths

Closes #16

## Test plan
- [ ] Run `/address-review` on a PR with review comments and verify it runs build/test/lint before committing
- [ ] Verify step numbering is correct and all cross-references updated
- [ ] Confirm `/start-issue` still works with the generic build log reference

🤖 Generated with [Claude Code](https://claude.com/claude-code)