### PR TITLE
fix(gopher-guides): env var expansion unreliable in Claude Code Bash tool

### DIFF
--- a/plugins/gopher-guides/skills/gopher-guides/SKILL.md
+++ b/plugins/gopher-guides/skills/gopher-guides/SKILL.md
@@ -100,9 +100,8 @@ The training materials cover:
 
 If `--variable` is not supported (curl versions before 8.3), use `printf` to avoid shell expansion issues:
 
-```bash
-printf -v AUTH_HEADER "Authorization: Bearer %s" "$(printenv GOPHER_GUIDES_API_KEY)"
-curl -s -H "$AUTH_HEADER" https://gopherguides.com/api/gopher-ai/me
+```sh
+KEY=$(printenv GOPHER_GUIDES_API_KEY) && curl -s -H "Authorization: Bearer $KEY" https://gopherguides.com/api/gopher-ai/me
 ```
 
 Check your curl version with `curl --version`.


### PR DESCRIPTION
Remove all `$VAR` shell expansion curl syntax from SKILL.md. Keep only the `--variable %` / `--expand-header` approach which works reliably in AI coding assistant bash tools.

Add fallback note for curl < 8.3 using printf workaround.

Closes #40