### PR TITLE
fix: remove hardcoded model versions from all skills and commands

### DIFF
--- a/plugins/go-dev/commands/bench.md
+++ b/plugins/go-dev/commands/bench.md
@@ -1,7 +1,6 @@
 ---
 argument-hint: "<file|function|package>"
 description: "Generate and run Go benchmarks with profiling and optimization analysis"
-model: claude-opus-4-6
 allowed-tools: ["Bash", "Read", "Write", "Glob", "Grep", "AskUserQuestion"]
 ---
 

--- a/plugins/go-dev/commands/build-fix.md
+++ b/plugins/go-dev/commands/build-fix.md
@@ -1,7 +1,6 @@
 ---
 argument-hint: "[log-path]"
 description: "Auto-detect build system, parse errors, and fix until clean"
-model: claude-opus-4-6
 allowed-tools: ["Bash", "Read", "Write", "Edit", "Glob", "Grep", "AskUserQuestion"]
 ---
 

--- a/plugins/go-dev/commands/explain.md
+++ b/plugins/go-dev/commands/explain.md
@@ -1,7 +1,6 @@
 ---
 argument-hint: "<file|function|package>"
 description: "Deep-dive explanation of Go code with diagrams"
-model: claude-opus-4-6
 allowed-tools: ["Read", "Glob", "Grep", "AskUserQuestion"]
 ---
 

--- a/plugins/go-dev/commands/lint-fix.md
+++ b/plugins/go-dev/commands/lint-fix.md
@@ -1,7 +1,6 @@
 ---
 argument-hint: "[path] [--check]"
 description: "Auto-fix Go linting issues with golangci-lint"
-model: claude-opus-4-6
 allowed-tools: ["Bash", "Read", "Write", "Edit", "Glob", "Grep", "AskUserQuestion"]
 ---
 

--- a/plugins/go-dev/commands/refactor-clean.md
+++ b/plugins/go-dev/commands/refactor-clean.md
@@ -1,7 +1,6 @@
 ---
 argument-hint: "[path] [--dry-run]"
 description: "Find and remove dead Go code, orphaned tests, and complexity issues"
-model: claude-opus-4-6
 allowed-tools: ["Bash", "Read", "Write", "Edit", "Glob", "Grep", "AskUserQuestion"]
 ---
 

--- a/plugins/go-dev/commands/test-gen.md
+++ b/plugins/go-dev/commands/test-gen.md
@@ -1,7 +1,6 @@
 ---
 argument-hint: "<file|function>"
 description: "Generate comprehensive Go tests with table-driven patterns"
-model: claude-opus-4-6
 allowed-tools: ["Bash", "Read", "Write", "Glob", "Grep", "AskUserQuestion"]
 ---
 

--- a/plugins/go-dev/commands/verify.md
+++ b/plugins/go-dev/commands/verify.md
@@ -1,7 +1,6 @@
 ---
 argument-hint: "[path]"
 description: "Run full pre-push verification: build, test, lint, vet, dev-server checks"
-model: claude-opus-4-6
 allowed-tools: ["Bash", "Read", "Write", "Edit", "Glob", "Grep", "AskUserQuestion"]
 ---
 

--- a/plugins/go-web/commands/convert-to-go-project.md
+++ b/plugins/go-web/commands/convert-to-go-project.md
@@ -1,7 +1,6 @@
 ---
 argument-hint: "[target-directory]"
 description: "Convert an existing project to the Go + Templ + HTMX + Tailwind stack"
-model: claude-opus-4-6
 allowed-tools: ["Bash", "Read", "Write", "Edit", "Glob", "Grep", "AskUserQuestion"]
 ---
 

--- a/plugins/go-web/commands/create-go-project.md
+++ b/plugins/go-web/commands/create-go-project.md
@@ -1,7 +1,6 @@
 ---
 argument-hint: "<project-name>"
 description: "Create a new Go web project with Templ, HTMX, Tailwind, and sqlc"
-model: claude-opus-4-6
 allowed-tools: ["Bash", "Read", "Write", "Edit", "Glob", "Grep", "AskUserQuestion"]
 ---
 

--- a/plugins/go-workflow/commands/commit.md
+++ b/plugins/go-workflow/commands/commit.md
@@ -1,7 +1,6 @@
 ---
 description: "Create a git commit with auto-generated message"
 allowed-tools: ["Bash(git add:*)", "Bash(git status:*)", "Bash(git commit:*)", "Bash(git diff:*)", "Bash(git log:*)", "Bash(git branch:*)", "Bash(git checkout:*)", "Bash(git remote:*)", "AskUserQuestion"]
