### PR TITLE
feat(go-workflow,llm-tools): auto-generate tests for fixes during address-review

### DIFF
--- a/plugins/go-workflow/commands/address-review.md
+++ b/plugins/go-workflow/commands/address-review.md
@@ -515,11 +515,11 @@ For each testable fix, check if a test file already exists:
 ls "${FILE%.*}_test.go" 2>/dev/null || ls "$(dirname "$FILE")"/*_test.go 2>/dev/null
 ```
 
-If a test file exists, look for existing table-driven tests for the affected function:
+If a test file exists, look for existing table-driven tests for the affected function across ALL `*_test.go` files in the package (tests may be split across multiple files):
 
 ```bash
-# Search for existing test tables targeting the function
-grep -n "func Test.*${FUNCTION_NAME}" "${FILE%.*}_test.go" 2>/dev/null
+# Search all package test files for existing tests targeting the function
+grep -n "func Test.*${FUNCTION_NAME}" "$(dirname "$FILE")"/*_test.go 2>/dev/null
 ```
 
 ### 4.5c. Detect Testing Patterns

--- a/plugins/go-workflow/commands/address-review.md
+++ b/plugins/go-workflow/commands/address-review.md
@@ -434,6 +434,7 @@ Read the comment carefully. Determine what change is being requested:
 - Documentation update?
 - Test addition?
 - Refactoring?
+- Testable change? (Does this fix alter observable behavior — return values, errors, side effects, HTTP responses?)
 
 ### 4b. Locate the Code
 
@@ -467,6 +468,97 @@ Keep a mental note of:
 - Thread ID
 - What was fixed
 - Brief explanation for the reply
+- Testability: `testable` or `not-testable` (from 4a assessment)
+- If testable: the affected function/method name and package
+
+---
+
+## Step 4.5: Generate Tests for Testable Fixes
+
+After all fixes are applied (Step 4 complete), generate tests for fixes classified as `testable` in Step 4e.
+
+### Testability Guidelines
+
+**DO write tests for:**
+- Bug fixes that change function/method output or behavior
+- Logic changes (conditionals, error handling, edge cases)
+- New or modified validation rules
+- Data transformation or parsing changes
+- API response changes
+- Concurrency or race condition fixes
+- Any change that alters what a function returns, how it mutates state, or what side effects it produces
+
+**DO NOT write tests for:**
+- Removing or adding comments
+- Adding/changing log statements
+- Formatting or whitespace changes
+- Import reordering
+- Variable/function renames (unless public API)
+- Documentation updates
+- Config file tweaks that don't affect runtime behavior
+- Typo fixes in non-user-facing strings
+
+**Rule of thumb:** If the change affects something a caller or user could observe — a return value, an error, a side effect, an HTTP response — it's testable and should get a test. If it's purely cosmetic or informational, skip it.
+
+### 4.5a. Identify Testable Fixes
+
+Review the tracking notes from Step 4e. Collect all fixes marked `testable` along with their affected function/method and package.
+
+If no fixes are testable, skip to Step 5.
+
+### 4.5b. Check for Existing Tests
+
+For each testable fix, check if a test file already exists:
+
+```bash
+# For a file like pkg/auth/validate.go, check for pkg/auth/validate_test.go
+ls "${FILE%.*}_test.go" 2>/dev/null || ls "$(dirname "$FILE")/*_test.go" 2>/dev/null
+```
+
+If a test file exists, look for existing table-driven tests for the affected function:
+
+```bash
+# Search for existing test tables targeting the function
+grep -n "func Test.*${FUNCTION_NAME}" "${FILE%.*}_test.go" 2>/dev/null
+```
+
+### 4.5c. Detect Testing Patterns
+
+Examine existing test files in the same package to detect conventions:
+
+- **Test framework**: stdlib `testing` or `testify` (check for `github.com/stretchr/testify` imports)
+- **Table-driven pattern**: look for `tests := []struct` or `tt := []struct` patterns
+- **Naming conventions**: `Test_functionName` vs `TestFunctionName` vs `TestPackage_FunctionName`
+- **Helper patterns**: test fixtures, setup/teardown, `testdata/` directory usage
+
+Match these conventions when writing new tests.
+
+### 4.5d. Write Tests
+
+For each testable fix:
+
+**If an existing table-driven test exists for the affected function:**
+- Add a new test case to the existing table that covers the scenario the review comment flagged
+- Name the case descriptively (e.g., `"returns error when input is nil"`)
+
+**If no existing test exists:**
+- Create a new table-driven test function in the appropriate `_test.go` file
+- Follow the package's detected conventions (4.5c)
+- Include at least:
+  - A test case that exercises the fixed behavior (the "green" case)
+  - A test case for the edge case or incorrect input the review comment identified
+
+### 4.5e. Verify Tests Pass
+
+Run the tests to confirm they pass with the fix applied:
+
+```bash
+go test ./path/to/package/... -run "TestFunctionName" -v
+```
+
+All new tests must pass (green). If any fail, fix the test until green.
+
+**Note on red-green:** The traditional red-green cycle (verify test fails without fix, then passes with fix) is impractical here because fixes are applied in batch during Step 4. The review comment itself serves as the "red" evidence — it identified broken or incorrect behavior. The green confirmation in this step validates the test correctly covers the fixed behavior.
 
 ---
 
@@ -491,7 +583,8 @@ After verification passes, bundle changes into a single commit:
 git add -A
 git commit -m "address review comments
 
-- [brief summary of each fix]"
+- [brief summary of each fix]
+- [tests added for testable fixes, if any]"
 git push
 ```
 

--- a/plugins/go-workflow/commands/address-review.md
+++ b/plugins/go-workflow/commands/address-review.md
@@ -512,7 +512,7 @@ For each testable fix, check if a test file already exists:
 
 ```bash
 # For a file like pkg/auth/validate.go, check for pkg/auth/validate_test.go
-ls "${FILE%.*}_test.go" 2>/dev/null || ls "$(dirname "$FILE")/*_test.go" 2>/dev/null
+ls "${FILE%.*}_test.go" 2>/dev/null || ls "$(dirname "$FILE")"/*_test.go 2>/dev/null
 ```
 
 If a test file exists, look for existing table-driven tests for the affected function:

--- a/plugins/go-workflow/commands/address-review.md
+++ b/plugins/go-workflow/commands/address-review.md
@@ -469,7 +469,7 @@ Keep a mental note of:
 - What was fixed
 - Brief explanation for the reply
 - Testability: `testable` or `not-testable` (from 4a assessment)
-- If testable: the affected function/method name and package
+- If testable: the source file path, affected function/method name, and package
 
 ---
 

--- a/plugins/llm-tools/commands/codex.md
+++ b/plugins/llm-tools/commands/codex.md
@@ -475,10 +475,11 @@ For every testable fix you make, write a corresponding test. A fix is testable i
 After Codex completes, check if `_test.go` files were created or modified:
 
 ```bash
-git diff --name-only HEAD | grep '_test.go$'
+# Check both tracked changes and untracked new files
+{ git diff --name-only HEAD; git ls-files --others --exclude-standard; } | grep '_test.go$'
 ```
 
-If no test files were changed AND the fix modified testable behavior, Claude generates the missing tests following the same guidelines above.
+If no test files were changed or created AND the fix modified testable behavior, Claude generates the missing tests following the same guidelines above.
 
 ### 1. Select Model
 

--- a/plugins/llm-tools/commands/codex.md
+++ b/plugins/llm-tools/commands/codex.md
@@ -449,6 +449,37 @@ For follow-ups, use: `codex resume --last`
 
 Use this flow for non-review tasks.
 
+### Review Fix Detection
+
+Before running Codex, detect if the prompt is addressing review feedback (e.g., contains phrases like "fix review comment", "address feedback", "fix the issue from review", or the prompt originates from an `/address-review` context). If a review-fix prompt is detected:
+
+Append these instructions to the Codex prompt:
+
+```text
+
+---
+
+## Test Generation Requirement
+
+For every testable fix you make, write a corresponding test. A fix is testable if it changes observable behavior (return values, errors, side effects, HTTP responses). Skip tests for cosmetic changes (comments, formatting, renames, log changes).
+
+- Check for existing `_test.go` files and table-driven tests for affected functions
+- If a table-driven test exists, add a new case covering the fixed behavior
+- If no test exists, create a new table-driven test
+- Follow the existing test conventions in the package (testify vs stdlib, naming patterns)
+- Verify all new tests pass
+```
+
+### Review Fix Fallback
+
+After Codex completes, check if `_test.go` files were created or modified:
+
+```bash
+git diff --name-only HEAD | grep '_test.go$'
+```
+
+If no test files were changed AND the fix modified testable behavior, Claude generates the missing tests following the same guidelines above.
+
 ### 1. Select Model
 
 Ask the user which model to use:

--- a/plugins/llm-tools/commands/codex.md
+++ b/plugins/llm-tools/commands/codex.md
@@ -92,8 +92,9 @@ for f in $(find . -name '*_test.go' -type f 2>/dev/null); do
   md5sum "$f" 2>/dev/null || md5 -r "$f" 2>/dev/null
 done | sort > "$TEST_CURRENT"
 
-# Find lines that differ (new files or modified content)
-CHANGED_TESTS=$(comm -3 "$TEST_BASELINE" "$TEST_CURRENT" | awk '{print $NF}' | sort -u)
+# Find lines only in current (new or modified files), excluding deletions
+# comm -13 shows lines in file2 not in file1 (new/changed hashes)
+CHANGED_TESTS=$(comm -13 "$TEST_BASELINE" "$TEST_CURRENT" | awk '{print $NF}' | sort -u)
 rm -f "$TEST_BASELINE" "$TEST_CURRENT"
 
 if [ -n "$CHANGED_TESTS" ]; then

--- a/plugins/llm-tools/commands/codex.md
+++ b/plugins/llm-tools/commands/codex.md
@@ -47,6 +47,38 @@ Run a task using OpenAI Codex CLI with the prompt: $ARGUMENTS
 Check if the prompt contains "review" (case-insensitive). If yes, route to **Review Flow**.
 Otherwise, continue with **Exec Flow**.
 
+## 2. Review Fix Detection (applies to both flows)
+
+Before running Codex in either flow, detect if the prompt is addressing review feedback (e.g., contains phrases like "fix review comment", "address feedback", "fix the issue from review", or the prompt originates from an `/address-review` context). If a review-fix prompt is detected:
+
+Append these instructions to the Codex prompt (whether using `codex review` or `codex exec`):
+
+```text
+
+---
+
+## Test Generation Requirement
+
+For every testable fix you make, write a corresponding test. A fix is testable if it changes observable behavior (return values, errors, side effects, HTTP responses). Skip tests for cosmetic changes (comments, formatting, renames, log changes).
+
+- Check for existing `_test.go` files and table-driven tests for affected functions
+- If a table-driven test exists, add a new case covering the fixed behavior
+- If no test exists, create a new table-driven test
+- Follow the existing test conventions in the package (testify vs stdlib, naming patterns)
+- Verify all new tests pass
+```
+
+### Review Fix Fallback (after either flow completes)
+
+After Codex completes (either flow), check if `_test.go` files were created or modified:
+
+```bash
+# Check both tracked changes and untracked new files
+{ git diff --name-only HEAD; git ls-files --others --exclude-standard; } | grep '_test.go$'
+```
+
+If no test files were changed or created AND the fix modified testable behavior, Claude generates the missing tests following the same guidelines above.
+
 ---
 
 ## Review Flow
@@ -448,38 +480,6 @@ For follow-ups, use: `codex resume --last`
 ## Exec Flow
 
 Use this flow for non-review tasks.
-
-### Review Fix Detection
-
-Before running Codex, detect if the prompt is addressing review feedback (e.g., contains phrases like "fix review comment", "address feedback", "fix the issue from review", or the prompt originates from an `/address-review` context). If a review-fix prompt is detected:
-
-Append these instructions to the Codex prompt:
-
-```text
-
----
-
-## Test Generation Requirement
-
-For every testable fix you make, write a corresponding test. A fix is testable if it changes observable behavior (return values, errors, side effects, HTTP responses). Skip tests for cosmetic changes (comments, formatting, renames, log changes).
-
-- Check for existing `_test.go` files and table-driven tests for affected functions
-- If a table-driven test exists, add a new case covering the fixed behavior
-- If no test exists, create a new table-driven test
-- Follow the existing test conventions in the package (testify vs stdlib, naming patterns)
-- Verify all new tests pass
-```
-
-### Review Fix Fallback
-
-After Codex completes, check if `_test.go` files were created or modified:
-
-```bash
-# Check both tracked changes and untracked new files
-{ git diff --name-only HEAD; git ls-files --others --exclude-standard; } | grep '_test.go$'
-```
-
-If no test files were changed or created AND the fix modified testable behavior, Claude generates the missing tests following the same guidelines above.
 
 ### 1. Select Model
 

--- a/plugins/llm-tools/commands/gemini.md
+++ b/plugins/llm-tools/commands/gemini.md
@@ -94,7 +94,20 @@ Default: `No`
 - Generate summary of current Claude session (~100 words)
 - Include goal, decisions made, files discussed
 
-## 4. Run Gemini
+## 4. Review Fix Detection
+
+Before running Gemini, detect if the prompt is addressing review feedback (e.g., contains phrases like "fix review comment", "address feedback", "fix the issue from review", or originates from an `/address-review` context). If a review-fix prompt is detected:
+
+Append to the Gemini prompt:
+
+```text
+
+---
+
+For every testable fix, write a corresponding test. A fix is testable if it changes observable behavior (return values, errors, side effects, HTTP responses). Skip tests for cosmetic changes (comments, formatting, renames, log changes). Add cases to existing table-driven tests when possible, or create new table-driven tests following the package's conventions.
+```
+
+## 5. Run Gemini
 
 **Without context:**
 
@@ -131,26 +144,13 @@ EOF
 )" -m <model>
 ```
 
-## 5. Report Results
+## 6. Report Results
 
 After execution completes:
 
 - Display the response to the user
 - Ask if they want a follow-up question or different perspective
 - Offer to try `/codex` or `/ollama` for comparison
-
-## Review Fix Detection
-
-Before running Gemini, detect if the prompt is addressing review feedback (e.g., contains phrases like "fix review comment", "address feedback", "fix the issue from review", or originates from an `/address-review` context). If a review-fix prompt is detected:
-
-Append to the Gemini prompt:
-
-```text
-
----
-
-For every testable fix, write a corresponding test. A fix is testable if it changes observable behavior (return values, errors, side effects, HTTP responses). Skip tests for cosmetic changes (comments, formatting, renames, log changes). Add cases to existing table-driven tests when possible, or create new table-driven tests following the package's conventions.
-```
 
 ### Review Fix Fallback
 

--- a/plugins/llm-tools/commands/gemini.md
+++ b/plugins/llm-tools/commands/gemini.md
@@ -139,6 +139,23 @@ After execution completes:
 - Ask if they want a follow-up question or different perspective
 - Offer to try `/codex` or `/ollama` for comparison
 
+## Review Fix Detection
+
+Before running Gemini, detect if the prompt is addressing review feedback (e.g., contains phrases like "fix review comment", "address feedback", "fix the issue from review", or originates from an `/address-review` context). If a review-fix prompt is detected:
+
+Append to the Gemini prompt:
+
+```text
+
+---
+
+For every testable fix, write a corresponding test. A fix is testable if it changes observable behavior (return values, errors, side effects, HTTP responses). Skip tests for cosmetic changes (comments, formatting, renames, log changes). Add cases to existing table-driven tests when possible, or create new table-driven tests following the package's conventions.
+```
+
+### Review Fix Fallback
+
+After Gemini completes, check if its response includes test code (look for `func Test` or `_test.go` content). If the response contains a fix but no tests for testable changes, Claude generates the missing tests using the same guidelines.
+
 ## Error Handling
 
 - If Gemini CLI exits with error, display the error message

--- a/plugins/llm-tools/commands/llm-compare.md
+++ b/plugins/llm-tools/commands/llm-compare.md
@@ -81,6 +81,19 @@ Default: `No`
 
 If context is selected, gather it once and use for all LLMs.
 
+## Review Fix Detection
+
+Before running the LLMs, detect if the prompt is addressing review feedback (e.g., contains phrases like "fix review comment", "address feedback", "fix the issue from review", or originates from an `/address-review` context). If a review-fix prompt is detected:
+
+Append to **ALL** LLM prompts:
+
+```text
+
+---
+
+For every testable fix, write a corresponding test. A fix is testable if it changes observable behavior (return values, errors, side effects, HTTP responses). Skip tests for cosmetic changes (comments, formatting, renames, log changes). Add cases to existing table-driven tests when possible, or create new table-driven tests following the package's conventions.
+```
+
 ## 4. Run LLMs
 
 Execute each LLM. Where possible, run in parallel for speed.
@@ -138,11 +151,21 @@ Present results in a structured format:
 ### Synthesis
 [Your analysis as Claude combining insights from all responses]
 
+### Test Coverage
+(Only included when review fix detection is active)
+- Which LLMs included tests with their fix
+- Quality comparison of generated tests (coverage, edge cases, conventions)
+- If no LLM produced tests: "No LLM generated tests — Claude will generate them as fallback"
+
 ### Recommendation
 Based on the comparison:
 - If models agree: "All models align on [approach]. This consensus suggests [conclusion]."
 - If models disagree: "Models differ on [aspect]. Consider [factors] when deciding."
 ```
+
+### Review Fix Fallback
+
+After generating the comparison report, if the review fix detection was active: check if ANY LLM produced test code (look for `func Test` or `_test.go` content in their responses). If no LLM produced tests for testable changes, Claude generates the missing tests using the same guidelines.
 
 ## 6. Follow-up Options
 

--- a/plugins/llm-tools/commands/ollama.md
+++ b/plugins/llm-tools/commands/ollama.md
@@ -134,7 +134,22 @@ Default: `No`
 **If "Session context":**
 - Generate summary of current Claude session (~100 words)
 
-## 6. Run Ollama
+## 6. Review Fix Detection
+
+Before running Ollama, detect if the prompt is addressing review feedback (e.g., contains phrases like "fix review comment", "address feedback", "fix the issue from review", or originates from an `/address-review` context). If a review-fix prompt is detected:
+
+Append to the Ollama prompt:
+
+```text
+
+---
+
+For every testable fix, write a corresponding test. A fix is testable if it changes observable behavior (return values, errors, side effects, HTTP responses). Skip tests for cosmetic changes (comments, formatting, renames, log changes). Add cases to existing table-driven tests when possible, or create new table-driven tests following the package's conventions.
+```
+
+**Note:** Local models commonly skip test generation or produce incomplete tests. The fallback below is especially important for Ollama.
+
+## 7. Run Ollama
 
 **Without context:**
 
@@ -179,28 +194,13 @@ EOF
 )"
 ```
 
-## 7. Report Results
+## 8. Report Results
 
 After execution completes:
 
 - Display the response to the user
 - Ask if they want a follow-up question
 - Offer to try a different model or compare with `/codex` or `/gemini`
-
-## Review Fix Detection
-
-Before running Ollama, detect if the prompt is addressing review feedback (e.g., contains phrases like "fix review comment", "address feedback", "fix the issue from review", or originates from an `/address-review` context). If a review-fix prompt is detected:
-
-Append to the Ollama prompt:
-
-```text
-
----
-
-For every testable fix, write a corresponding test. A fix is testable if it changes observable behavior (return values, errors, side effects, HTTP responses). Skip tests for cosmetic changes (comments, formatting, renames, log changes). Add cases to existing table-driven tests when possible, or create new table-driven tests following the package's conventions.
-```
-
-**Note:** Local models commonly skip test generation or produce incomplete tests. The fallback below is especially important for Ollama.
 
 ### Review Fix Fallback
 

--- a/plugins/llm-tools/commands/ollama.md
+++ b/plugins/llm-tools/commands/ollama.md
@@ -187,6 +187,25 @@ After execution completes:
 - Ask if they want a follow-up question
 - Offer to try a different model or compare with `/codex` or `/gemini`
 
+## Review Fix Detection
+
+Before running Ollama, detect if the prompt is addressing review feedback (e.g., contains phrases like "fix review comment", "address feedback", "fix the issue from review", or originates from an `/address-review` context). If a review-fix prompt is detected:
+
+Append to the Ollama prompt:
+
+```text
+
+---
+
+For every testable fix, write a corresponding test. A fix is testable if it changes observable behavior (return values, errors, side effects, HTTP responses). Skip tests for cosmetic changes (comments, formatting, renames, log changes). Add cases to existing table-driven tests when possible, or create new table-driven tests following the package's conventions.
+```
+
+**Note:** Local models commonly skip test generation or produce incomplete tests. The fallback below is especially important for Ollama.
+
+### Review Fix Fallback
+
+After Ollama completes, check if its response includes test code (look for `func Test` or `_test.go` content). If the response contains a fix but no tests for testable changes, Claude generates the missing tests using the same guidelines.
+
 ## Error Handling
 
 - If model loading fails (OOM), suggest a smaller model


### PR DESCRIPTION
## Summary

- Add **Step 4.5** to `/address-review` that automatically generates tests for testable fixes after all review comments are addressed
- Expand Step 4a/4e tracking to classify each fix as testable or not, with affected function/package
- Update commit message template (Step 6) to mention test additions
- Add **Review Fix Detection** to `/codex`, `/gemini`, `/ollama`, and `/llm-compare` that appends test generation instructions to LLM prompts when review-fix context is detected
- Add **fallback** to each LLM command so Claude generates tests if the delegated LLM skips them

Fixes #75

## Test Plan

- [ ] Run `/address-review` on a PR with testable review comments (e.g., logic fix, error handling) — verify Step 4.5 generates tests
- [ ] Run `/address-review` on a PR with non-testable comments (formatting, comments) — verify Step 4.5 is skipped
- [ ] Run `/codex` with a review-fix prompt — verify test instructions are appended and fallback triggers if needed
- [ ] Run `/gemini` with a review-fix prompt — verify same behavior
- [ ] Run `/ollama` with a review-fix prompt — verify same behavior with local model note
- [ ] Run `/llm-compare` with a review-fix prompt — verify test instructions added to all LLM prompts and Test Coverage section appears in report
- [ ] Verify step numbering in address-review.md is intact (4 → 4.5 → 5 → ... → 12)
- [ ] Verify `./scripts/check-shared-sync.sh` passes