### PR TITLE
fix(go-workflow,productivity): replace backtick bash patterns with robust $() substitution

### DIFF
--- a/plugins/go-workflow/commands/address-review.md
+++ b/plugins/go-workflow/commands/address-review.md
@@ -39,10 +39,10 @@ Initialize persistent loop to ensure work continues until complete:
 
 ## Context
 
-- PR details: !$(PR_NUM="${ARGUMENTS:-$(gh pr view --json number --jq '.number' 2>/dev/null)}"; gh pr view "$PR_NUM" --json title,state,body,headRefName,baseRefName 2>/dev/null || echo "PR not found")
-- Current branch: !$(git branch --show-current 2>&1 || echo "unknown")
-- Default branch: !$(git remote show origin 2>/dev/null | grep 'HEAD branch' | sed 's/.*: //' || echo "main")
-- PR number: !$(echo "${ARGUMENTS:-$(gh pr view --json number --jq '.number' 2>/dev/null)}")
+- PR details: !`PR_NUM="${ARGUMENTS:-\`gh pr view --json number --jq '.number' 2>/dev/null\`}"; gh pr view "$PR_NUM" --json title,state,body,headRefName,baseRefName 2>/dev/null || echo "PR not found"`
+- Current branch: !`git branch --show-current 2>&1 || echo "unknown"`
+- Default branch: !`git remote show origin 2>/dev/null | grep 'HEAD branch' | sed 's/.*: //' || echo "main"`
+- PR number: !`echo "${ARGUMENTS:-\`gh pr view --json number --jq '.number' 2>/dev/null\`}"`
 
 ---
 

--- a/plugins/go-workflow/commands/address-review.md
+++ b/plugins/go-workflow/commands/address-review.md
@@ -39,10 +39,10 @@ Initialize persistent loop to ensure work continues until complete:
 
 ## Context
 
-- PR details: !`PR_NUM="${ARGUMENTS:-$(gh pr view --json number --jq '.number' 2>/dev/null)}"; gh pr view "$PR_NUM" --json title,state,body,headRefName,baseRefName 2>/dev/null || echo "PR not found"`
-- Current branch: !`git branch --show-current`
-- Default branch: !`git remote show origin 2>/dev/null | grep 'HEAD branch' | sed 's/.*: //' || echo "main"`
-- PR number: !`echo "${ARGUMENTS:-$(gh pr view --json number --jq '.number' 2>/dev/null)}"`
+- PR details: !$(PR_NUM="${ARGUMENTS:-$(gh pr view --json number --jq '.number' 2>/dev/null)}"; gh pr view "$PR_NUM" --json title,state,body,headRefName,baseRefName 2>/dev/null || echo "PR not found")
+- Current branch: !$(git branch --show-current 2>&1 || echo "unknown")
+- Default branch: !$(git remote show origin 2>/dev/null | grep 'HEAD branch' | sed 's/.*: //' || echo "main")
+- PR number: !$(echo "${ARGUMENTS:-$(gh pr view --json number --jq '.number' 2>/dev/null)}")
 
 ---
 

--- a/plugins/go-workflow/commands/commit.md
+++ b/plugins/go-workflow/commands/commit.md
@@ -8,11 +8,11 @@ model: haiku
 
 ## Context
 
-- Current git status: !$(git status 2>&1 || echo "Unable to get git status")
-- Current git diff (staged and unstaged changes): !$(git diff HEAD 2>&1 || echo "No diff available (may have no commits)")
-- Current branch: !$(git branch --show-current 2>&1 || echo "unknown")
-- Default branch: !$(git remote show origin 2>/dev/null | grep 'HEAD branch' | sed 's/.*: //' || echo "main")
-- Recent commits (for style matching): !$(git log --oneline -10 2>&1 || echo "No commits in history")
+- Current git status: !`git status 2>&1 || echo "Unable to get git status"`
+- Current git diff (staged and unstaged changes): !`git diff HEAD 2>&1 || echo "No diff available (may have no commits)"`
+- Current branch: !`git branch --show-current 2>&1 || echo "unknown"`
+- Default branch: !`git remote show origin 2>/dev/null | grep 'HEAD branch' | sed 's/.*: //' || echo "main"`
+- Recent commits (for style matching): !`git log --oneline -10 2>&1 || echo "No commits in history"`
 
 ## Branch Protection
 