-model: haiku
 ---
 
 # Create Git Commit

--- a/plugins/go-workflow/commands/create-worktree.md
+++ b/plugins/go-workflow/commands/create-worktree.md
@@ -2,7 +2,6 @@
 argument-hint: "<issue-or-pr-number>"
 description: "Create a new git worktree for a GitHub issue or PR"
 allowed-tools: ["Bash(git:*)", "Bash(gh:*)", "Bash(pwd:*)", "Bash(echo:*)", "Bash(cp:*)", "Bash(basename:*)", "Bash(for:*)", "Bash(if:*)", "Bash(*worktree-state*)", "Read", "AskUserQuestion"]
-model: haiku
 ---
 
 # Create Worktree for Issue or PR

--- a/plugins/go-workflow/commands/prune-worktree.md
+++ b/plugins/go-workflow/commands/prune-worktree.md
@@ -1,7 +1,6 @@
 ---
 description: "Batch cleanup of all completed issue worktrees"
 allowed-tools: ["Bash(git:*)", "Bash(gh:*)", "Bash(echo:*)", "Bash(basename:*)", "Bash(grep:*)", "Bash(*worktree-state*)", "Read", "AskUserQuestion"]
-model: haiku
 ---
 
 # Prune Issue Worktrees

--- a/plugins/go-workflow/commands/remove-worktree.md
+++ b/plugins/go-workflow/commands/remove-worktree.md
@@ -1,7 +1,6 @@
 ---
 description: "Interactively select and remove a git worktree"
 allowed-tools: ["Bash(git:*)", "Bash(gh:*)", "Bash(echo:*)", "Bash(cd:*)", "Bash(grep:*)", "Bash(cat:*)", "Bash(*worktree-state*)", "Read", "AskUserQuestion"]
-model: haiku
 ---
 
 # Remove Worktree

--- a/plugins/go-workflow/commands/start-issue.md
+++ b/plugins/go-workflow/commands/start-issue.md
@@ -1,7 +1,6 @@
 ---
 argument-hint: "<issue-number>"
 description: "Start working on a GitHub issue (auto-detects bug vs feature)"
-model: claude-opus-4-6
 allowed-tools: ["Bash", "Read", "Glob", "Grep", "Edit", "Write", "AskUserQuestion", "EnterPlanMode"]
 ---
 

--- a/plugins/go-workflow/skills/address-review/SKILL.md
+++ b/plugins/go-workflow/skills/address-review/SKILL.md
@@ -10,7 +10,6 @@ description: |
   NOT for: creating new PRs, performing your own code review, general coding tasks, or
   closing/managing PRs without review context.
 argument-hint: "[PR-number] [--no-watch]"
-model: claude-opus-4-6
 allowed-tools: ["Bash", "Read", "Glob", "Grep", "Edit", "Write", "Task", "AskUserQuestion"]
 ---
 

--- a/plugins/llm-tools/commands/convert.md
+++ b/plugins/llm-tools/commands/convert.md
@@ -1,7 +1,6 @@
 ---
 argument-hint: "<from> <to> [file]"
 description: "Convert between formats, languages, and data structures"
-model: claude-opus-4-6
 allowed-tools: ["Bash", "Read", "Write", "Edit", "Glob", "Grep", "AskUserQuestion"]
 ---
 

--- a/plugins/llm-tools/commands/llm-compare.md
+++ b/plugins/llm-tools/commands/llm-compare.md
@@ -1,7 +1,6 @@
 ---
 argument-hint: "<prompt>"
 description: "Compare responses from multiple LLMs"
-model: claude-opus-4-6
 allowed-tools: ["Bash", "Read", "AskUserQuestion"]
 ---
 

--- a/plugins/llm-tools/commands/review-loop.md
+++ b/plugins/llm-tools/commands/review-loop.md
@@ -1,7 +1,6 @@
 ---
 argument-hint: "[--llm codex|gemini|ollama] [--max-passes <n>] [scope hint]"
 description: "Iterative LLM review loop: review, fix, verify, repeat until clean"
-model: claude-opus-4-6
 allowed-tools: ["Bash", "Read", "Glob", "Grep", "Edit", "Write", "AskUserQuestion"]
 ---
 

--- a/plugins/productivity/commands/changelog.md
+++ b/plugins/productivity/commands/changelog.md
@@ -1,7 +1,6 @@
 ---
 argument-hint: "[tag|version]"
 description: "Generate changelog from commits since last release"
