### PR TITLE
fix(go-workflow): add CI check retry logic to prevent false negatives

### DIFF
--- a/plugins/go-workflow/commands/address-review.md
+++ b/plugins/go-workflow/commands/address-review.md
@@ -266,7 +266,7 @@ for i in 1 2 3; do sleep 10 && gh pr checks "$PR_NUM" --watch && break; done
 If still no checks after retries, verify the repo actually has CI workflow files:
 
 ```bash
-ls .github/workflows/*.{yml,yaml} 2>/dev/null || echo "No workflow files found"
+find .github/workflows -maxdepth 1 -name '*.yml' -o -name '*.yaml' 2>/dev/null | head -1 | grep -q . || echo "No workflow files found"
 ```
 
 Only conclude there are no CI checks if no `.yml`/`.yaml` workflow files exist. If workflow files exist, the checks are likely still propagating — wait longer and retry.

--- a/plugins/go-workflow/commands/start-issue.md
+++ b/plugins/go-workflow/commands/start-issue.md
@@ -322,7 +322,7 @@ After creating the PR, watch CI and fix any failures:
    ```
    If still no checks after retries, verify the repo actually has CI workflow files:
    ```bash
-   ls .github/workflows/*.{yml,yaml} 2>/dev/null || echo "No workflow files found"
+   find .github/workflows -maxdepth 1 -name '*.yml' -o -name '*.yaml' 2>/dev/null | head -1 | grep -q . || echo "No workflow files found"
    ```
    Only conclude there are no CI checks if no `.yml`/`.yaml` workflow files exist. If workflow files exist, the checks are likely still propagating — wait longer and retry.
 3. If checks fail:
@@ -451,7 +451,7 @@ After creating the PR, watch CI and fix any failures:
    ```
    If still no checks after retries, verify the repo actually has CI workflow files:
    ```bash
-   ls .github/workflows/*.{yml,yaml} 2>/dev/null || echo "No workflow files found"
+   find .github/workflows -maxdepth 1 -name '*.yml' -o -name '*.yaml' 2>/dev/null | head -1 | grep -q . || echo "No workflow files found"
    ```
    Only conclude there are no CI checks if no `.yml`/`.yaml` workflow files exist. If workflow files exist, the checks are likely still propagating — wait longer and retry.
 3. If checks fail:


### PR DESCRIPTION
## Summary

- Add retry logic (3 attempts, 10s delays) to all `gh pr checks --watch` steps in `start-issue` and `address-review` commands
- Add workflow file verification (`ls .github/workflows/`) as a fallback before concluding a repo has no CI checks
- Prevents false reports of "no CI checks" when GitHub hasn't registered the checks yet after a push
- Also updated `~/.claude/CLAUDE.md` global instructions with the same workflow file verification

## Files changed

- `plugins/go-workflow/commands/start-issue.md` — Bug Fix Step 10 + Feature Step 11
- `plugins/go-workflow/commands/address-review.md` — Step 7

## Test plan

- [ ] Run `/start-issue` on a repo with CI workflows and verify retry behavior when checks are slow to register
- [ ] Run `/address-review` after pushing and verify it retries before reporting no checks
- [ ] Verify repos with no `.github/workflows/` directory correctly report no CI checks without unnecessary retries

🤖 Generated with [Claude Code](https://claude.com/claude-code)