### PR TITLE
feat(go-dev): add /bench command for benchmark generation and analysis

### DIFF
--- a/plugins/go-dev/commands/bench.md
+++ b/plugins/go-dev/commands/bench.md
@@ -136,7 +136,8 @@ Initialize persistent loop to ensure benchmarks are complete and analyzed:
    - Include sub-benchmarks for different input sizes where applicable
    - Create realistic test data, not trivial inputs
    - For unexported functions, use the same package (not `_test` suffix)
-   - For exported functions, prefer `_test` suffix package for realistic API testing
+   - For exported functions, use `_test` suffix package only when all parameter and return types
+     are also exported; otherwise use the same package to access unexported types
 
 4. **Run Benchmarks**
 


### PR DESCRIPTION
## Summary

- Add new `/bench` command to the go-dev plugin for Go benchmark generation, execution, and analysis
- Generates table-driven benchmarks with `b.ReportAllocs()`, sink variables, and sub-benchmarks for varying input sizes
- Runs benchmarks with `-benchmem -count=6` for statistical rigor, compares against baselines with `benchstat`, profiles CPU/memory with pprof, and suggests concrete optimizations

## Test plan

- [ ] Verify `/bench pkg/some/file.go` generates table-driven benchmark code
- [ ] Verify `/bench FunctionName` finds the function and generates benchmarks
- [ ] Verify empty `/bench` displays usage help and asks for target
- [ ] Verify benchstat comparison works when baseline exists
- [ ] Verify profiling step generates and analyzes cpu.pprof and mem.pprof
- [ ] Verify completion criteria enforces all steps before `<done>COMPLETE</done>`

Closes #18

🤖 Generated with [Claude Code](https://claude.com/claude-code)