--- a/plugins/go-workflow/commands/commit.md
+++ b/plugins/go-workflow/commands/commit.md
@@ -8,11 +8,11 @@ model: haiku
 
 ## Context
 
-- Current git status: !`git status`
-- Current git diff (staged and unstaged changes): !`git diff HEAD`
-- Current branch: !`git branch --show-current`
-- Default branch: !`git remote show origin 2>/dev/null | grep 'HEAD branch' | sed 's/.*: //' || echo "main"`
-- Recent commits (for style matching): !`git log --oneline -10`
+- Current git status: !$(git status 2>&1 || echo "Unable to get git status")
+- Current git diff (staged and unstaged changes): !$(git diff HEAD 2>&1 || echo "No diff available (may have no commits)")
+- Current branch: !$(git branch --show-current 2>&1 || echo "unknown")
+- Default branch: !$(git remote show origin 2>/dev/null | grep 'HEAD branch' | sed 's/.*: //' || echo "main")
+- Recent commits (for style matching): !$(git log --oneline -10 2>&1 || echo "No commits in history")
 
 ## Branch Protection
 

--- a/plugins/go-workflow/commands/create-pr.md
+++ b/plugins/go-workflow/commands/create-pr.md
@@ -7,12 +7,12 @@ allowed-tools: ["Read", "Bash(git:*)", "Bash(gh:*)", "Bash(cat:*)", "Bash(ls:*)"
 
 ## Context
 
-- Current branch: !`git branch --show-current`
-- Default branch: !`git remote show origin 2>/dev/null | grep 'HEAD branch' | sed 's/.*: //' | grep . || echo "main"`
-- Commits on this branch: !`git log $(git remote show origin 2>/dev/null | grep 'HEAD branch' | sed 's/.*: //' | grep . || echo "main")..HEAD --oneline 2>/dev/null || echo "No commits found"`
-- Diff stat: !`git diff $(git remote show origin 2>/dev/null | grep 'HEAD branch' | sed 's/.*: //' | grep . || echo "main")..HEAD --stat 2>/dev/null || echo "No diff"`
-- PR template: !`cat .github/pull_request_template.md 2>/dev/null || cat .github/PULL_REQUEST_TEMPLATE.md 2>/dev/null || cat docs/pull_request_template.md 2>/dev/null || cat pull_request_template.md 2>/dev/null || echo "NO_TEMPLATE_FOUND"`
-- Multiple templates directory: !`ls .github/PULL_REQUEST_TEMPLATE/ 2>/dev/null || ls docs/PULL_REQUEST_TEMPLATE/ 2>/dev/null || ls PULL_REQUEST_TEMPLATE/ 2>/dev/null || echo "NO_TEMPLATE_DIR"`
+- Current branch: !$(git branch --show-current 2>&1 || echo "unknown")
+- Default branch: !$(git remote show origin 2>/dev/null | grep 'HEAD branch' | sed 's/.*: //' | grep . || echo "main")
+- Commits on this branch: !$(git log "$(git remote show origin 2>/dev/null | grep 'HEAD branch' | sed 's/.*: //' | grep . || echo 'main')"..HEAD --oneline 2>/dev/null || echo "No commits found")
+- Diff stat: !$(git diff "$(git remote show origin 2>/dev/null | grep 'HEAD branch' | sed 's/.*: //' | grep . || echo 'main')"..HEAD --stat 2>/dev/null || echo "No diff")
+- PR template: !$(cat .github/pull_request_template.md 2>/dev/null || cat .github/PULL_REQUEST_TEMPLATE.md 2>/dev/null || cat docs/pull_request_template.md 2>/dev/null || cat pull_request_template.md 2>/dev/null || echo "NO_TEMPLATE_FOUND")
+- Multiple templates directory: !$(ls .github/PULL_REQUEST_TEMPLATE/ 2>/dev/null || ls docs/PULL_REQUEST_TEMPLATE/ 2>/dev/null || ls PULL_REQUEST_TEMPLATE/ 2>/dev/null || echo "NO_TEMPLATE_DIR")
 
 ## Branch Protection
 

--- a/plugins/go-workflow/commands/create-pr.md
+++ b/plugins/go-workflow/commands/create-pr.md
@@ -7,12 +7,12 @@ allowed-tools: ["Read", "Bash(git:*)", "Bash(gh:*)", "Bash(cat:*)", "Bash(ls:*)"
 
 ## Context
 
-- Current branch: !$(git branch --show-current 2>&1 || echo "unknown")
-- Default branch: !$(git remote show origin 2>/dev/null | grep 'HEAD branch' | sed 's/.*: //' | grep . || echo "main")
-- Commits on this branch: !$(git log "$(git remote show origin 2>/dev/null | grep 'HEAD branch' | sed 's/.*: //' | grep . || echo 'main')"..HEAD --oneline 2>/dev/null || echo "No commits found")
-- Diff stat: !$(git diff "$(git remote show origin 2>/dev/null | grep 'HEAD branch' | sed 's/.*: //' | grep . || echo 'main')"..HEAD --stat 2>/dev/null || echo "No diff")
-- PR template: !$(cat .github/pull_request_template.md 2>/dev/null || cat .github/PULL_REQUEST_TEMPLATE.md 2>/dev/null || cat docs/pull_request_template.md 2>/dev/null || cat pull_request_template.md 2>/dev/null || echo "NO_TEMPLATE_FOUND")
-- Multiple templates directory: !$(ls .github/PULL_REQUEST_TEMPLATE/ 2>/dev/null || ls docs/PULL_REQUEST_TEMPLATE/ 2>/dev/null || ls PULL_REQUEST_TEMPLATE/ 2>/dev/null || echo "NO_TEMPLATE_DIR")
+- Current branch: !`git branch --show-current 2>&1 || echo "unknown"`
+- Default branch: !`git remote show origin 2>/dev/null | grep 'HEAD branch' | sed 's/.*: //' | grep . || echo "main"`
+- Commits on this branch: !`DEFAULT=\`git remote show origin 2>/dev/null | grep 'HEAD branch' | sed 's/.*: //' | grep . || echo "main"\`; git log "$DEFAULT"..HEAD --oneline 2>/dev/null || echo "No commits found"`
+- Diff stat: !`DEFAULT=\`git remote show origin 2>/dev/null | grep 'HEAD branch' | sed 's/.*: //' | grep . || echo "main"\`; git diff "$DEFAULT"..HEAD --stat 2>/dev/null || echo "No diff"`
+- PR template: !`cat .github/pull_request_template.md 2>/dev/null || cat .github/PULL_REQUEST_TEMPLATE.md 2>/dev/null || cat docs/pull_request_template.md 2>/dev/null || cat pull_request_template.md 2>/dev/null || echo "NO_TEMPLATE_FOUND"`
+- Multiple templates directory: !`ls .github/PULL_REQUEST_TEMPLATE/ 2>/dev/null || ls docs/PULL_REQUEST_TEMPLATE/ 2>/dev/null || ls PULL_REQUEST_TEMPLATE/ 2>/dev/null || echo "NO_TEMPLATE_DIR"`
 
 ## Branch Protection
 

--- a/plugins/go-workflow/commands/create-worktree.md
+++ b/plugins/go-workflow/commands/create-worktree.md
@@ -46,10 +46,10 @@ Clear any stale worktree state so the pre-tool-use hook doesn't block setup comm
 
 ## Context
 
-- Current directory: !$(pwd 2>&1 || echo "unknown")
-- Repository name: !$(basename "$(git rev-parse --show-toplevel 2>/dev/null)" 2>/dev/null || echo "unknown")
-- Default branch: !$(git remote show origin 2>/dev/null | grep 'HEAD branch' | sed 's/.*: //' || echo "main")
-- Existing worktrees: !$(git worktree list 2>&1 || echo "No worktrees found")
+- Current directory: !`pwd 2>&1 || echo "unknown"`
+- Repository name: !`basename \`git rev-parse --show-toplevel 2>/dev/null\` 2>/dev/null || echo "unknown"`
+- Default branch: !`git remote show origin 2>/dev/null | grep 'HEAD branch' | sed 's/.*: //' || echo "main"`
+- Existing worktrees: !`git worktree list 2>&1 || echo "No worktrees found"`
 
 ## Steps
 

--- a/plugins/go-workflow/commands/create-worktree.md
+++ b/plugins/go-workflow/commands/create-worktree.md
@@ -46,10 +46,10 @@ Clear any stale worktree state so the pre-tool-use hook doesn't block setup comm
 
 ## Context
 
-- Current directory: !`pwd`
-- Repository name: !`basename $(git rev-parse --show-toplevel)`
-- Default branch: !`git remote show origin | grep 'HEAD branch' | sed 's/.*: //'`
-- Existing worktrees: !`git worktree list`
+- Current directory: !$(pwd 2>&1 || echo "unknown")
+- Repository name: !$(basename "$(git rev-parse --show-toplevel 2>/dev/null)" 2>/dev/null || echo "unknown")
+- Default branch: !$(git remote show origin 2>/dev/null | grep 'HEAD branch' | sed 's/.*: //' || echo "main")
+- Existing worktrees: !$(git worktree list 2>&1 || echo "No worktrees found")
 
 ## Steps
 

--- a/plugins/go-workflow/commands/prune-worktree.md
+++ b/plugins/go-workflow/commands/prune-worktree.md
@@ -31,10 +31,10 @@ Clear any active worktree state so the pre-tool-use hook doesn't block cleanup c
 
 ## Context
 
-- Repository name: !`basename $(git rev-parse --show-toplevel)`
-- Default branch: !`git remote show origin | grep 'HEAD branch' | sed 's/.*: //'`
-- All worktrees: !`git worktree list`
-- Issue worktrees: !`git worktree list | grep -E "issue-[0-9]+" || echo "No issue worktrees found"`
+- Repository name: !$(basename "$(git rev-parse --show-toplevel 2>/dev/null)" 2>/dev/null || echo "unknown")
+- Default branch: !$(git remote show origin 2>/dev/null | grep 'HEAD branch' | sed 's/.*: //' || echo "main")
+- All worktrees: !$(git worktree list 2>&1 || echo "No worktrees found")
+- Issue worktrees: !$(git worktree list 2>/dev/null | grep -E "issue-[0-9]+" || echo "No issue worktrees found")
 
 ---
 

--- a/plugins/go-workflow/commands/prune-worktree.md
+++ b/plugins/go-workflow/commands/prune-worktree.md
@@ -31,10 +31,10 @@ Clear any active worktree state so the pre-tool-use hook doesn't block cleanup c
 
 ## Context
 
-- Repository name: !$(basename "$(git rev-parse --show-toplevel 2>/dev/null)" 2>/dev/null || echo "unknown")
-- Default branch: !$(git remote show origin 2>/dev/null | grep 'HEAD branch' | sed 's/.*: //' || echo "main")
-- All worktrees: !$(git worktree list 2>&1 || echo "No worktrees found")
-- Issue worktrees: !$(git worktree list 2>/dev/null | grep -E "issue-[0-9]+" || echo "No issue worktrees found")
+- Repository name: !`basename \`git rev-parse --show-toplevel 2>/dev/null\` 2>/dev/null || echo "unknown"`
+- Default branch: !`git remote show origin 2>/dev/null | grep 'HEAD branch' | sed 's/.*: //' || echo "main"`
+- All worktrees: !`git worktree list 2>&1 || echo "No worktrees found"`
+- Issue worktrees: !`git worktree list 2>/dev/null | grep -E "issue-[0-9]+" || echo "No issue worktrees found"`
 
 ---
 

--- a/plugins/go-workflow/commands/remove-worktree.md
+++ b/plugins/go-workflow/commands/remove-worktree.md
@@ -17,10 +17,10 @@ Clear any active worktree state so the pre-tool-use hook doesn't block cleanup c
 
 ## Context
 
-- Repository name: !$(basename "$(git rev-parse --show-toplevel 2>/dev/null)" 2>/dev/null || echo "unknown")
-- Default branch: !$(git remote show origin 2>/dev/null | grep 'HEAD branch' | sed 's/.*: //' || echo "main")
-- All worktrees: !$(git worktree list 2>&1 || echo "No worktrees found")
-- Issue worktrees: !$(git worktree list 2>/dev/null | grep -E "issue-[0-9]+" || echo "No issue worktrees found")
+- Repository name: !`basename \`git rev-parse --show-toplevel 2>/dev/null\` 2>/dev/null || echo "unknown"`
+- Default branch: !`git remote show origin 2>/dev/null | grep 'HEAD branch' | sed 's/.*: //' || echo "main"`
+- All worktrees: !`git worktree list 2>&1 || echo "No worktrees found"`
+- Issue worktrees: !`git worktree list 2>/dev/null | grep -E "issue-[0-9]+" || echo "No issue worktrees found"`
 
 ---
 

--- a/plugins/go-workflow/commands/remove-worktree.md
+++ b/plugins/go-workflow/commands/remove-worktree.md
@@ -17,10 +17,10 @@ Clear any active worktree state so the pre-tool-use hook doesn't block cleanup c
 
 ## Context
 
-- Repository name: !`basename $(git rev-parse --show-toplevel)`
-- Default branch: !`git remote show origin | grep 'HEAD branch' | sed 's/.*: //'`
-- All worktrees: !`git worktree list`
-- Issue worktrees: !`git worktree list | grep -E "issue-[0-9]+" || echo "No issue worktrees found"`
+- Repository name: !$(basename "$(git rev-parse --show-toplevel 2>/dev/null)" 2>/dev/null || echo "unknown")
+- Default branch: !$(git remote show origin 2>/dev/null | grep 'HEAD branch' | sed 's/.*: //' || echo "main")
+- All worktrees: !$(git worktree list 2>&1 || echo "No worktrees found")
+- Issue worktrees: !$(git worktree list 2>/dev/null | grep -E "issue-[0-9]+" || echo "No issue worktrees found")
 
 ---
 

--- a/plugins/go-workflow/commands/start-issue.md
+++ b/plugins/go-workflow/commands/start-issue.md
@@ -50,11 +50,11 @@ Initialize persistent loop to ensure work continues until complete:
 
 ## Context
 
-- Issue details: !`gh issue view "$ARGUMENTS" --json title,state,body,labels,comments 2>/dev/null || echo "Issue not found"`
-- Current branch: !`git branch --show-current`
-- Default branch: !`git remote show origin | grep 'HEAD branch' | sed 's/.*: //'`
-- Repository name: !`basename $(git rev-parse --show-toplevel)`
-- Existing worktrees: !`git worktree list`
+- Issue details: !$(gh issue view "$ARGUMENTS" --json title,state,body,labels,comments 2>/dev/null || echo "Issue not found")
+- Current branch: !$(git branch --show-current 2>&1 || echo "unknown")
+- Default branch: !$(git remote show origin 2>/dev/null | grep 'HEAD branch' | sed 's/.*: //' || echo "main")
+- Repository name: !$(basename "$(git rev-parse --show-toplevel 2>/dev/null)" 2>/dev/null || echo "unknown")
+- Existing worktrees: !$(git worktree list 2>&1 || echo "No worktrees found")
 
 ---
 

--- a/plugins/go-workflow/commands/start-issue.md
+++ b/plugins/go-workflow/commands/start-issue.md
@@ -50,11 +50,11 @@ Initialize persistent loop to ensure work continues until complete:
 
 ## Context
 
-- Issue details: !$(gh issue view "$ARGUMENTS" --json title,state,body,labels,comments 2>/dev/null || echo "Issue not found")
-- Current branch: !$(git branch --show-current 2>&1 || echo "unknown")
-- Default branch: !$(git remote show origin 2>/dev/null | grep 'HEAD branch' | sed 's/.*: //' || echo "main")
-- Repository name: !$(basename "$(git rev-parse --show-toplevel 2>/dev/null)" 2>/dev/null || echo "unknown")
-- Existing worktrees: !$(git worktree list 2>&1 || echo "No worktrees found")
+- Issue details: !`gh issue view "$ARGUMENTS" --json title,state,body,labels,comments 2>/dev/null || echo "Issue not found"`
+- Current branch: !`git branch --show-current 2>&1 || echo "unknown"`
+- Default branch: !`git remote show origin 2>/dev/null | grep 'HEAD branch' | sed 's/.*: //' || echo "main"`
+- Repository name: !`basename \`git rev-parse --show-toplevel 2>/dev/null\` 2>/dev/null || echo "unknown"`
+- Existing worktrees: !`git worktree list 2>&1 || echo "No worktrees found"`
 
 ---
 

--- a/plugins/productivity/commands/changelog.md
+++ b/plugins/productivity/commands/changelog.md
@@ -7,9 +7,9 @@ allowed-tools: ["Bash(git:*)", "Read", "Glob", "Grep"]
 
 ## Context
 
-- Latest tag: !$(git describe --tags --abbrev=0 2>/dev/null || echo "No tags found")
-- Commits since last tag: !$(git log "$(git describe --tags --abbrev=0 2>/dev/null || echo 'HEAD~20')"..HEAD --format="%h %s" 2>/dev/null | head -15 || echo "No commits found")
-- Repository: !$(basename "$(git rev-parse --show-toplevel 2>/dev/null)" 2>/dev/null || echo "unknown")
+- Latest tag: !`git describe --tags --abbrev=0 2>/dev/null || echo "No tags found"`
+- Commits since last tag: !`TAG=\`git describe --tags --abbrev=0 2>/dev/null || echo "HEAD~20"\`; git log "$TAG"..HEAD --format="%h %s" 2>/dev/null | head -15 || echo "No commits found"`
+- Repository: !`basename \`git rev-parse --show-toplevel 2>/dev/null\` 2>/dev/null || echo "unknown"`
 
 **If `$ARGUMENTS` is empty or not provided:**
 

--- a/plugins/productivity/commands/changelog.md
+++ b/plugins/productivity/commands/changelog.md
@@ -7,9 +7,9 @@ allowed-tools: ["Bash(git:*)", "Read", "Glob", "Grep"]
 
 ## Context
 
-- Latest tag: !`git describe --tags --abbrev=0 2>/dev/null || echo "No tags found"`
-- Commits since last tag: !`git log $(git describe --tags --abbrev=0 2>/dev/null || echo "HEAD~20")..HEAD --format="%h %s" 2>/dev/null | head -15`
-- Repository: !`basename $(git rev-parse --show-toplevel)`
+- Latest tag: !$(git describe --tags --abbrev=0 2>/dev/null || echo "No tags found")
+- Commits since last tag: !$(git log "$(git describe --tags --abbrev=0 2>/dev/null || echo 'HEAD~20')"..HEAD --format="%h %s" 2>/dev/null | head -15 || echo "No commits found")
+- Repository: !$(basename "$(git rev-parse --show-toplevel 2>/dev/null)" 2>/dev/null || echo "unknown")
 
 **If `$ARGUMENTS` is empty or not provided:**
 

--- a/plugins/productivity/commands/release.md
+++ b/plugins/productivity/commands/release.md
@@ -6,10 +6,10 @@ allowed-tools: ["Bash(git:*)", "Bash(gh:*)", "Bash(jq:*)", "Read", "Edit", "AskU
 
 ## Context
 
-- Repository: !$(basename "$(git rev-parse --show-toplevel 2>/dev/null)" 2>/dev/null || echo "unknown")
-- Current version: !$(jq -r '.plugins[0].version' .claude-plugin/marketplace.json 2>/dev/null || echo "unknown")
-- Latest tag: !$(git describe --tags --abbrev=0 2>/dev/null || echo "No tags found")
-- Commits since last tag: !$(git log "$(git describe --tags --abbrev=0 2>/dev/null || git rev-list --max-parents=0 HEAD)"..HEAD --oneline 2>/dev/null | wc -l | tr -d ' ' || echo "0")
+- Repository: !`basename \`git rev-parse --show-toplevel 2>/dev/null\` 2>/dev/null || echo "unknown"`
+- Current version: !`jq -r '.plugins[0].version' .claude-plugin/marketplace.json 2>/dev/null || echo "unknown"`
+- Latest tag: !`git describe --tags --abbrev=0 2>/dev/null || echo "No tags found"`
+- Commits since last tag: !`TAG=\`git describe --tags --abbrev=0 2>/dev/null || git rev-list --max-parents=0 HEAD\`; git log "$TAG"..HEAD --oneline 2>/dev/null | wc -l | tr -d ' ' || echo "0"`
 
 ## Instructions
 

--- a/plugins/productivity/commands/release.md
+++ b/plugins/productivity/commands/release.md
@@ -6,10 +6,10 @@ allowed-tools: ["Bash(git:*)", "Bash(gh:*)", "Bash(jq:*)", "Read", "Edit", "AskU
 
 ## Context
 
-- Repository: !`basename $(git rev-parse --show-toplevel)`
-- Current version: !`jq -r '.plugins[0].version' .claude-plugin/marketplace.json 2>/dev/null || echo "unknown"`
-- Latest tag: !`git describe --tags --abbrev=0 2>/dev/null || echo "No tags found"`
-- Commits since last tag: !`git log $(git describe --tags --abbrev=0 2>/dev/null || git rev-list --max-parents=0 HEAD)..HEAD --oneline 2>/dev/null | wc -l | tr -d ' '`
+- Repository: !$(basename "$(git rev-parse --show-toplevel 2>/dev/null)" 2>/dev/null || echo "unknown")
+- Current version: !$(jq -r '.plugins[0].version' .claude-plugin/marketplace.json 2>/dev/null || echo "unknown")
+- Latest tag: !$(git describe --tags --abbrev=0 2>/dev/null || echo "No tags found")
+- Commits since last tag: !$(git log "$(git describe --tags --abbrev=0 2>/dev/null || git rev-list --max-parents=0 HEAD)"..HEAD --oneline 2>/dev/null | wc -l | tr -d ' ' || echo "0")
 
 ## Instructions
 

--- a/plugins/productivity/commands/standup.md
+++ b/plugins/productivity/commands/standup.md
@@ -7,10 +7,10 @@ allowed-tools: ["Bash(git:*)", "Bash(date:*)", "Read", "Glob", "Grep"]
 
 ## Context
 
-- Current git user: !`git config user.name`
-- Current branch: !`git branch --show-current`
-- Today: !`date +%A`
-- Recent commits (24h): !`git log --author="$(git config user.name)" --since="24 hours ago" --format="%h %s" --all 2>/dev/null | head -10`
+- Current git user: !$(git config user.name 2>/dev/null || echo "unknown")
+- Current branch: !$(git branch --show-current 2>&1 || echo "unknown")
+- Today: !$(date +%A 2>/dev/null || echo "unknown")
+- Recent commits (24h): !$(git log --author="$(git config user.name 2>/dev/null)" --since="24 hours ago" --format="%h %s" --all 2>/dev/null | head -10 || echo "No commits found")
 
 **If `$ARGUMENTS` is empty or not provided:**
 

--- a/plugins/productivity/commands/standup.md
+++ b/plugins/productivity/commands/standup.md
@@ -7,10 +7,10 @@ allowed-tools: ["Bash(git:*)", "Bash(date:*)", "Read", "Glob", "Grep"]
 
 ## Context
 
-- Current git user: !$(git config user.name 2>/dev/null || echo "unknown")
-- Current branch: !$(git branch --show-current 2>&1 || echo "unknown")
-- Today: !$(date +%A 2>/dev/null || echo "unknown")
-- Recent commits (24h): !$(git log --author="$(git config user.name 2>/dev/null)" --since="24 hours ago" --format="%h %s" --all 2>/dev/null | head -10 || echo "No commits found")
+- Current git user: !`git config user.name 2>/dev/null || echo "unknown"`
+- Current branch: !`git branch --show-current 2>&1 || echo "unknown"`
+- Today: !`date +%A 2>/dev/null || echo "unknown"`
+- Recent commits (24h): !`AUTHOR=\`git config user.name 2>/dev/null\`; git log --author="$AUTHOR" --since="24 hours ago" --format="%h %s" --all 2>/dev/null | head -10 || echo "No commits found"`
 
 **If `$ARGUMENTS` is empty or not provided:**
 

--- a/plugins/productivity/commands/weekly-summary.md
+++ b/plugins/productivity/commands/weekly-summary.md
@@ -7,9 +7,9 @@ allowed-tools: ["Bash(git:*)", "Bash(date:*)", "Bash(find:*)", "Read", "Glob", "
 
 ## Context
 
-- Current git user: !$(git config user.name 2>/dev/null || echo "unknown")
-- This week's commits: !$(git log --author="$(git config user.name 2>/dev/null)" --since="last monday" --format="%h %s" --all 2>/dev/null | head -15 || echo "No commits found")
-- Week start: !$(date -v-monday +%Y-%m-%d 2>/dev/null || date -d "last monday" +%Y-%m-%d 2>/dev/null || echo "Monday")
+- Current git user: !`git config user.name 2>/dev/null || echo "unknown"`
+- This week's commits: !`AUTHOR=\`git config user.name 2>/dev/null\`; git log --author="$AUTHOR" --since="last monday" --format="%h %s" --all 2>/dev/null | head -15 || echo "No commits found"`
+- Week start: !`date -v-monday +%Y-%m-%d 2>/dev/null || date -d "last monday" +%Y-%m-%d 2>/dev/null || echo "Monday"`
 
 **If `$ARGUMENTS` is empty or not provided:**
 

--- a/plugins/productivity/commands/weekly-summary.md
+++ b/plugins/productivity/commands/weekly-summary.md
@@ -7,9 +7,9 @@ allowed-tools: ["Bash(git:*)", "Bash(date:*)", "Bash(find:*)", "Read", "Glob", "
 
 ## Context
 
-- Current git user: !`git config user.name`
-- This week's commits: !`git log --author="$(git config user.name)" --since="last monday" --format="%h %s" --all 2>/dev/null | head -15`
-- Week start: !`date -v-monday +%Y-%m-%d 2>/dev/null || date -d "last monday" +%Y-%m-%d 2>/dev/null || echo "Monday"`
+- Current git user: !$(git config user.name 2>/dev/null || echo "unknown")
+- This week's commits: !$(git log --author="$(git config user.name 2>/dev/null)" --since="last monday" --format="%h %s" --all 2>/dev/null | head -15 || echo "No commits found")
+- Week start: !$(date -v-monday +%Y-%m-%d 2>/dev/null || date -d "last monday" +%Y-%m-%d 2>/dev/null || echo "Monday")
 
 **If `$ARGUMENTS` is empty or not provided:**
 


### PR DESCRIPTION
## Summary

- Replace backtick (`` ` ``) command substitution with `$()` in all `!` prompt-assembly patterns across 11 command files
- Add `2>&1 || echo "fallback"` error handling to every git/shell command so they never return non-zero during prompt assembly
- Fixes "Bash command failed for pattern '!git status'" crash when `/commit` runs in edge-case git states (no commits, detached HEAD, invalid working directory)

**Files changed (11):**
- `plugins/go-workflow/commands/`: commit.md, start-issue.md, create-pr.md, address-review.md, create-worktree.md, remove-worktree.md, prune-worktree.md
- `plugins/productivity/commands/`: weekly-summary.md, standup.md, changelog.md, release.md

## Test Plan

- [ ] Run `/go-workflow:commit` from a repo with uncommitted changes
- [ ] Run `/go-workflow:commit` from a repo with no commits (initial state)
- [ ] Run `/go-workflow:start-issue` and verify context section populates
- [ ] Run `/productivity:standup` and verify context section populates

🤖 Generated with [Claude Code](https://claude.com/claude-code)