### PR TITLE
feat(llm-tools): add /review-loop command for iterative LLM code review

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -64,7 +64,7 @@
       "name": "llm-tools",
       "source": "./plugins/llm-tools",
       "description": "Multi-LLM integration for second opinions and task delegation",
-      "version": "1.3.0",
+      "version": "1.4.0",
       "keywords": [
         "llm",
         "openai",

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,14 +6,14 @@
   },
   "metadata": {
     "description": "Go-specific and general-purpose AI coding assistant plugins - by Gopher Guides",
-    "version": "1.3.0"
+    "version": "1.4.0"
   },
   "plugins": [
     {
       "name": "go-workflow",
       "source": "./plugins/go-workflow",
       "description": "Issue-to-PR workflow automation with worktree management",
-      "version": "1.3.0",
+      "version": "1.4.0",
       "keywords": [
         "workflow",
         "github",
@@ -26,7 +26,7 @@
       "name": "go-dev",
       "source": "./plugins/go-dev",
       "description": "Go-specific development tools with best practices",
-      "version": "1.3.0",
+      "version": "1.4.0",
       "keywords": [
         "go",
         "testing",
@@ -39,7 +39,7 @@
       "name": "productivity",
       "source": "./plugins/productivity",
       "description": "Standup reports and git productivity helpers",
-      "version": "1.3.0",
+      "version": "1.4.0",
       "keywords": [
         "standup",
         "changelog",
@@ -52,7 +52,7 @@
       "name": "gopher-guides",
       "source": "./plugins/gopher-guides",
       "description": "Go best practices guidance powered by Gopher Guides training materials",
-      "version": "1.3.0",
+      "version": "1.4.0",
       "keywords": [
         "go",
         "training",
@@ -79,7 +79,7 @@
       "name": "go-web",
       "source": "./plugins/go-web",
       "description": "Opinionated Go web app scaffolding with Templ + HTMX + Alpine.js + Tailwind",
-      "version": "1.3.0",
+      "version": "1.4.0",
       "keywords": [
         "go",
         "web",
@@ -95,7 +95,7 @@
       "name": "tailwind",
       "source": "./plugins/tailwind",
       "description": "Tailwind CSS v4 tools for initialization, auditing, migration, and optimization",
-      "version": "1.3.0",
+      "version": "1.4.0",
       "keywords": [
         "tailwind",
         "css",

--- a/plugins/go-dev/.claude-plugin/plugin.json
+++ b/plugins/go-dev/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "go-dev",
   "description": "Go-specific development tools with idiomatic best practices",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "author": {
     "name": "Gopher Guides",
     "email": "support@gopherguides.com"

--- a/plugins/go-web/.claude-plugin/plugin.json
+++ b/plugins/go-web/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "go-web",
   "description": "Opinionated Go web app scaffolding with Templ + HTMX + Alpine.js + Tailwind",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "author": {
     "name": "Gopher Guides",
     "email": "support@gopherguides.com"

--- a/plugins/go-workflow/.claude-plugin/plugin.json
+++ b/plugins/go-workflow/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "go-workflow",
   "description": "Issue-to-PR workflow automation with git worktree management",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "author": {
     "name": "Gopher Guides",
     "email": "support@gopherguides.com"

--- a/plugins/go-workflow/hooks/stop-hook.sh
+++ b/plugins/go-workflow/hooks/stop-hook.sh
@@ -90,10 +90,19 @@ NEW_ITERATION=$((ITERATION + 1))
 # Build system message with iteration info and guidance
 SYSTEM_MSG="Iteration $NEW_ITERATION of loop '$LOOP_NAME'."
 
-# Phase-aware re-feed: use targeted message for watching phase
+# Phase-aware re-feed: use targeted message based on current phase
 if [ "$PHASE" = "watching" ]; then
   REASON="Resume Step 12: Check bot approval status, poll if needed. Do NOT re-run Steps 1-11."
   SYSTEM_MSG="$SYSTEM_MSG RESUME AT STEP 12a: The fix cycle (Steps 1-11) is already complete. Check bot approval status and poll for re-reviews. Do NOT restart the fix cycle."
+elif [ "$PHASE" = "reviewing" ]; then
+  REASON="Continue the review loop: run the next LLM review pass and address findings."
+  SYSTEM_MSG="$SYSTEM_MSG Resume the review-fix-verify cycle. Run the next review pass."
+elif [ "$PHASE" = "fixing" ]; then
+  REASON="Continue fixing: address remaining review findings, then verify."
+  SYSTEM_MSG="$SYSTEM_MSG Continue addressing review findings."
+elif [ "$PHASE" = "verifying" ]; then
+  REASON="Continue verification: run build, test, and lint on fixes."
+  SYSTEM_MSG="$SYSTEM_MSG Verify fixes pass build, test, and lint."
 else
   REASON="$ORIGINAL_PROMPT"
   SYSTEM_MSG="$SYSTEM_MSG Continue working on the task."

--- a/plugins/gopher-guides/.claude-plugin/plugin.json
+++ b/plugins/gopher-guides/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "gopher-guides",
   "description": "Gopher Guides training materials integrated into Claude",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "author": {
     "name": "Gopher Guides",
     "email": "support@gopherguides.com"

--- a/plugins/llm-tools/.claude-plugin/plugin.json
+++ b/plugins/llm-tools/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "llm-tools",
   "description": "Multi-LLM integration for second opinions and task delegation",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "author": {
     "name": "Gopher Guides",
     "email": "support@gopherguides.com"

--- a/plugins/llm-tools/README.md
+++ b/plugins/llm-tools/README.md
@@ -22,6 +22,7 @@ Or install via marketplace:
 | `/ollama <prompt>` | Use local models (data stays on your machine) |
 | `/llm-compare <prompt>` | Compare responses from multiple LLMs |
 | `/convert <from> <to>` | Convert between formats (JSON→TS, SQL→Prisma, etc.) |
+| `/review-loop [options]` | Iterative LLM review loop: review, fix, verify, repeat until clean |
 
 ## Skills (Auto-invoked)
 

--- a/plugins/llm-tools/commands/cancel-loop.md
+++ b/plugins/llm-tools/commands/cancel-loop.md
@@ -1,0 +1,23 @@
+---
+argument-hint: "[loop-name]"
+description: "Cancel any active persistent loop"
+allowed-tools: ["Bash"]
+---
+
+# Cancel Loop
+
+Cancel the currently active persistent loop and allow normal session behavior.
+
+**Usage:**
+- `/cancel-loop` - Cancel all active loops
+- `/cancel-loop <name>` - Cancel a specific loop by name
+
+## Execute Cancellation
+
+!`"${CLAUDE_PLUGIN_ROOT}/scripts/cleanup-loop.sh" "$ARGUMENTS"`
+
+## Result
+
+The loop has been cancelled. You can now exit the session normally or start a new task.
+
+If you want to restart the previous task, you can run the original command again.

--- a/plugins/llm-tools/commands/review-loop.md
+++ b/plugins/llm-tools/commands/review-loop.md
@@ -54,7 +54,14 @@ if [ -f "$STATE_FILE" ]; then
 fi
 ```
 
-If `PHASE` is set (non-empty), this is a re-entry from the stop-hook. Skip to the corresponding phase:
+If `PHASE` is set (non-empty), this is a re-entry from the stop-hook. Runtime state (scope, model, pass count) is lost on re-entry because `setup-loop.sh` only preserves `phase`. On re-entry:
+
+1. Re-read `ORIGINAL_PROMPT` from the state file to recover the `$ARGUMENTS` (contains `--llm`, `--max-passes`, scope hint)
+2. Re-parse those arguments to restore `LLM_CHOICE`, `MAX_PASSES`, `SCOPE_HINT`
+3. For `REVIEW_SCOPE`, `BASE_BRANCH`, and `MODEL`: infer defaults (`changes vs main`, default model for the LLM) rather than re-asking the user. The stop-hook reason message provides enough context to continue.
+4. For `PASS`: check git log for previous `"fix: address <llm> review findings (pass N)"` commits to infer current pass number.
+
+Then skip to the corresponding phase:
 
 - `reviewing` → go to Step 5
 - `fixing` → go to Step 7
@@ -144,7 +151,7 @@ Show model options based on `LLM_CHOICE`:
 ### 4c. Conditional Follow-Up
 
 If "Changes vs branch" was selected, ask for the base branch (default: `main`).
-If "Specific files" was selected, ask for the file paths.
+If "Specific files" was selected, ask for the base branch (default: `main`) AND the file paths.
 If "Custom" model was selected, ask for the model name.
 
 Store all selections: `REVIEW_SCOPE`, `BASE_BRANCH`, `MODEL`, `FILE_PATHS`.
@@ -197,8 +204,9 @@ EOF
 
 **Gemini:**
 
+Use the `DIFF` generated in Step 5a (scope-aware), not a hardcoded branch diff.
+
 ```bash
-DIFF=$(git diff ${BASE_BRANCH}...HEAD)
 gemini -m "$MODEL" <<EOF
 Review the following code changes for bugs, security issues, performance problems, and best practice violations.
 
@@ -215,8 +223,9 @@ EOF
 
 **Ollama:**
 
+Use the `DIFF` generated in Step 5a (scope-aware), not a hardcoded branch diff.
+
 ```bash
-DIFF=$(git diff ${BASE_BRANCH}...HEAD)
 ollama run "$MODEL" <<EOF
 Review the following code changes for bugs, security issues, performance problems, and best practice violations.
 

--- a/plugins/llm-tools/commands/review-loop.md
+++ b/plugins/llm-tools/commands/review-loop.md
@@ -19,6 +19,15 @@ Parse `$ARGUMENTS` to extract:
 
 Store as `LLM_CHOICE`, `MAX_PASSES`, and `SCOPE_HINT`.
 
+**Persist arguments to state file** for re-entry recovery. After parsing, append these fields to `.claude/review-loop.loop.local.md` if they don't already exist:
+
+```yaml
+args: <raw $ARGUMENTS string>
+pass: 0
+```
+
+This ensures stop-hook re-entry can restore the original configuration.
+
 ## 2. Prerequisite Check
 
 Verify the selected LLM CLI is installed. Fail fast with install instructions if not found.
@@ -54,12 +63,11 @@ if [ -f "$STATE_FILE" ]; then
 fi
 ```
 
-If `PHASE` is set (non-empty), this is a re-entry from the stop-hook. Runtime state (scope, model, pass count) is lost on re-entry because `setup-loop.sh` only preserves `phase`. On re-entry:
+If `PHASE` is set (non-empty), this is a re-entry from the stop-hook. Recover state from the persisted fields in the state file:
 
-1. Re-read `ORIGINAL_PROMPT` from the state file to recover the `$ARGUMENTS` (contains `--llm`, `--max-passes`, scope hint)
-2. Re-parse those arguments to restore `LLM_CHOICE`, `MAX_PASSES`, `SCOPE_HINT`
+1. Read `args:` field from the state file and re-parse to restore `LLM_CHOICE`, `MAX_PASSES`, `SCOPE_HINT`
+2. Read `pass:` field from the state file to restore the current pass count
 3. For `REVIEW_SCOPE`, `BASE_BRANCH`, and `MODEL`: infer defaults (`changes vs main`, default model for the LLM) rather than re-asking the user. The stop-hook reason message provides enough context to continue.
-4. For `PASS`: check git log for previous `"fix: address <llm> review findings (pass N)"` commits to infer current pass number.
 
 Then skip to the corresponding phase:
 
@@ -156,18 +164,19 @@ If "Custom" model was selected, ask for the model name.
 
 Store all selections: `REVIEW_SCOPE`, `BASE_BRANCH`, `MODEL`, `FILE_PATHS`.
 
-Initialize pass counter: `PASS=0`.
+The `pass:` field in the state file was initialized to 0 in Step 1.
 
 ## 5. Review Phase
 
-Set phase to `reviewing`:
+Set phase to `reviewing` and increment the `pass:` field in the state file:
 
 ```bash
 source "${CLAUDE_PLUGIN_ROOT}/lib/loop-state.sh"
 set_loop_phase ".claude/review-loop.loop.local.md" "reviewing"
+# Increment pass counter in state file (read current value, increment, write back)
 ```
 
-Increment pass counter: `PASS=$((PASS + 1))`
+Read the updated `pass:` value from the state file into `PASS` for use in this pass.
 
 ### 5a. Generate Diff
 

--- a/plugins/llm-tools/commands/review-loop.md
+++ b/plugins/llm-tools/commands/review-loop.md
@@ -34,7 +34,13 @@ elif [ "$LLM_CHOICE" = "ollama" ]; then
 fi
 ```
 
-If the check fails, report the error and stop. Do NOT continue the loop.
+If the check fails, report the error, clean up the loop state file to prevent stale re-entry, and stop:
+
+```bash
+"${CLAUDE_PLUGIN_ROOT}/scripts/cleanup-loop.sh" "review-loop"
+```
+
+Do NOT continue the loop. Output `<done>REVIEW_CLEAN</done>` to signal completion.
 
 ## 3. Re-entry Check
 
@@ -275,15 +281,15 @@ Auto-detect project type and run appropriate verification:
 ```bash
 go build ./...
 go test ./...
-golangci-lint run 2>/dev/null || true
+golangci-lint run 2>/dev/null || true  # optional: may not be installed
 ```
 
 **Node/TypeScript** (package.json exists):
 
 ```bash
-npm run build 2>/dev/null || true
-npm test 2>/dev/null || true
-npm run lint 2>/dev/null || true
+npm run build  # fail if build breaks
+npm test       # fail if tests break
+npm run lint 2>/dev/null || true  # optional: lint script may not exist
 ```
 
 **Rust** (Cargo.toml exists):
@@ -291,14 +297,14 @@ npm run lint 2>/dev/null || true
 ```bash
 cargo build
 cargo test
-cargo clippy 2>/dev/null || true
+cargo clippy 2>/dev/null || true  # optional: may not be installed
 ```
 
 **Python** (pyproject.toml or setup.py exists):
 
 ```bash
-pytest 2>/dev/null || python -m pytest 2>/dev/null || true
-ruff check . 2>/dev/null || flake8 . 2>/dev/null || true
+pytest 2>/dev/null || python -m pytest  # fail if tests break
+ruff check . 2>/dev/null || flake8 . 2>/dev/null || true  # optional: linter may not be installed
 ```
 
 **Fallback:** If no project type detected, ask the user what verify command to run.
@@ -311,12 +317,14 @@ If any verification fails:
 
 ## 9. Commit Fixes
 
-Stage and commit all changes from this pass:
+Stage only the files that were fixed in this pass and commit. Do NOT use `git add -A` as it may sweep in unrelated working-tree changes:
 
 ```bash
-git add -A
+git add <list of files modified during fix phase>
 git commit -m "fix: address $LLM_CHOICE review findings (pass $PASS)"
 ```
+
+Track which files were edited during the fix phase (Step 7) and only stage those specific files.
 
 Display summary for this pass:
 - Findings reported by LLM

--- a/plugins/llm-tools/commands/review-loop.md
+++ b/plugins/llm-tools/commands/review-loop.md
@@ -1,0 +1,366 @@
+---
+argument-hint: "[--llm codex|gemini|ollama] [--max-passes <n>] [scope hint]"
+description: "Iterative LLM review loop: review, fix, verify, repeat until clean"
+model: claude-opus-4-6
+allowed-tools: ["Bash", "Read", "Glob", "Grep", "Edit", "Write", "AskUserQuestion"]
+---
+
+# Iterative LLM Review Loop
+
+!`"${CLAUDE_PLUGIN_ROOT}/scripts/setup-loop.sh" "review-loop" "REVIEW_CLEAN" 25`
+
+## 1. Parse Arguments
+
+Parse `$ARGUMENTS` to extract:
+
+- `--llm <value>`: LLM to use for reviews. Options: `codex` (default), `gemini`, `ollama`
+- `--max-passes <n>`: Maximum review passes before stopping (default: 5)
+- Remaining text: scope hint (e.g., "focus on error handling")
+
+Store as `LLM_CHOICE`, `MAX_PASSES`, and `SCOPE_HINT`.
+
+## 2. Prerequisite Check
+
+Verify the selected LLM CLI is installed. Fail fast with install instructions if not found.
+
+```bash
+# Check based on LLM_CHOICE
+if [ "$LLM_CHOICE" = "codex" ]; then
+  command -v codex >/dev/null 2>&1 || { echo "codex not found. Install: npm install -g @openai/codex"; exit 1; }
+elif [ "$LLM_CHOICE" = "gemini" ]; then
+  command -v gemini >/dev/null 2>&1 || { echo "gemini not found. Install: npm install -g @google/gemini-cli"; exit 1; }
+elif [ "$LLM_CHOICE" = "ollama" ]; then
+  command -v ollama >/dev/null 2>&1 || { echo "ollama not found. Install: brew install ollama"; exit 1; }
+fi
+```
+
+If the check fails, report the error and stop. Do NOT continue the loop.
+
+## 3. Re-entry Check
+
+Read the loop state file at `.claude/review-loop.loop.local.md`:
+
+```bash
+source "${CLAUDE_PLUGIN_ROOT}/lib/loop-state.sh"
+STATE_FILE=".claude/review-loop.loop.local.md"
+if [ -f "$STATE_FILE" ]; then
+  read_loop_state "$STATE_FILE"
+fi
+```
+
+If `PHASE` is set (non-empty), this is a re-entry from the stop-hook. Skip to the corresponding phase:
+
+- `reviewing` → go to Step 5
+- `fixing` → go to Step 7
+- `verifying` → go to Step 8
+
+If `PHASE` is empty or unset, this is a fresh start. Continue to Step 4.
+
+## 4. Detect Review Scope
+
+### 4a. Silent PR Auto-Detection
+
+Before asking any questions, silently detect PR context using multiple strategies:
+
+**Strategy 1 — Current branch:**
+
+```bash
+PR_JSON=`gh pr view --json number,title,body,state,closingIssuesReferences --jq '.' 2>/dev/null`
+```
+
+**Strategy 2 — Match HEAD commit against open PRs:**
+
+```bash
+if [ -z "$PR_JSON" ]; then
+  HEAD_SHA=`git rev-parse HEAD 2>/dev/null`
+  PR_NUM=`gh pr list --search "$HEAD_SHA" --state open --json number --jq '.[0].number' 2>/dev/null`
+  if [ -n "$PR_NUM" ] && [ "$PR_NUM" != "null" ]; then
+    PR_JSON=`gh pr view "$PR_NUM" --json number,title,body,state,closingIssuesReferences 2>/dev/null`
+  fi
+fi
+```
+
+**Strategy 3 — Check merged/closed PRs too:**
+
+```bash
+if [ -z "$PR_JSON" ]; then
+  HEAD_SHA=`git rev-parse HEAD 2>/dev/null`
+  PR_NUM=`gh pr list --search "$HEAD_SHA" --state all --limit 5 --json number --jq '.[0].number' 2>/dev/null`
+  if [ -n "$PR_NUM" ] && [ "$PR_NUM" != "null" ]; then
+    PR_JSON=`gh pr view "$PR_NUM" --json number,title,body,state,closingIssuesReferences 2>/dev/null`
+  fi
+fi
+```
+
+If a PR was found, display a brief summary.
+
+### 4b. Ask User for Review Scope
+
+Use a **single `AskUserQuestion` call** with these questions:
+
+**Question 1 — "What do you want to review?"**
+
+| Option | Description |
+|--------|-------------|
+| Changes vs branch (Recommended) | Review changes against a base branch (default: `main`) |
+| Uncommitted changes | Review staged, unstaged, and untracked changes |
+| Specific files | Review only specific files or directories |
+
+**Question 2 — "Which model?"**
+
+Show model options based on `LLM_CHOICE`:
+
+**If codex:**
+
+| Model | Description |
+|-------|-------------|
+| gpt-5.4 (Recommended) | Latest frontier model, best overall |
+| gpt-5.4-pro | Maximum performance on complex tasks |
+| gpt-5.3-codex | Previous generation frontier model |
+| gpt-5.1-codex-mini | Cost-efficient |
+
+**If gemini:**
+
+| Model | Description |
+|-------|-------------|
+| gemini-2.5-pro (Recommended) | Most capable |
+| gemini-2.5-flash | Faster, cost-efficient |
+
+**If ollama:**
+
+| Model | Description |
+|-------|-------------|
+| codellama (Recommended) | Code-specialized |
+| llama3 | General purpose |
+| deepseek-coder | Code-specialized |
+| Custom | Enter model name |
+
+### 4c. Conditional Follow-Up
+
+If "Changes vs branch" was selected, ask for the base branch (default: `main`).
+If "Specific files" was selected, ask for the file paths.
+If "Custom" model was selected, ask for the model name.
+
+Store all selections: `REVIEW_SCOPE`, `BASE_BRANCH`, `MODEL`, `FILE_PATHS`.
+
+Initialize pass counter: `PASS=0`.
+
+## 5. Review Phase
+
+Set phase to `reviewing`:
+
+```bash
+source "${CLAUDE_PLUGIN_ROOT}/lib/loop-state.sh"
+set_loop_phase ".claude/review-loop.loop.local.md" "reviewing"
+```
+
+Increment pass counter: `PASS=$((PASS + 1))`
+
+### 5a. Generate Diff
+
+Based on `REVIEW_SCOPE`:
+
+- **Changes vs branch:** `git diff ${BASE_BRANCH}...HEAD`
+- **Uncommitted changes:** `git diff HEAD` combined with `git diff --cached` and `git ls-files --others --exclude-standard`
+- **Specific files:** `git diff ${BASE_BRANCH}...HEAD -- <file_paths>`
+
+### 5b. Run LLM Review
+
+Execute the review based on `LLM_CHOICE`:
+
+**Codex:**
+
+```bash
+# For changes vs branch (native mode):
+codex review --base "$BASE_BRANCH" -c model="$MODEL"
+
+# For uncommitted:
+codex review --uncommitted -c model="$MODEL"
+
+# For specific files or when scope hint is provided, use stdin:
+DIFF=$(git diff ${BASE_BRANCH}...HEAD -- <files>)
+echo "$DIFF" | codex review -c model="$MODEL" - <<EOF
+$DIFF
+
+## Review Instructions
+${SCOPE_HINT:+Focus area: $SCOPE_HINT}
+Report each finding with: file path, line number, severity (error/warning/suggestion), and description.
+If there are no issues, respond with exactly: NO_ISSUES_FOUND
+EOF
+```
+
+**Gemini:**
+
+```bash
+DIFF=$(git diff ${BASE_BRANCH}...HEAD)
+gemini -m "$MODEL" <<EOF
+Review the following code changes for bugs, security issues, performance problems, and best practice violations.
+
+${SCOPE_HINT:+Focus area: $SCOPE_HINT}
+
+Report each finding with: file path, line number, severity (error/warning/suggestion), and description.
+If there are no issues, respond with exactly: NO_ISSUES_FOUND
+
+\`\`\`diff
+$DIFF
+\`\`\`
+EOF
+```
+
+**Ollama:**
+
+```bash
+DIFF=$(git diff ${BASE_BRANCH}...HEAD)
+ollama run "$MODEL" <<EOF
+Review the following code changes for bugs, security issues, performance problems, and best practice violations.
+
+${SCOPE_HINT:+Focus area: $SCOPE_HINT}
+
+Report each finding with: file path, line number, severity (error/warning/suggestion), and description.
+If there are no issues, respond with exactly: NO_ISSUES_FOUND
+
+\`\`\`diff
+$DIFF
+\`\`\`
+EOF
+```
+
+Capture the output as `FINDINGS`.
+
+## 6. Parse Findings
+
+After capturing the LLM review output:
+
+- If output (trimmed) equals exactly `NO_ISSUES_FOUND` or has fewer than 20 characters of content:
+  - If `PASS == 1`: Ask user to confirm the scope is correct (first-pass clean review may indicate wrong scope). If user confirms scope is fine → output `<done>REVIEW_CLEAN</done>` and stop.
+  - If `PASS > 1`: Clean review after fixes. Output summary and `<done>REVIEW_CLEAN</done>`.
+- Otherwise: Extract structured findings from the output. Display findings to user with pass number.
+
+**Filter bot noise:** Silently discard any finding that contains usage-limit or quota messages (e.g., "reached your Codex usage limits", "usage limits for code reviews", "see your limits").
+
+## 7. Fix Phase
+
+Set phase to `fixing`:
+
+```bash
+set_loop_phase ".claude/review-loop.loop.local.md" "fixing"
+```
+
+For each finding from Step 6:
+
+1. Read the relevant file and surrounding code context
+2. Evaluate the finding — is it valid and actionable?
+3. If valid: make the fix using Edit tool
+4. If not valid or intentionally skipped: record the reason
+5. For testable fixes (changes observable behavior): generate a corresponding test
+   - Check for existing `_test.go` / `_test.ts` / `test_*.py` files
+   - If table-driven tests exist, add a new case
+   - If no test exists, create one following project conventions
+   - Verify the new test passes
+
+Track counts: `FIXED`, `SKIPPED` (with reasons).
+
+## 8. Verify Phase
+
+Set phase to `verifying`:
+
+```bash
+set_loop_phase ".claude/review-loop.loop.local.md" "verifying"
+```
+
+Auto-detect project type and run appropriate verification:
+
+**Go** (go.mod exists):
+
+```bash
+go build ./...
+go test ./...
+golangci-lint run 2>/dev/null || true
+```
+
+**Node/TypeScript** (package.json exists):
+
+```bash
+npm run build 2>/dev/null || true
+npm test 2>/dev/null || true
+npm run lint 2>/dev/null || true
+```
+
+**Rust** (Cargo.toml exists):
+
+```bash
+cargo build
+cargo test
+cargo clippy 2>/dev/null || true
+```
+
+**Python** (pyproject.toml or setup.py exists):
+
+```bash
+pytest 2>/dev/null || python -m pytest 2>/dev/null || true
+ruff check . 2>/dev/null || flake8 . 2>/dev/null || true
+```
+
+**Fallback:** If no project type detected, ask the user what verify command to run.
+
+If any verification fails:
+1. Analyze the failure
+2. Fix the issue
+3. Re-run the failing verification
+4. Repeat until all verifications pass
+
+## 9. Commit Fixes
+
+Stage and commit all changes from this pass:
+
+```bash
+git add -A
+git commit -m "fix: address $LLM_CHOICE review findings (pass $PASS)"
+```
+
+Display summary for this pass:
+- Findings reported by LLM
+- Findings fixed
+- Findings skipped (with reasons)
+- Files changed
+- Verification status
+
+## 10. Loop Decision
+
+Check if we should continue:
+
+- If `PASS >= MAX_PASSES`:
+  - Display overall summary (total passes, total findings addressed, total skipped, files changed)
+  - Ask user: "Max passes reached. Continue for another round or stop?"
+  - If stop → output `<done>REVIEW_CLEAN</done>`
+  - If continue → reset `MAX_PASSES` to `MAX_PASSES + current value` and go to Step 5
+- Otherwise:
+  - Go to Step 5 (next review pass)
+
+## Completion
+
+When outputting completion, always include a summary:
+
+```
+## Review Loop Complete
+
+- **LLM:** <llm> (<model>)
+- **Total passes:** <n>
+- **Findings addressed:** <n>
+- **Findings skipped:** <n> (with reasons listed)
+- **Files changed:** <list>
+- **All verifications passed:** yes/no
+```
+
+Then output the completion promise:
+
+```
+<done>REVIEW_CLEAN</done>
+```
+
+## Important Notes
+
+- **Bot message filtering:** When processing LLM review output, silently discard any content about external service usage limits or quota messages. These are irrelevant to the local review.
+- **De-duplication across passes:** If a finding from a previous pass appears again (same file, same line, same issue), skip it — it was already addressed or intentionally skipped.
+- **Phase re-entry:** The stop-hook will re-feed this command if the session exits mid-loop. The phase check in Step 3 ensures we resume at the correct point.
+- **Cancel:** Users can run `/cancel-loop review-loop` at any time to cleanly exit the loop.

--- a/plugins/llm-tools/commands/review-loop.md
+++ b/plugins/llm-tools/commands/review-loop.md
@@ -65,9 +65,9 @@ fi
 
 If `PHASE` is set (non-empty), this is a re-entry from the stop-hook. Recover state from the persisted fields in the state file:
 
-1. Read `args:` field from the state file and re-parse to restore `LLM_CHOICE`, `MAX_PASSES`, `SCOPE_HINT`
-2. Read `pass:` field from the state file to restore the current pass count
-3. For `REVIEW_SCOPE`, `BASE_BRANCH`, and `MODEL`: infer defaults (`changes vs main`, default model for the LLM) rather than re-asking the user. The stop-hook reason message provides enough context to continue.
+1. Read `args:` field and re-parse to restore `LLM_CHOICE`, `MAX_PASSES`, `SCOPE_HINT`
+2. Read `pass:` field to restore the current pass count
+3. Read `scope:`, `base_branch:`, `model:`, `file_paths:` fields to restore `REVIEW_SCOPE`, `BASE_BRANCH`, `MODEL`, `FILE_PATHS`
 
 Then skip to the corresponding phase:
 
@@ -163,6 +163,15 @@ If "Specific files" was selected, ask for the base branch (default: `main`) AND 
 If "Custom" model was selected, ask for the model name.
 
 Store all selections: `REVIEW_SCOPE`, `BASE_BRANCH`, `MODEL`, `FILE_PATHS`.
+
+**Persist scope/model to state file** for re-entry recovery. Append these fields to `.claude/review-loop.loop.local.md`:
+
+```yaml
+scope: <REVIEW_SCOPE>
+base_branch: <BASE_BRANCH>
+model: <MODEL>
+file_paths: <FILE_PATHS or empty>
+```
 
 The `pass:` field in the state file was initialized to 0 in Step 1.
 
@@ -335,14 +344,23 @@ If any verification fails:
 
 ## 9. Commit Fixes
 
-Stage only the files that were fixed in this pass and commit. Do NOT use `git add -A` as it may sweep in unrelated working-tree changes:
+Stage only the files that were fixed in this pass. Do NOT use `git add -A` as it may sweep in unrelated working-tree changes:
 
 ```bash
 git add <list of files modified during fix phase>
-git commit -m "fix: address $LLM_CHOICE review findings (pass $PASS)"
 ```
 
 Track which files were edited during the fix phase (Step 7) and only stage those specific files.
+
+**Only commit if there are staged changes.** Passes can legitimately have zero fixable findings (all skipped/invalid), so check before committing:
+
+```bash
+if ! git diff --cached --quiet; then
+  git commit -m "fix: address $LLM_CHOICE review findings (pass $PASS)"
+else
+  echo "No changes to commit for this pass"
+fi
+```
 
 Display summary for this pass:
 - Findings reported by LLM

--- a/plugins/llm-tools/lib/loop-state.sh
+++ b/plugins/llm-tools/lib/loop-state.sh
@@ -1,0 +1,84 @@
+#!/bin/bash
+# Shared functions for loop state management
+# Used by stop-hook.sh and other loop-related scripts
+
+# Read loop state from a state file
+# Sets global variables: ITERATION, MAX_ITERATIONS, COMPLETION_PROMISE, LOOP_NAME, PHASE, ORIGINAL_PROMPT
+read_loop_state() {
+  local state_file="$1"
+  ITERATION=$(grep '^iteration:' "$state_file" | sed 's/iteration: *//')
+  MAX_ITERATIONS=$(grep '^max_iterations:' "$state_file" | sed 's/max_iterations: *//')
+  COMPLETION_PROMISE=$(grep '^completion_promise:' "$state_file" | sed 's/completion_promise: *//')
+  LOOP_NAME=$(grep '^loop_name:' "$state_file" | sed 's/loop_name: *//')
+  PHASE=$(grep '^phase:' "$state_file" | sed 's/phase: *//' || true)
+  # Get content after the second --- (the prompt/body)
+  ORIGINAL_PROMPT=$(awk '/^---$/{p++; next} p==2' "$state_file")
+}
+
+# Increment the iteration counter in a state file
+increment_iteration() {
+  local state_file="$1"
+  local new_iteration=$((ITERATION + 1))
+
+  # Use portable sed syntax (works on both macOS and Linux)
+  if [[ "$OSTYPE" == "darwin"* ]]; then
+    sed -i '' "s/^iteration: .*/iteration: $new_iteration/" "$state_file"
+  else
+    sed -i "s/^iteration: .*/iteration: $new_iteration/" "$state_file"
+  fi
+}
+
+# Set the phase field in a state file
+set_loop_phase() {
+  local state_file="$1"
+  local new_phase="$2"
+
+  if grep -q '^phase:' "$state_file"; then
+    if [[ "$OSTYPE" == "darwin"* ]]; then
+      sed -i '' "s/^phase: .*/phase: $new_phase/" "$state_file"
+    else
+      sed -i "s/^phase: .*/phase: $new_phase/" "$state_file"
+    fi
+  else
+    if [[ "$OSTYPE" == "darwin"* ]]; then
+      sed -i '' "/^completion_promise:/a\\
+phase: $new_phase" "$state_file"
+    else
+      sed -i "/^completion_promise:/a phase: $new_phase" "$state_file"
+    fi
+  fi
+}
+
+# Remove a loop state file (cleanup)
+cleanup_loop() {
+  local state_file="$1"
+  rm -f "$state_file"
+}
+
+# Check if the completion promise appears in recent transcript output
+# Returns 0 if found, 1 if not found
+check_completion_promise() {
+  local promise="$1"
+  local transcript=".claude/transcript.jsonl"
+
+  if [ -f "$transcript" ]; then
+    # Check the last 10 lines of transcript for the completion promise
+    # The promise should be wrapped in <done>...</done> tags
+    if tail -10 "$transcript" | grep -q "<done>$promise</done>"; then
+      return 0
+    fi
+  fi
+  return 1
+}
+
+# Find all active loop state files
+find_active_loops() {
+  find .claude -name "*.loop.local.md" 2>/dev/null
+}
+
+# Get the count of active loops
+count_active_loops() {
+  local count
+  count=$(find_active_loops | wc -l | tr -d ' ')
+  echo "$count"
+}

--- a/plugins/llm-tools/scripts/cleanup-loop.sh
+++ b/plugins/llm-tools/scripts/cleanup-loop.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+# Clean up loop state files
+# Usage: cleanup-loop.sh [loop-name]
+#
+# If loop-name is provided, only that loop is cleaned up
+# If no loop-name, all loops are cleaned up
+
+set -euo pipefail
+
+LOOP_NAME="${1:-}"
+
+if [ -n "$LOOP_NAME" ]; then
+  # Clean up specific loop
+  SAFE_LOOP_NAME=$(echo "$LOOP_NAME" | sed 's/[^a-zA-Z0-9_-]/-/g')
+  STATE_FILE=".claude/${SAFE_LOOP_NAME}.loop.local.md"
+
+  if [ -f "$STATE_FILE" ]; then
+    rm -f "$STATE_FILE"
+    echo "Loop '$LOOP_NAME' cancelled."
+  else
+    echo "No active loop found with name '$LOOP_NAME'."
+  fi
+else
+  # Clean up all loops
+  LOOP_FILES=$(find .claude -name "*.loop.local.md" 2>/dev/null || true)
+
+  if [ -z "$LOOP_FILES" ]; then
+    echo "No active loops found."
+  else
+    echo "$LOOP_FILES" | while read -r file; do
+      loop_name=$(grep '^loop_name:' "$file" 2>/dev/null | sed 's/loop_name: *//' || echo "unknown")
+      rm -f "$file"
+      echo "Cancelled loop: $loop_name"
+    done
+    echo "All active loops cancelled."
+  fi
+fi

--- a/plugins/llm-tools/scripts/setup-loop.sh
+++ b/plugins/llm-tools/scripts/setup-loop.sh
@@ -1,0 +1,67 @@
+#!/bin/bash
+# Initialize a persistent loop for any command
+# Usage: setup-loop.sh <loop-name> <completion-promise> [max-iterations] [initial-phase]
+#
+# Example:
+#   setup-loop.sh "start-issue-123" "COMPLETE"
+#   setup-loop.sh "create-project" "DONE" 50
+#   setup-loop.sh "address-review-42" "COMPLETE" "" "fixing"
+
+set -euo pipefail
+
+LOOP_NAME="${1:-}"
+COMPLETION_PROMISE="${2:-COMPLETE}"
+MAX_ITERATIONS="${3:-}"  # Optional, defaults to unlimited
+INITIAL_PHASE="${4:-}"   # Optional, defaults to empty
+
+if [ -z "$LOOP_NAME" ]; then
+  echo "Error: loop-name is required"
+  echo "Usage: setup-loop.sh <loop-name> <completion-promise> [max-iterations] [initial-phase]"
+  exit 1
+fi
+
+# Sanitize loop name for use in filename
+SAFE_LOOP_NAME=$(echo "$LOOP_NAME" | sed 's/[^a-zA-Z0-9_-]/-/g')
+STATE_FILE=".claude/${SAFE_LOOP_NAME}.loop.local.md"
+
+# Create .claude directory if it doesn't exist
+mkdir -p .claude
+
+# Check for existing loop — preserve phase and bot_review_baseline if re-initializing
+EXISTING_PHASE=""
+EXISTING_BASELINE=""
+if [ -f "$STATE_FILE" ]; then
+  EXISTING_PHASE=$(grep '^phase:' "$STATE_FILE" | sed 's/phase: *//' || true)
+  EXISTING_BASELINE=$(grep '^bot_review_baseline:' "$STATE_FILE" | sed 's/bot_review_baseline: *//' || true)
+  echo "Warning: Loop '$LOOP_NAME' already active. Resetting (preserving phase: ${EXISTING_PHASE:-<none>}, baseline: ${EXISTING_BASELINE:-<none>})..."
+fi
+
+# Preserve existing phase from state file, fall back to INITIAL_PHASE for fresh runs
+# This allows re-entry to maintain phase context (e.g., watching) across stop-hook restarts
+# while INITIAL_PHASE provides a default for first-time initialization
+PHASE="${EXISTING_PHASE:-$INITIAL_PHASE}"
+
+# Create state file with YAML frontmatter
+cat > "$STATE_FILE" << EOF
+---
+loop_name: $LOOP_NAME
+iteration: 1
+max_iterations: $MAX_ITERATIONS
+completion_promise: $COMPLETION_PROMISE
+phase: $PHASE
+bot_review_baseline: $EXISTING_BASELINE
+started_at: $(date -u +"%Y-%m-%dT%H:%M:%SZ")
+---
+
+Persistent loop initialized for: $LOOP_NAME
+Completion promise: $COMPLETION_PROMISE
+Max iterations: ${MAX_ITERATIONS:-unlimited}
+
+This loop will continue until:
+1. The completion promise <done>$COMPLETION_PROMISE</done> is output
+2. Max iterations is reached (if set)
+3. User cancels with /cancel-loop
+EOF
+
+echo "Loop initialized: $LOOP_NAME"
+echo "Output <done>$COMPLETION_PROMISE</done> when all completion criteria are met."

--- a/plugins/productivity/.claude-plugin/plugin.json
+++ b/plugins/productivity/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "productivity",
   "description": "Standup reports, changelogs, and git productivity helpers",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "author": {
     "name": "Gopher Guides",
     "email": "support@gopherguides.com"

--- a/plugins/tailwind/.claude-plugin/plugin.json
+++ b/plugins/tailwind/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "tailwind",
   "description": "Tailwind CSS v4 tools for initialization, auditing, migration, and optimization",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "author": {
     "name": "Gopher Guides",
     "email": "support@gopherguides.com"

--- a/scripts/check-shared-sync.sh
+++ b/scripts/check-shared-sync.sh
@@ -14,7 +14,7 @@ SHARED_DIR="$ROOT_DIR/shared"
 PLUGINS_DIR="$ROOT_DIR/plugins"
 
 # Plugins that use the shared loop infrastructure
-LOOP_PLUGINS=("go-workflow" "go-web" "go-dev" "tailwind")
+LOOP_PLUGINS=("go-workflow" "go-web" "go-dev" "tailwind" "llm-tools")
 
 # Only go-workflow has the stop hook
 HOOK_PLUGIN="go-workflow"

--- a/scripts/sync-shared.sh
+++ b/scripts/sync-shared.sh
@@ -14,7 +14,7 @@ SHARED_DIR="$ROOT_DIR/shared"
 PLUGINS_DIR="$ROOT_DIR/plugins"
 
 # Plugins that use the shared loop infrastructure
-LOOP_PLUGINS=("go-workflow" "go-web" "go-dev" "tailwind")
+LOOP_PLUGINS=("go-workflow" "go-web" "go-dev" "tailwind" "llm-tools")
 
 # Only go-workflow has the stop hook (owns persistent loop management)
 HOOK_PLUGIN="go-workflow"

--- a/shared/hooks/stop-hook.sh
+++ b/shared/hooks/stop-hook.sh
@@ -90,10 +90,19 @@ NEW_ITERATION=$((ITERATION + 1))
 # Build system message with iteration info and guidance
 SYSTEM_MSG="Iteration $NEW_ITERATION of loop '$LOOP_NAME'."
 
-# Phase-aware re-feed: use targeted message for watching phase
+# Phase-aware re-feed: use targeted message based on current phase
 if [ "$PHASE" = "watching" ]; then
   REASON="Resume Step 12: Check bot approval status, poll if needed. Do NOT re-run Steps 1-11."
   SYSTEM_MSG="$SYSTEM_MSG RESUME AT STEP 12a: The fix cycle (Steps 1-11) is already complete. Check bot approval status and poll for re-reviews. Do NOT restart the fix cycle."
+elif [ "$PHASE" = "reviewing" ]; then
+  REASON="Continue the review loop: run the next LLM review pass and address findings."
+  SYSTEM_MSG="$SYSTEM_MSG Resume the review-fix-verify cycle. Run the next review pass."
+elif [ "$PHASE" = "fixing" ]; then
+  REASON="Continue fixing: address remaining review findings, then verify."
+  SYSTEM_MSG="$SYSTEM_MSG Continue addressing review findings."
+elif [ "$PHASE" = "verifying" ]; then
+  REASON="Continue verification: run build, test, and lint on fixes."
+  SYSTEM_MSG="$SYSTEM_MSG Verify fixes pass build, test, and lint."
 else
   REASON="$ORIGINAL_PROMPT"
   SYSTEM_MSG="$SYSTEM_MSG Continue working on the task."


### PR DESCRIPTION
## Summary

- Add `/review-loop` command that runs an iterative LLM review → fix → verify → re-review cycle until clean
- Supports Codex, Gemini, and Ollama as reviewers (`--llm codex|gemini|ollama`)
- Uses existing stop-hook loop infrastructure with new `reviewing`/`fixing`/`verifying` phase handlers
- Add `llm-tools` to `LOOP_PLUGINS` for shared loop infrastructure sync (scripts, lib, cancel-loop)
- Bump llm-tools version 1.3.0 → 1.4.0

Fixes #81

## Key Design Decisions

- **Generalized name** (`/review-loop` not `/codex-review-loop`) to support multiple LLMs
- **No hooks in llm-tools** — go-workflow's stop-hook already detects any `.claude/*.loop.local.md` file
- **Phase-aware re-entry** — stop-hook provides targeted resume messages per phase
- **Safety limits** — `--max-passes` default 5, hard `max_iterations` 25, warning at 15

## Changes

| File | Purpose |
|------|---------|
| `plugins/llm-tools/commands/review-loop.md` | Main command: 10-step review-fix-verify loop |
| `shared/hooks/stop-hook.sh` | Add reviewing/fixing/verifying phase handlers |
| `plugins/go-workflow/hooks/stop-hook.sh` | Synced copy of stop-hook |
| `scripts/sync-shared.sh` | Add llm-tools to LOOP_PLUGINS |
| `scripts/check-shared-sync.sh` | Add llm-tools to LOOP_PLUGINS |
| `plugins/llm-tools/{scripts,lib,commands/cancel-loop.md}` | Synced loop infrastructure |
| `plugins/llm-tools/.claude-plugin/plugin.json` | Version 1.4.0 |
| `.claude-plugin/marketplace.json` | Version 1.4.0 for llm-tools |
| `plugins/llm-tools/README.md` | Document /review-loop |

## Test Plan

- [x] `./scripts/check-shared-sync.sh` passes
- [x] Loop setup/teardown: `setup-loop.sh` creates state, `cleanup-loop.sh` removes it
- [x] Phase transitions: `set_loop_phase` correctly updates reviewing → fixing → verifying
- [x] Stop-hook: produces correct JSON with phase-aware reason/systemMessage for all 3 phases
- [x] Max iterations safety: stop-hook allows exit when limit reached
- [x] Live test: `/review-loop --llm codex` ran 2 passes with gpt-5.4, found and fixed 7 real issues
- [ ] Test with `--llm gemini` and `--llm ollama`
- [ ] Test `/cancel-loop review-loop` mid-run
- [ ] Test stop-hook re-entry (close session mid-fix, reopen)