### PR TITLE
fix(go-workflow): prevent address-review watch loop from exiting early

### DIFF
--- a/plugins/go-dev/scripts/setup-loop.sh
+++ b/plugins/go-dev/scripts/setup-loop.sh
@@ -34,9 +34,10 @@ if [ -f "$STATE_FILE" ]; then
   echo "Warning: Loop '$LOOP_NAME' already active. Resetting (preserving phase: ${EXISTING_PHASE:-<none>})..."
 fi
 
-# Use INITIAL_PHASE if provided, otherwise preserve existing phase from state file
+# Preserve existing phase from state file, fall back to INITIAL_PHASE for fresh runs
 # This allows re-entry to maintain phase context (e.g., watching) across stop-hook restarts
-PHASE="${INITIAL_PHASE:-$EXISTING_PHASE}"
+# while INITIAL_PHASE provides a default for first-time initialization
+PHASE="${EXISTING_PHASE:-$INITIAL_PHASE}"
 
 # Create state file with YAML frontmatter
 cat > "$STATE_FILE" << EOF

--- a/plugins/go-dev/scripts/setup-loop.sh
+++ b/plugins/go-dev/scripts/setup-loop.sh
@@ -27,15 +27,15 @@ STATE_FILE=".claude/${SAFE_LOOP_NAME}.loop.local.md"
 # Create .claude directory if it doesn't exist
 mkdir -p .claude
 
-# Check for existing loop — preserve phase if re-initializing
-EXISTING_PHASE=""
+# Check for existing loop
 if [ -f "$STATE_FILE" ]; then
-  EXISTING_PHASE=$(grep '^phase:' "$STATE_FILE" | sed 's/phase: *//' || true)
-  echo "Warning: Loop '$LOOP_NAME' already active. Resetting (preserving phase: ${EXISTING_PHASE:-<none>})..."
+  echo "Warning: Loop '$LOOP_NAME' already active. Resetting..."
 fi
 
-# Use existing phase if no initial phase provided and state file had one
-PHASE="${INITIAL_PHASE:-$EXISTING_PHASE}"
+# Only use phase if explicitly passed as 4th arg
+# Do NOT auto-preserve from existing state file — this prevents stale phase
+# from a prior run (e.g., address-review-auto) leaking into a fresh invocation
+PHASE="${INITIAL_PHASE:-}"
 
 # Create state file with YAML frontmatter
 cat > "$STATE_FILE" << EOF

--- a/plugins/go-dev/scripts/setup-loop.sh
+++ b/plugins/go-dev/scripts/setup-loop.sh
@@ -27,11 +27,13 @@ STATE_FILE=".claude/${SAFE_LOOP_NAME}.loop.local.md"
 # Create .claude directory if it doesn't exist
 mkdir -p .claude
 
-# Check for existing loop — preserve phase if re-initializing
+# Check for existing loop — preserve phase and bot_review_baseline if re-initializing
 EXISTING_PHASE=""
+EXISTING_BASELINE=""
 if [ -f "$STATE_FILE" ]; then
   EXISTING_PHASE=$(grep '^phase:' "$STATE_FILE" | sed 's/phase: *//' || true)
-  echo "Warning: Loop '$LOOP_NAME' already active. Resetting (preserving phase: ${EXISTING_PHASE:-<none>})..."
+  EXISTING_BASELINE=$(grep '^bot_review_baseline:' "$STATE_FILE" | sed 's/bot_review_baseline: *//' || true)
+  echo "Warning: Loop '$LOOP_NAME' already active. Resetting (preserving phase: ${EXISTING_PHASE:-<none>}, baseline: ${EXISTING_BASELINE:-<none>})..."
 fi
 
 # Preserve existing phase from state file, fall back to INITIAL_PHASE for fresh runs
@@ -47,6 +49,7 @@ iteration: 1
 max_iterations: $MAX_ITERATIONS
 completion_promise: $COMPLETION_PROMISE
 phase: $PHASE
+bot_review_baseline: $EXISTING_BASELINE
 started_at: $(date -u +"%Y-%m-%dT%H:%M:%SZ")
 ---
 

--- a/plugins/go-web/scripts/setup-loop.sh
+++ b/plugins/go-web/scripts/setup-loop.sh
@@ -34,9 +34,10 @@ if [ -f "$STATE_FILE" ]; then
   echo "Warning: Loop '$LOOP_NAME' already active. Resetting (preserving phase: ${EXISTING_PHASE:-<none>})..."
 fi
 
