### PR TITLE
docs(mcp): Add MCP server documentation and fallback guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,6 +221,43 @@ Extensions are installed per-module. Each extension includes:
 - `skills/` - Auto-invoked skills
 - `commands/` - Command definitions (TOML format)
 
+## MCP Servers
+
+The **tailwind** module includes an MCP (Model Context Protocol) server for Tailwind CSS documentation lookups. This is configured automatically when using Claude Code.
+
+### tailwindcss-mcp-server
+
+**Defined in:** `plugins/tailwind/.claude-plugin/plugin.json`
+
+```json
+{
+  "mcpServers": {
+    "tailwindcss": {
+      "command": "npx",
+      "args": ["-y", "tailwindcss-mcp-server"]
+    }
+  }
+}
+```
+
+**Dependencies:**
+- Node.js 16+ (`node` and `npx` must be on your PATH)
+- Internet access on first run (to download the package)
+
+**Available MCP tools:**
+- `search_tailwind_docs` — Search Tailwind CSS documentation
+- `get_tailwind_utilities` — Get utility classes for CSS properties
+- `get_tailwind_colors` — Get color palette information
+- `convert_css_to_tailwind` — Convert CSS to Tailwind utilities
+
+**Fallback behavior:**
+If the MCP server is unavailable (Node.js not installed, network issues, or using a non-Claude platform), the Tailwind slash commands (`/tailwind-init`, `/tailwind-migrate`, `/tailwind-audit`, `/tailwind-optimize`) still work fully — they do not depend on the MCP server. The MCP tools provide supplementary documentation lookups only.
+
+**Troubleshooting:**
+- **"npx: command not found"** — Install Node.js 16+ (`brew install node` or [nodejs.org](https://nodejs.org))
+- **MCP tools not appearing** — Ensure you installed the `tailwind` plugin module; run `/plugin install tailwind@gopher-ai`
+- **Timeout on first run** — The first `npx -y tailwindcss-mcp-server` invocation downloads the package; subsequent runs are cached
+
 ## Requirements
 
 **All platforms:**

--- a/plugins/go-web/skills/templui/SKILL.md
+++ b/plugins/go-web/skills/templui/SKILL.md
@@ -6,7 +6,8 @@ description: |
   WHEN NOT: Non-Go projects, general web development without templ
 ---
 
-# templUI & HTMX/Alpine Best Practices
+
+<!-- cache:start --># templUI & HTMX/Alpine Best Practices
 
 Apply templUI patterns and HTMX/Alpine.js best practices when building Go/Templ web applications.
 
@@ -405,3 +406,5 @@ See "CRITICAL: Templ Interpolation in JavaScript" section above.
 ---
 
 *This skill provides templUI and HTMX/Alpine.js best practices for Go/Templ web development.*
+
+<!-- cache:end -->


### PR DESCRIPTION
Add 'MCP Servers' section to README.md documenting the tailwindcss-mcp-server, including dependencies, fallback behavior, and troubleshooting.

Closes #37