### PR TITLE
fix: update owner email to info@gopherguides.com

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -2,7 +2,7 @@
   "name": "gopher-ai",
   "owner": {
     "name": "Gopher Guides",
-    "email": "support@gopherguides.com"
+    "email": "info@gopherguides.com"
   },
   "metadata": {
     "description": "Claude Code plugins for Go developers - by Gopher Guides",


### PR DESCRIPTION
## Summary
- Update marketplace owner email from `support@gopherguides.com` to `info@gopherguides.com` since the support address doesn't exist

## Test plan
- [ ] Verify `marketplace.json` is valid JSON
- [ ] Confirm `info@gopherguides.com` is the correct contact address

🤖 Generated with [Claude Code](https://claude.com/claude-code)