-# Use INITIAL_PHASE if provided, otherwise preserve existing phase from state file
+# Preserve existing phase from state file, fall back to INITIAL_PHASE for fresh runs
 # This allows re-entry to maintain phase context (e.g., watching) across stop-hook restarts
-PHASE="${INITIAL_PHASE:-$EXISTING_PHASE}"
+# while INITIAL_PHASE provides a default for first-time initialization
+PHASE="${EXISTING_PHASE:-$INITIAL_PHASE}"
 
 # Create state file with YAML frontmatter
 cat > "$STATE_FILE" << EOF

--- a/plugins/go-web/scripts/setup-loop.sh
+++ b/plugins/go-web/scripts/setup-loop.sh
@@ -27,15 +27,15 @@ STATE_FILE=".claude/${SAFE_LOOP_NAME}.loop.local.md"
 # Create .claude directory if it doesn't exist
 mkdir -p .claude
 
-# Check for existing loop — preserve phase if re-initializing
-EXISTING_PHASE=""
+# Check for existing loop
 if [ -f "$STATE_FILE" ]; then
-  EXISTING_PHASE=$(grep '^phase:' "$STATE_FILE" | sed 's/phase: *//' || true)
-  echo "Warning: Loop '$LOOP_NAME' already active. Resetting (preserving phase: ${EXISTING_PHASE:-<none>})..."
+  echo "Warning: Loop '$LOOP_NAME' already active. Resetting..."
 fi
 
-# Use existing phase if no initial phase provided and state file had one
-PHASE="${INITIAL_PHASE:-$EXISTING_PHASE}"
+# Only use phase if explicitly passed as 4th arg
+# Do NOT auto-preserve from existing state file — this prevents stale phase
+# from a prior run (e.g., address-review-auto) leaking into a fresh invocation
+PHASE="${INITIAL_PHASE:-}"
 
 # Create state file with YAML frontmatter
 cat > "$STATE_FILE" << EOF

--- a/plugins/go-web/scripts/setup-loop.sh
+++ b/plugins/go-web/scripts/setup-loop.sh
@@ -27,11 +27,13 @@ STATE_FILE=".claude/${SAFE_LOOP_NAME}.loop.local.md"
 # Create .claude directory if it doesn't exist
 mkdir -p .claude
 
-# Check for existing loop — preserve phase if re-initializing
+# Check for existing loop — preserve phase and bot_review_baseline if re-initializing
 EXISTING_PHASE=""
+EXISTING_BASELINE=""
 if [ -f "$STATE_FILE" ]; then
   EXISTING_PHASE=$(grep '^phase:' "$STATE_FILE" | sed 's/phase: *//' || true)
-  echo "Warning: Loop '$LOOP_NAME' already active. Resetting (preserving phase: ${EXISTING_PHASE:-<none>})..."
+  EXISTING_BASELINE=$(grep '^bot_review_baseline:' "$STATE_FILE" | sed 's/bot_review_baseline: *//' || true)
+  echo "Warning: Loop '$LOOP_NAME' already active. Resetting (preserving phase: ${EXISTING_PHASE:-<none>}, baseline: ${EXISTING_BASELINE:-<none>})..."
 fi
 
 # Preserve existing phase from state file, fall back to INITIAL_PHASE for fresh runs
@@ -47,6 +49,7 @@ iteration: 1
 max_iterations: $MAX_ITERATIONS
 completion_promise: $COMPLETION_PROMISE
 phase: $PHASE
+bot_review_baseline: $EXISTING_BASELINE
 started_at: $(date -u +"%Y-%m-%dT%H:%M:%SZ")
 ---
 

--- a/plugins/go-workflow/commands/address-review.md
+++ b/plugins/go-workflow/commands/address-review.md
@@ -846,11 +846,13 @@ Interpret the result:
 
 Note: Copilot cannot be re-triggered via comment (see 12d).
 
-**Claude (`claude[bot]`):** Same timestamp-based check as Copilot but for `claude[bot]`:
+**Claude (`claude[bot]`):** Same timestamp-based check as Copilot but for `claude[bot]`, with silent approval handling:
 - Use `BOT_REVIEW_BASELINE` captured in Phase Transition (do NOT recompute)
 - Check if `claude[bot]` posted a NEW review AFTER that baseline
 - If post-push review exists with 0 new unresolved threads → done
