### PR TITLE
fix(go-workflow): prevent unconditional bot re-review in address-review

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ The `/start-issue` command handles the full issue-to-PR workflow:
 The `/address-review` command automates PR review handling:
 1. Addresses feedback from human and bot reviewers
 2. Auto-resolves review threads after fixes
-3. Requests re-review from bot reviewers (Codex, CodeRabbit, Greptile)
+3. Requests re-review only from reviewers who actually left feedback on the PR (including bots such as Codex, CodeRabbit, and Greptile when applicable)
 
 ### go-dev
 


### PR DESCRIPTION
## Summary

- Remove the standalone "Known AI/Bot Reviewers" table that primed the LLM to contact bots (like @codex) even when they never reviewed the PR
- Rewrite Step 11 with an explicit guard: only request re-review from reviewers who actually left feedback (collected in Step 4)
- Fix completion criteria item 9 to scope re-reviews to actual PR reviewers, not "all reviewers"
- Clarify Step 4 reviewer tracking as the source of truth for Step 11

The root cause was that the prominent bot table and ambiguous "all reviewers" language biased the LLM to unconditionally request `@codex review` on every PR.

## Test plan

- [ ] Run `/address-review` on a PR that was NOT reviewed by codex — verify no `@codex review` comment is posted
- [ ] Run `/address-review` on a PR that WAS reviewed by codex — verify `@codex review` comment IS posted
- [ ] Run `/address-review` on a PR with only human reviewers — verify only `gh pr edit --add-reviewer` is used

🤖 Generated with [Claude Code](https://claude.com/claude-code)