### PR TITLE
feat(go-web): auto-increment port and add Clerk CDN integration

### DIFF
--- a/plugins/go-web/commands/convert-to-go-project.md
+++ b/plugins/go-web/commands/convert-to-go-project.md
@@ -2812,7 +2812,7 @@ COPY . .
 
 RUN go install github.com/a-h/templ/cmd/templ@latest && \
     go install github.com/sqlc-dev/sqlc/cmd/sqlc@latest && \
-    sqlc generate && \
+    sqlc generate -f sqlc/sqlc.yaml && \
     templ generate && \
     npx @tailwindcss/cli -i static/css/input.css -o static/css/output.css --minify && \
     CGO_ENABLED=0 go build -o server ./cmd/server

--- a/plugins/go-web/commands/create-go-project.md
+++ b/plugins/go-web/commands/create-go-project.md
@@ -2571,7 +2571,7 @@ COPY . .
 
 RUN go install github.com/a-h/templ/cmd/templ@latest && \
     go install github.com/sqlc-dev/sqlc/cmd/sqlc@latest && \
-    sqlc generate && \
+    sqlc generate -f sqlc/sqlc.yaml && \
     templ generate && \
     npx @tailwindcss/cli -i static/css/input.css -o static/css/output.css --minify && \
     CGO_ENABLED=0 go build -o server ./cmd/server


### PR DESCRIPTION
## Summary

- **Auto-increment server port**: When the configured port (default 3000) is busy, the generated server code now tries the next available port, incrementing up to +100. Uses `net.Listen` with `e.Listener` to avoid TOCTOU race conditions. Logs a warning with the actual clickable URL when a different port is selected.

- **Clerk CDN integration**: Adds complete Clerk authentication templates to both `create-go-project` and `convert-to-go-project` commands. Fixes three issues with previous Clerk patterns:
  - Uses `data-clerk-publishable-key` attribute on the `<script>` tag (not a `<meta>` tag)
  - Uses `Clerk` as a global object directly (not `new Clerk()` constructor)
  - Uses `forceRedirectUrl` (not deprecated `afterSignInUrl`/`afterSignUpUrl`)
  - Adds client-side `Clerk.user` check on public pages as auth redirect fallback

## Test plan

- [ ] Generate a project with `/create-go-project`, start server on port 3000, start second instance — verify it binds to 3001 with a warning log
- [ ] Generate a project with Clerk selected — verify sign-in/sign-up pages render correctly
- [ ] Verify Clerk script tag has `data-clerk-publishable-key` attribute
- [ ] Verify redirect after authentication goes to `/dashboard`
- [ ] Verify home page redirects authenticated users to `/dashboard`

🤖 Generated with [Claude Code](https://claude.com/claude-code)