### PR TITLE
fix(go-workflow): skip worktree question when already in a worktree

### DIFF
--- a/plugins/go-workflow/commands/start-issue.md
+++ b/plugins/go-workflow/commands/start-issue.md
@@ -64,21 +64,14 @@ Initialize persistent loop to ensure work continues until complete:
 
 ```bash
 IN_WORKTREE=false
-TOPLEVEL="$(git rev-parse --show-toplevel 2>/dev/null)"
+GIT_DIR="$(git rev-parse --git-dir 2>/dev/null)"
 GIT_COMMON="$(git rev-parse --git-common-dir 2>/dev/null)"
-# Normalize to absolute path and strip trailing /.git
-if [ -n "$GIT_COMMON" ]; then
-  case "$GIT_COMMON" in
-    /*) COMMON_DIR="${GIT_COMMON%/.git}" ;;
-    *)  COMMON_DIR="$(cd "$TOPLEVEL" && cd "$GIT_COMMON/.." && pwd)" ;;
-  esac
-fi
-if [ -n "$TOPLEVEL" ] && [ -n "$COMMON_DIR" ] && [ "$TOPLEVEL" != "$COMMON_DIR" ]; then
+if [ -n "$GIT_DIR" ] && [ -n "$GIT_COMMON" ] && [ "$GIT_DIR" != "$GIT_COMMON" ]; then
   IN_WORKTREE=true
 fi
 ```
 
-This compares `--show-toplevel` (current checkout root) against the normalized `--git-common-dir` parent. In a main repo both resolve to the same absolute path; they differ only in a true worktree.
+This compares `--git-dir` against `--git-common-dir`. In the main repo both return `.git`; in a linked worktree `--git-dir` points to `.git/worktrees/<name>` while `--git-common-dir` stays `.git`. No path normalization needed since both use the same reference frame.
 
 **If `IN_WORKTREE=true`:** Skip the worktree question entirely. You are already in an isolated worktree. Proceed directly to "Plan Mode Check" (the "No, work in current directory" path). Display:
 

--- a/plugins/go-workflow/commands/start-issue.md
+++ b/plugins/go-workflow/commands/start-issue.md
@@ -58,9 +58,24 @@ Initialize persistent loop to ensure work continues until complete:
 
 ---
 
-## **HARD STOP** - Worktree Decision Required (BEFORE Plan Mode)
+## Worktree Detection & Decision (BEFORE Plan Mode)
 
-**You MUST use AskUserQuestion NOW before doing anything else — including EnterPlanMode.**
+**First, check if already running inside a git worktree:**
+
+```bash
+IN_WORKTREE=false
+if [ -f "$(git rev-parse --show-toplevel 2>/dev/null)/.git" ]; then
+  IN_WORKTREE=true
+fi
+```
+
+**If `IN_WORKTREE=true`:** Skip the worktree question entirely. You are already in an isolated worktree. Proceed directly to "Plan Mode Check" (the "No, work in current directory" path). Display:
+
+```
+Already running in a worktree — skipping worktree creation.
+```
+
+**If `IN_WORKTREE=false`:** You MUST use AskUserQuestion NOW before doing anything else — including EnterPlanMode.
 
 Do not:
 - Call EnterPlanMode yet

--- a/plugins/go-workflow/commands/start-issue.md
+++ b/plugins/go-workflow/commands/start-issue.md
@@ -64,14 +64,14 @@ Initialize persistent loop to ensure work continues until complete:
 
 ```bash
 IN_WORKTREE=false
-GIT_DIR="$(git rev-parse --git-dir 2>/dev/null)"
-GIT_COMMON="$(git rev-parse --git-common-dir 2>/dev/null)"
-if [ -n "$GIT_DIR" ] && [ -n "$GIT_COMMON" ] && [ "$GIT_DIR" != "$GIT_COMMON" ]; then
+GIT_DIR_ABS="$(cd "$(git rev-parse --git-dir 2>/dev/null)" && pwd)"
+GIT_COMMON_ABS="$(cd "$(git rev-parse --git-common-dir 2>/dev/null)" && pwd)"
+if [ -n "$GIT_DIR_ABS" ] && [ -n "$GIT_COMMON_ABS" ] && [ "$GIT_DIR_ABS" != "$GIT_COMMON_ABS" ]; then
   IN_WORKTREE=true
 fi
 ```
 