-model: haiku
 allowed-tools: ["Bash(git:*)", "Read", "Glob", "Grep"]
 ---
 

--- a/plugins/productivity/commands/gopher-ai-refresh.md
+++ b/plugins/productivity/commands/gopher-ai-refresh.md
@@ -2,7 +2,6 @@
 argument-hint: ""
 description: "Refresh all gopher-ai plugins (clear cache + reinstall)"
 allowed-tools: ["Bash(bash:*)"]
-model: haiku
 ---
 
 # Refresh Gopher-AI Plugins

--- a/plugins/productivity/commands/standup.md
+++ b/plugins/productivity/commands/standup.md
@@ -1,7 +1,6 @@
 ---
 argument-hint: "[hours|days]"
 description: "Generate standup notes from recent git activity"
-model: haiku
 allowed-tools: ["Bash(git:*)", "Bash(date:*)", "Read", "Glob", "Grep"]
 ---
 

--- a/plugins/productivity/commands/weekly-summary.md
+++ b/plugins/productivity/commands/weekly-summary.md
@@ -1,7 +1,6 @@
 ---
 argument-hint: "[weeks-back]"
 description: "Generate weekly work summary from git activity"
-model: haiku
 allowed-tools: ["Bash(git:*)", "Bash(date:*)", "Bash(find:*)", "Read", "Glob", "Grep"]
 ---
 

--- a/plugins/tailwind/commands/audit.md
+++ b/plugins/tailwind/commands/audit.md
@@ -1,7 +1,6 @@
 ---
 argument-hint: "[path] [--fix]"
 description: "Audit Tailwind CSS usage for best practices and consistency"
-model: claude-opus-4-6
 allowed-tools: ["Bash", "Read", "Write", "Edit", "Glob", "Grep", "AskUserQuestion", "mcp__tailwindcss__search_tailwind_docs", "mcp__tailwindcss__get_tailwind_utilities", "mcp__tailwindcss__convert_css_to_tailwind"]
 ---
 

--- a/plugins/tailwind/commands/init.md
+++ b/plugins/tailwind/commands/init.md
@@ -1,7 +1,6 @@
 ---
 argument-hint: "[project-path]"
 description: "Initialize Tailwind CSS v4 in an existing project"
-model: claude-sonnet-4-20250514
 allowed-tools: ["Bash", "Read", "Write", "Edit", "Glob", "Grep", "AskUserQuestion", "mcp__tailwindcss__install_tailwind", "mcp__tailwindcss__get_tailwind_config_guide"]
 ---
 

--- a/plugins/tailwind/commands/migrate.md
+++ b/plugins/tailwind/commands/migrate.md
@@ -1,7 +1,6 @@
 ---
 argument-hint: "[--check]"
 description: "Migrate Tailwind CSS v3 configuration to v4 CSS-based config"
-model: claude-opus-4-6
 allowed-tools: ["Bash", "Read", "Write", "Edit", "Glob", "Grep", "AskUserQuestion", "mcp__tailwindcss__search_tailwind_docs", "mcp__tailwindcss__get_tailwind_config_guide"]
 ---
 

--- a/plugins/tailwind/commands/optimize.md
+++ b/plugins/tailwind/commands/optimize.md
@@ -1,7 +1,6 @@
 ---
 argument-hint: "[--report|--fix]"
 description: "Analyze and optimize Tailwind CSS output"
-model: claude-sonnet-4-20250514
 allowed-tools: ["Bash", "Read", "Write", "Edit", "Glob", "Grep", "AskUserQuestion", "mcp__tailwindcss__search_tailwind_docs", "mcp__tailwindcss__get_tailwind_utilities"]
 ---
 


### PR DESCRIPTION
## Summary

- Removes `model:` frontmatter from all 26 skill and command files across all 7 plugins
- Skills now inherit the user's chosen model instead of forcing specific versions (e.g., `claude-opus-4-6`, `claude-sonnet-4-20250514`, `haiku`)
- Prevents skills from becoming stale when new model versions are released

## Test Plan

- [ ] Run a skill that previously had `model: claude-opus-4-6` (e.g., `/start-issue`) and verify it uses the current session model
- [ ] Run a skill that previously had `model: haiku` (e.g., `/standup`) and verify it works with the current model
- [ ] Verify the template placeholder `model: <MODEL>` in `review-loop.md` line 172 is untouched