-- If no post-push review → hasn't re-reviewed yet (keep waiting)
+- If post-push review exists with unresolved threads → has new issues (not done)
+- If no post-push review AND no unresolved Claude threads → **silent approval** (Claude doesn't always post a review when it finds no issues). Consider done after a reasonable wait (2+ polling cycles with no new Claude activity).
+- If no post-push review AND unresolved Claude threads exist from before baseline → those are stale (already resolved), consider done
 
 **If ALL detected bots are done → output `<done>COMPLETE</done>` and stop.**
 

--- a/plugins/go-workflow/commands/address-review.md
+++ b/plugins/go-workflow/commands/address-review.md
@@ -65,8 +65,8 @@ Store `RESOLVED_PR` for use in loop initialization and throughout the workflow.
 
 ## Loop Initialization
 
-Initialize persistent loop with PR-specific name and `fixing` phase (so stop-hook re-entry during the fix cycle knows a cycle is in progress):
-!`"${CLAUDE_PLUGIN_ROOT}/scripts/setup-loop.sh" "address-review-${RESOLVED_PR:-auto}" "COMPLETE" "" "fixing"`
+Initialize persistent loop with PR-specific name (no initial phase — fresh runs start neutral):
+!`"${CLAUDE_PLUGIN_ROOT}/scripts/setup-loop.sh" "address-review-${RESOLVED_PR:-auto}" "COMPLETE"`
 
 ## Re-entry Check
 
@@ -413,6 +413,16 @@ Address the feedback, but note to the user:
 ---
 
 ## Step 4: Address Each Comment
+
+**Set phase to `fixing` now that the fix cycle is actually starting:**
+
+```bash
+SAFE_LOOP_NAME=$(echo "address-review-${RESOLVED_PR:-auto}" | sed 's/[^a-zA-Z0-9_-]/-/g')
+LOOP_STATE_FILE=".claude/${SAFE_LOOP_NAME}.loop.local.md"
+if [ -f "$LOOP_STATE_FILE" ]; then
+  sed -i '' "s/^phase: .*/phase: fixing/" "$LOOP_STATE_FILE" 2>/dev/null || sed -i "s/^phase: .*/phase: fixing/" "$LOOP_STATE_FILE"
+fi
+```
 
 For each unresolved review comment:
 

--- a/plugins/go-workflow/commands/address-review.md
+++ b/plugins/go-workflow/commands/address-review.md
@@ -112,7 +112,7 @@ Reference table of known review bots. Used ONLY for matching against bots actual
 
 ## Context
 
-- PR details: !`PR_NUM="${PR_ARG:-\`gh pr view --json number --jq '.number' 2>/dev/null\`}"; gh pr view "$PR_NUM" --json title,state,body,headRefName,baseRefName 2>/dev/null || echo "PR not found"`
+- PR details: !`PR_NUM="${PR_ARG:-\`gh pr view --json number --jq '.number' 2>/dev/null\`}"; gh pr view "$PR_NUM" --json title,state,body,headRefName,baseRefName --jq '.' 2>/dev/null || echo "PR not found"`
 - Current branch: !`git branch --show-current 2>&1 || echo "unknown"`
 - Default branch: !`git remote show origin 2>/dev/null | grep 'HEAD branch' | sed 's/.*: //' || echo "main"`
 - PR number: !`echo "${PR_ARG:-\`gh pr view --json number --jq '.number' 2>/dev/null\`}"`

--- a/plugins/go-workflow/commands/address-review.md
+++ b/plugins/go-workflow/commands/address-review.md
@@ -802,9 +802,22 @@ If any bot hasn't approved yet:
 
 After the quiet period ends and new unresolved comments/threads exist:
 
+**First, clear the `watching` phase** so stop-hook re-entry runs the fix cycle instead of skipping to Step 12:
+
+```bash
+SAFE_LOOP_NAME=$(echo "address-review-${ARGUMENTS:-auto}" | sed 's/[^a-zA-Z0-9_-]/-/g')
+LOOP_STATE_FILE=".claude/${SAFE_LOOP_NAME}.loop.local.md"
+if [ -f "$LOOP_STATE_FILE" ]; then
+  sed -i '' "s/^phase: .*/phase: fixing/" "$LOOP_STATE_FILE" 2>/dev/null || sed -i "s/^phase: .*/phase: fixing/" "$LOOP_STATE_FILE"
+  echo "Phase reset to: fixing (new bot feedback detected)"
+fi
+```
+
+Then:
+
 1. Re-fetch all review feedback (Step 2) but **only address NEW unresolved comments** from bots. Already-resolved threads stay resolved.
 2. Loop back through Steps 2-11 for the new feedback only.
-3. After completing the fix cycle, return to Step 12a to re-check approval status.
+3. After completing the fix cycle, return to Step 12a to re-check approval status (the Phase Transition section will set phase back to `watching`).
 
 ### 12d. No new comments but bot hasn't approved — re-trigger
 

--- a/plugins/go-workflow/commands/address-review.md
+++ b/plugins/go-workflow/commands/address-review.md
@@ -739,11 +739,12 @@ If the Greptile check shows `pass` AND no new inline comments were posted since 
 **Copilot (`copilot-pull-request-review[bot]`):** Timestamp-based check — verify the bot posted a NEW review AFTER the last push:
 
 ```bash
-# Get the PR's head commit timestamp from GitHub API (reflects when GitHub
-# received the push, not local commit date which can be preserved from rebases)
-HEAD_SHA=$(gh pr view "$PR_NUM" --json headRefOid --jq '.headRefOid')
-LAST_PUSH=$(gh api "repos/$OWNER/$REPO/commits/$HEAD_SHA" --jq '.commit.committer.date')
-echo "Push baseline timestamp: $LAST_PUSH"
+# Use current UTC time as the baseline. Since we just pushed (Step 6) and
+# completed CI/replies/re-review requests, any bot review after NOW is a
+# re-review of our latest changes. This is more reliable than commit dates
+# which can be older due to rebases/cherry-picks.
+LAST_PUSH=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+echo "Bot review baseline: $LAST_PUSH"
 
 COPILOT_STATUS=$(gh api graphql -f query='
   query($owner: String!, $repo: String!, $pr: Int!) {

--- a/plugins/go-workflow/commands/address-review.md
+++ b/plugins/go-workflow/commands/address-review.md
@@ -726,7 +726,8 @@ If the Greptile check shows `pass` AND no new inline comments were posted since 
 **Copilot (`copilot-pull-request-review[bot]`):** Timestamp-based check — verify the bot posted a NEW review AFTER the last push:
 
 ```bash
-LAST_PUSH=$(gh api "repos/$OWNER/$REPO/pulls/$PR_NUM/commits" --jq 'last | .commit.committer.date')
+# Get last push timestamp from local git (reliable, no pagination issues)
+LAST_PUSH=$(git log -1 --format=%cI HEAD)
 echo "Last push timestamp: $LAST_PUSH"
 
 COPILOT_STATUS=$(gh api graphql -f query='

--- a/plugins/go-workflow/commands/start-issue.md
+++ b/plugins/go-workflow/commands/start-issue.md
@@ -50,7 +50,7 @@ Initialize persistent loop to ensure work continues until complete:
 
 ## Context
 
-- Issue details: !`gh issue view "$ARGUMENTS" --json title,state,body,labels,comments 2>/dev/null || echo "Issue not found"`
+- Issue details: !`gh issue view "$ARGUMENTS" --json title,state,body,labels,comments --jq '.' 2>/dev/null || echo "Issue not found"`
 - Current branch: !`git branch --show-current 2>&1 || echo "unknown"`
 - Default branch: !`git remote show origin 2>/dev/null | grep 'HEAD branch' | sed 's/.*: //' || echo "main"`
 - Repository name: !`basename \`git rev-parse --show-toplevel 2>/dev/null\` 2>/dev/null || echo "unknown"`

--- a/plugins/go-workflow/hooks/stop-hook.sh
+++ b/plugins/go-workflow/hooks/stop-hook.sh
@@ -90,7 +90,16 @@ increment_iteration "$STATE_FILE"
 NEW_ITERATION=$((ITERATION + 1))
 
 # Build system message with iteration info and guidance
-SYSTEM_MSG="Iteration $NEW_ITERATION of loop '$LOOP_NAME'. Continue working on the task."
+SYSTEM_MSG="Iteration $NEW_ITERATION of loop '$LOOP_NAME'."
+
+# Phase-aware re-feed: use targeted message for watching phase
+if [ "$PHASE" = "watching" ]; then
+  REASON="Resume Step 12: Check bot approval status, poll if needed. Do NOT re-run Steps 1-11."
+  SYSTEM_MSG="$SYSTEM_MSG RESUME AT STEP 12a: The fix cycle (Steps 1-11) is already complete. Check bot approval status and poll for re-reviews. Do NOT restart the fix cycle."
+else
+  REASON="$ORIGINAL_PROMPT"
+  SYSTEM_MSG="$SYSTEM_MSG Continue working on the task."
+fi
 
 # Add guidance after many iterations
 if [ "$NEW_ITERATION" -ge 15 ]; then
@@ -102,5 +111,5 @@ SYSTEM_MSG="$SYSTEM_MSG Output <done>$COMPLETION_PROMISE</done> ONLY when ALL co
 # Block exit and re-feed prompt
 # Note: Using printf to handle special characters in prompt
 printf '{"decision": "block", "reason": "%s", "systemMessage": "%s"}\n' \
-  "$(echo "$ORIGINAL_PROMPT" | sed 's/"/\\"/g' | tr '\n' ' ')" \
+  "$(echo "$REASON" | sed 's/"/\\"/g' | tr '\n' ' ')" \
   "$(echo "$SYSTEM_MSG" | sed 's/"/\\"/g')"

--- a/plugins/go-workflow/scripts/setup-loop.sh
+++ b/plugins/go-workflow/scripts/setup-loop.sh
@@ -34,9 +34,10 @@ if [ -f "$STATE_FILE" ]; then
   echo "Warning: Loop '$LOOP_NAME' already active. Resetting (preserving phase: ${EXISTING_PHASE:-<none>})..."
 fi
 
-# Use INITIAL_PHASE if provided, otherwise preserve existing phase from state file
+# Preserve existing phase from state file, fall back to INITIAL_PHASE for fresh runs
 # This allows re-entry to maintain phase context (e.g., watching) across stop-hook restarts
-PHASE="${INITIAL_PHASE:-$EXISTING_PHASE}"
+# while INITIAL_PHASE provides a default for first-time initialization
+PHASE="${EXISTING_PHASE:-$INITIAL_PHASE}"
 
 # Create state file with YAML frontmatter
 cat > "$STATE_FILE" << EOF

--- a/plugins/go-workflow/scripts/setup-loop.sh
+++ b/plugins/go-workflow/scripts/setup-loop.sh
@@ -27,15 +27,15 @@ STATE_FILE=".claude/${SAFE_LOOP_NAME}.loop.local.md"
 # Create .claude directory if it doesn't exist
 mkdir -p .claude
 
-# Check for existing loop — preserve phase if re-initializing
-EXISTING_PHASE=""
+# Check for existing loop
 if [ -f "$STATE_FILE" ]; then
-  EXISTING_PHASE=$(grep '^phase:' "$STATE_FILE" | sed 's/phase: *//' || true)
-  echo "Warning: Loop '$LOOP_NAME' already active. Resetting (preserving phase: ${EXISTING_PHASE:-<none>})..."
+  echo "Warning: Loop '$LOOP_NAME' already active. Resetting..."
 fi
 
-# Use existing phase if no initial phase provided and state file had one
-PHASE="${INITIAL_PHASE:-$EXISTING_PHASE}"
+# Only use phase if explicitly passed as 4th arg
+# Do NOT auto-preserve from existing state file — this prevents stale phase
+# from a prior run (e.g., address-review-auto) leaking into a fresh invocation
+PHASE="${INITIAL_PHASE:-}"
 
 # Create state file with YAML frontmatter
 cat > "$STATE_FILE" << EOF

--- a/plugins/go-workflow/scripts/setup-loop.sh
+++ b/plugins/go-workflow/scripts/setup-loop.sh
@@ -27,11 +27,13 @@ STATE_FILE=".claude/${SAFE_LOOP_NAME}.loop.local.md"
 # Create .claude directory if it doesn't exist
 mkdir -p .claude
 
-# Check for existing loop — preserve phase if re-initializing
+# Check for existing loop — preserve phase and bot_review_baseline if re-initializing
 EXISTING_PHASE=""
+EXISTING_BASELINE=""
 if [ -f "$STATE_FILE" ]; then
   EXISTING_PHASE=$(grep '^phase:' "$STATE_FILE" | sed 's/phase: *//' || true)
-  echo "Warning: Loop '$LOOP_NAME' already active. Resetting (preserving phase: ${EXISTING_PHASE:-<none>})..."
+  EXISTING_BASELINE=$(grep '^bot_review_baseline:' "$STATE_FILE" | sed 's/bot_review_baseline: *//' || true)
+  echo "Warning: Loop '$LOOP_NAME' already active. Resetting (preserving phase: ${EXISTING_PHASE:-<none>}, baseline: ${EXISTING_BASELINE:-<none>})..."
 fi
 
 # Preserve existing phase from state file, fall back to INITIAL_PHASE for fresh runs
@@ -47,6 +49,7 @@ iteration: 1
 max_iterations: $MAX_ITERATIONS
 completion_promise: $COMPLETION_PROMISE
 phase: $PHASE
+bot_review_baseline: $EXISTING_BASELINE
 started_at: $(date -u +"%Y-%m-%dT%H:%M:%SZ")
 ---
 

--- a/plugins/llm-tools/commands/codex.md
+++ b/plugins/llm-tools/commands/codex.md
@@ -60,7 +60,7 @@ Before asking any questions, silently detect PR context using multiple strategie
 **Strategy 1 — Current branch (works when branch name matches a PR):**
 
 ```bash
-PR_JSON=`gh pr view --json number,title,body,state,closingIssuesReferences,comments,reviews 2>/dev/null`
+PR_JSON=`gh pr view --json number,title,body,state,closingIssuesReferences,comments,reviews --jq '.' 2>/dev/null`
 ```
 
 **Strategy 2 — Match HEAD commit against open PRs via GitHub search (handles worktrees):**
@@ -104,7 +104,7 @@ ISSUE_NUMS=`echo "$PR_JSON" | jq -r '.closingIssuesReferences[].number' 2>/dev/n
 
 # Fetch each linked issue
 for NUM in $ISSUE_NUMS; do
-  gh issue view "$NUM" --json number,title,body,labels,comments
+  gh issue view "$NUM" --json number,title,body,labels,comments --jq '.'
 done
 
 # Fetch inline review comments
@@ -191,11 +191,11 @@ After processing answers from R2, check if any selections require additional inp
 - **"Provide PR number"** was selected → ask: "Enter the PR number"
   - Validate input is numeric: `echo "$NUM" | grep -qE '^[0-9]+$'`
   - If invalid, show error and ask again
-  - Fetch PR: `gh pr view "$NUM" --json number,title,body,state,closingIssuesReferences,comments,reviews`
+  - Fetch PR: `gh pr view "$NUM" --json number,title,body,state,closingIssuesReferences,comments,reviews --jq '.'`
   - Fetch linked issues and inline review comments as in R1
 - **"Provide issue number"** was selected → ask: "Enter the issue number"
   - Validate input is numeric
-  - Fetch issue: `gh issue view "$NUM" --json number,title,body,labels,comments`
+  - Fetch issue: `gh issue view "$NUM" --json number,title,body,labels,comments --jq '.'`
   - Skip PR-specific data (no reviews to fetch)
 - **"Multi-pass (custom)"** was selected → ask: "How many passes? (2-5)"
   - Validate numeric, clamp to range

--- a/plugins/tailwind/scripts/setup-loop.sh
+++ b/plugins/tailwind/scripts/setup-loop.sh
@@ -34,9 +34,10 @@ if [ -f "$STATE_FILE" ]; then
   echo "Warning: Loop '$LOOP_NAME' already active. Resetting (preserving phase: ${EXISTING_PHASE:-<none>})..."
 fi
 
-# Use INITIAL_PHASE if provided, otherwise preserve existing phase from state file
+# Preserve existing phase from state file, fall back to INITIAL_PHASE for fresh runs
 # This allows re-entry to maintain phase context (e.g., watching) across stop-hook restarts
-PHASE="${INITIAL_PHASE:-$EXISTING_PHASE}"
+# while INITIAL_PHASE provides a default for first-time initialization
+PHASE="${EXISTING_PHASE:-$INITIAL_PHASE}"
 
 # Create state file with YAML frontmatter
 cat > "$STATE_FILE" << EOF

--- a/plugins/tailwind/scripts/setup-loop.sh
+++ b/plugins/tailwind/scripts/setup-loop.sh
@@ -27,15 +27,15 @@ STATE_FILE=".claude/${SAFE_LOOP_NAME}.loop.local.md"
 # Create .claude directory if it doesn't exist
 mkdir -p .claude
 
-# Check for existing loop — preserve phase if re-initializing
-EXISTING_PHASE=""
+# Check for existing loop
 if [ -f "$STATE_FILE" ]; then
-  EXISTING_PHASE=$(grep '^phase:' "$STATE_FILE" | sed 's/phase: *//' || true)
-  echo "Warning: Loop '$LOOP_NAME' already active. Resetting (preserving phase: ${EXISTING_PHASE:-<none>})..."
+  echo "Warning: Loop '$LOOP_NAME' already active. Resetting..."
 fi
 
-# Use existing phase if no initial phase provided and state file had one
-PHASE="${INITIAL_PHASE:-$EXISTING_PHASE}"
+# Only use phase if explicitly passed as 4th arg
+# Do NOT auto-preserve from existing state file — this prevents stale phase
+# from a prior run (e.g., address-review-auto) leaking into a fresh invocation
+PHASE="${INITIAL_PHASE:-}"
 
 # Create state file with YAML frontmatter
 cat > "$STATE_FILE" << EOF

--- a/plugins/tailwind/scripts/setup-loop.sh
+++ b/plugins/tailwind/scripts/setup-loop.sh
@@ -27,11 +27,13 @@ STATE_FILE=".claude/${SAFE_LOOP_NAME}.loop.local.md"
 # Create .claude directory if it doesn't exist
 mkdir -p .claude
 
-# Check for existing loop — preserve phase if re-initializing
+# Check for existing loop — preserve phase and bot_review_baseline if re-initializing
 EXISTING_PHASE=""
+EXISTING_BASELINE=""
 if [ -f "$STATE_FILE" ]; then
   EXISTING_PHASE=$(grep '^phase:' "$STATE_FILE" | sed 's/phase: *//' || true)
-  echo "Warning: Loop '$LOOP_NAME' already active. Resetting (preserving phase: ${EXISTING_PHASE:-<none>})..."
+  EXISTING_BASELINE=$(grep '^bot_review_baseline:' "$STATE_FILE" | sed 's/bot_review_baseline: *//' || true)
+  echo "Warning: Loop '$LOOP_NAME' already active. Resetting (preserving phase: ${EXISTING_PHASE:-<none>}, baseline: ${EXISTING_BASELINE:-<none>})..."
 fi
 
 # Preserve existing phase from state file, fall back to INITIAL_PHASE for fresh runs
@@ -47,6 +49,7 @@ iteration: 1
 max_iterations: $MAX_ITERATIONS
 completion_promise: $COMPLETION_PROMISE
 phase: $PHASE
+bot_review_baseline: $EXISTING_BASELINE
 started_at: $(date -u +"%Y-%m-%dT%H:%M:%SZ")
 ---
 

--- a/shared/hooks/stop-hook.sh
+++ b/shared/hooks/stop-hook.sh
@@ -90,7 +90,16 @@ increment_iteration "$STATE_FILE"
 NEW_ITERATION=$((ITERATION + 1))
 
 # Build system message with iteration info and guidance
-SYSTEM_MSG="Iteration $NEW_ITERATION of loop '$LOOP_NAME'. Continue working on the task."
+SYSTEM_MSG="Iteration $NEW_ITERATION of loop '$LOOP_NAME'."
+
+# Phase-aware re-feed: use targeted message for watching phase
+if [ "$PHASE" = "watching" ]; then
+  REASON="Resume Step 12: Check bot approval status, poll if needed. Do NOT re-run Steps 1-11."
+  SYSTEM_MSG="$SYSTEM_MSG RESUME AT STEP 12a: The fix cycle (Steps 1-11) is already complete. Check bot approval status and poll for re-reviews. Do NOT restart the fix cycle."
+else
+  REASON="$ORIGINAL_PROMPT"
+  SYSTEM_MSG="$SYSTEM_MSG Continue working on the task."
+fi
 
 # Add guidance after many iterations
 if [ "$NEW_ITERATION" -ge 15 ]; then
@@ -102,5 +111,5 @@ SYSTEM_MSG="$SYSTEM_MSG Output <done>$COMPLETION_PROMISE</done> ONLY when ALL co
 # Block exit and re-feed prompt
 # Note: Using printf to handle special characters in prompt
 printf '{"decision": "block", "reason": "%s", "systemMessage": "%s"}\n' \
-  "$(echo "$ORIGINAL_PROMPT" | sed 's/"/\\"/g' | tr '\n' ' ')" \
+  "$(echo "$REASON" | sed 's/"/\\"/g' | tr '\n' ' ')" \
   "$(echo "$SYSTEM_MSG" | sed 's/"/\\"/g')"

--- a/shared/scripts/setup-loop.sh
+++ b/shared/scripts/setup-loop.sh
@@ -34,9 +34,10 @@ if [ -f "$STATE_FILE" ]; then
   echo "Warning: Loop '$LOOP_NAME' already active. Resetting (preserving phase: ${EXISTING_PHASE:-<none>})..."
 fi
 
-# Use INITIAL_PHASE if provided, otherwise preserve existing phase from state file
+# Preserve existing phase from state file, fall back to INITIAL_PHASE for fresh runs
 # This allows re-entry to maintain phase context (e.g., watching) across stop-hook restarts
-PHASE="${INITIAL_PHASE:-$EXISTING_PHASE}"
+# while INITIAL_PHASE provides a default for first-time initialization
+PHASE="${EXISTING_PHASE:-$INITIAL_PHASE}"
 
 # Create state file with YAML frontmatter
 cat > "$STATE_FILE" << EOF

--- a/shared/scripts/setup-loop.sh
+++ b/shared/scripts/setup-loop.sh
@@ -27,15 +27,15 @@ STATE_FILE=".claude/${SAFE_LOOP_NAME}.loop.local.md"
 # Create .claude directory if it doesn't exist
 mkdir -p .claude
 
-# Check for existing loop — preserve phase if re-initializing
-EXISTING_PHASE=""
+# Check for existing loop
 if [ -f "$STATE_FILE" ]; then
-  EXISTING_PHASE=$(grep '^phase:' "$STATE_FILE" | sed 's/phase: *//' || true)
-  echo "Warning: Loop '$LOOP_NAME' already active. Resetting (preserving phase: ${EXISTING_PHASE:-<none>})..."
+  echo "Warning: Loop '$LOOP_NAME' already active. Resetting..."
 fi
 
-# Use existing phase if no initial phase provided and state file had one
-PHASE="${INITIAL_PHASE:-$EXISTING_PHASE}"
+# Only use phase if explicitly passed as 4th arg
+# Do NOT auto-preserve from existing state file — this prevents stale phase
+# from a prior run (e.g., address-review-auto) leaking into a fresh invocation
+PHASE="${INITIAL_PHASE:-}"
 
 # Create state file with YAML frontmatter
 cat > "$STATE_FILE" << EOF

--- a/shared/scripts/setup-loop.sh
+++ b/shared/scripts/setup-loop.sh
@@ -27,11 +27,13 @@ STATE_FILE=".claude/${SAFE_LOOP_NAME}.loop.local.md"
 # Create .claude directory if it doesn't exist
 mkdir -p .claude
 
-# Check for existing loop — preserve phase if re-initializing
+# Check for existing loop — preserve phase and bot_review_baseline if re-initializing
 EXISTING_PHASE=""
+EXISTING_BASELINE=""
 if [ -f "$STATE_FILE" ]; then
   EXISTING_PHASE=$(grep '^phase:' "$STATE_FILE" | sed 's/phase: *//' || true)
-  echo "Warning: Loop '$LOOP_NAME' already active. Resetting (preserving phase: ${EXISTING_PHASE:-<none>})..."
+  EXISTING_BASELINE=$(grep '^bot_review_baseline:' "$STATE_FILE" | sed 's/bot_review_baseline: *//' || true)
+  echo "Warning: Loop '$LOOP_NAME' already active. Resetting (preserving phase: ${EXISTING_PHASE:-<none>}, baseline: ${EXISTING_BASELINE:-<none>})..."
 fi
 
 # Preserve existing phase from state file, fall back to INITIAL_PHASE for fresh runs
@@ -47,6 +49,7 @@ iteration: 1
 max_iterations: $MAX_ITERATIONS
 completion_promise: $COMPLETION_PROMISE
 phase: $PHASE
+bot_review_baseline: $EXISTING_BASELINE
 started_at: $(date -u +"%Y-%m-%dT%H:%M:%SZ")
 ---
 


### PR DESCRIPTION
## Summary

- **Add phase tracking to loop state infrastructure**: New `phase` field in loop state, `set_loop_phase()` function, and `setup-loop.sh` preserves phase on re-init (backwards compatible — existing callers unaffected)
- **Make stop hook phase-aware**: When `phase=watching`, re-feed targets Step 12 ("check bot approval status") instead of generic "continue working" which restarted from Step 1
- **Fix address-review.md early exit** (4 surgical changes):
  - Re-entry detection: reads phase from state file, skips to Step 12a if already in `watching` phase
  - Step 3 conditional exit: "no unresolved feedback" in watch mode with bots detected skips to Step 12 instead of outputting COMPLETE
  - Phase transition: writes `phase: watching` before entering Step 12
  - Timestamp-based bot detection: Copilot/Claude checks compare review `createdAt` against last push time instead of counting unresolved threads (which are all resolved by Step 9)

## Root Causes

Three bugs combined to cause the watch loop to exit after one fix cycle:

1. **Step 3 early exit**: After fix cycle resolved all threads, stop-hook re-entry found no unresolved feedback → Step 3 output `<done>COMPLETE</done>`, bypassing Step 12 entirely
2. **Thread-based bot detection broken**: Step 9 resolves ALL threads, so Copilot/Claude always appeared "approved" even before re-reviewing
3. **Stop hook re-feed lacked phase context**: Generic re-feed message caused Claude to restart from Step 1 instead of resuming at Step 12

## Test Plan

- [ ] Run `/address-review` on a PR with bot reviews — verify it enters Step 12 and polls instead of exiting after CI
- [ ] Verify stop-hook re-entry with `phase=watching` goes to Step 12a, not Step 1
- [ ] Verify `/address-review --no-watch` still exits after one fix cycle
- [ ] Verify other loop commands (`/start-issue`, `/lint-fix`, etc.) still work — they don't pass a 4th arg so `phase` defaults to empty
- [ ] Run `./scripts/check-shared-sync.sh` — confirms all shared files are in sync