-This compares `--git-dir` against `--git-common-dir`. In the main repo both return `.git`; in a linked worktree `--git-dir` points to `.git/worktrees/<name>` while `--git-common-dir` stays `.git`. No path normalization needed since both use the same reference frame.
+This resolves both `--git-dir` and `--git-common-dir` to absolute paths via `cd ... && pwd`, then compares them. In the main repo (even from a subdirectory) both resolve to the same absolute `.git` path. In a linked worktree, `--git-dir` resolves to `.git/worktrees/<name>` while `--git-common-dir` resolves to `.git`.
 
 **If `IN_WORKTREE=true`:** Skip the worktree question entirely. You are already in an isolated worktree. Proceed directly to "Plan Mode Check" (the "No, work in current directory" path). Display:
 

--- a/plugins/go-workflow/commands/start-issue.md
+++ b/plugins/go-workflow/commands/start-issue.md
@@ -64,10 +64,14 @@ Initialize persistent loop to ensure work continues until complete:
 
 ```bash
 IN_WORKTREE=false
-if [ -f "$(git rev-parse --show-toplevel 2>/dev/null)/.git" ]; then
+TOPLEVEL="$(git rev-parse --show-toplevel 2>/dev/null)"
+COMMON_DIR="$(git rev-parse --git-common-dir 2>/dev/null | sed 's|/\.git$||')"
+if [ -n "$TOPLEVEL" ] && [ -n "$COMMON_DIR" ] && [ "$TOPLEVEL" != "$COMMON_DIR" ]; then
   IN_WORKTREE=true
 fi
 ```
+
+This compares `--show-toplevel` (current checkout root) against `--git-common-dir` (main repo's `.git` parent). They differ only in a true worktree, not in submodules or `--separate-git-dir` setups.
 
 **If `IN_WORKTREE=true`:** Skip the worktree question entirely. You are already in an isolated worktree. Proceed directly to "Plan Mode Check" (the "No, work in current directory" path). Display:
 

--- a/plugins/go-workflow/commands/start-issue.md
+++ b/plugins/go-workflow/commands/start-issue.md
@@ -64,8 +64,8 @@ Initialize persistent loop to ensure work continues until complete:
 
 ```bash
 IN_WORKTREE=false
-GIT_DIR_ABS="$(cd "$(git rev-parse --git-dir 2>/dev/null)" && pwd)"
-GIT_COMMON_ABS="$(cd "$(git rev-parse --git-common-dir 2>/dev/null)" && pwd)"
+GIT_DIR_ABS=`cd \`git rev-parse --git-dir 2>/dev/null\` && pwd`
+GIT_COMMON_ABS=`cd \`git rev-parse --git-common-dir 2>/dev/null\` && pwd`
 if [ -n "$GIT_DIR_ABS" ] && [ -n "$GIT_COMMON_ABS" ] && [ "$GIT_DIR_ABS" != "$GIT_COMMON_ABS" ]; then
   IN_WORKTREE=true
 fi


### PR DESCRIPTION
## Summary

- When `/start-issue` is run inside an existing worktree (e.g., launched via `claude -w` or the `wt` alias), it now detects this and skips the "Would you like to create a worktree?" question
- Detection uses `[ -f .git ]` — in worktrees `.git` is a file, in the main repo it's a directory
- Proceeds directly to plan mode as if the user chose "No, work in current directory"

## Test plan

- [ ] Run `wt <num>` (creates worktree + launches `claude -w`), then `/start-issue <num>` — should skip the worktree question and go straight to plan mode
- [ ] Run `/start-issue <num>` from the main repo (not a worktree) — should still ask the worktree question as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)