### PR TITLE
fix(go-workflow): detect and clean up stale loop state files

### DIFF
--- a/plugins/go-workflow/hooks/stop-hook.sh
+++ b/plugins/go-workflow/hooks/stop-hook.sh
@@ -49,6 +49,26 @@ fi
 # Read state from file
 read_loop_state "$STATE_FILE"
 
+# Check if loop is stale (from a previous session)
+# Compare state file's started_at against the current transcript file's creation time.
+# If the transcript is newer than the loop, the loop is from a dead session.
+if [ -n "$TRANSCRIPT_PATH" ] && [ -f "$TRANSCRIPT_PATH" ]; then
+  STARTED_AT=$(grep '^started_at:' "$STATE_FILE" | sed 's/started_at: *//')
+  if [ -n "$STARTED_AT" ]; then
+    if [[ "$OSTYPE" == "darwin"* ]]; then
+      TRANSCRIPT_BIRTH=$(stat -f %B "$TRANSCRIPT_PATH" 2>/dev/null || echo "0")
+      LOOP_EPOCH=$(date -j -f "%Y-%m-%dT%H:%M:%SZ" "$STARTED_AT" +%s 2>/dev/null || echo "0")
+    else
+      TRANSCRIPT_BIRTH=$(stat -c %W "$TRANSCRIPT_PATH" 2>/dev/null || echo "0")
+      LOOP_EPOCH=$(date -d "$STARTED_AT" +%s 2>/dev/null || echo "0")
+    fi
+    if [ "$LOOP_EPOCH" -gt 0 ] && [ "$TRANSCRIPT_BIRTH" -gt 0 ] && [ "$TRANSCRIPT_BIRTH" -gt "$LOOP_EPOCH" ]; then
+      cleanup_loop "$STATE_FILE"
+      exit 0
+    fi
+  fi
+fi
+
 # Validate iteration is a number
 if ! [[ "$ITERATION" =~ ^[0-9]+$ ]]; then
   # Invalid state - cleanup and allow exit

--- a/shared/hooks/stop-hook.sh
+++ b/shared/hooks/stop-hook.sh
@@ -49,6 +49,26 @@ fi
 # Read state from file
 read_loop_state "$STATE_FILE"
 
+# Check if loop is stale (from a previous session)
+# Compare state file's started_at against the current transcript file's creation time.
+# If the transcript is newer than the loop, the loop is from a dead session.
+if [ -n "$TRANSCRIPT_PATH" ] && [ -f "$TRANSCRIPT_PATH" ]; then
+  STARTED_AT=$(grep '^started_at:' "$STATE_FILE" | sed 's/started_at: *//')
+  if [ -n "$STARTED_AT" ]; then
+    if [[ "$OSTYPE" == "darwin"* ]]; then
+      TRANSCRIPT_BIRTH=$(stat -f %B "$TRANSCRIPT_PATH" 2>/dev/null || echo "0")
+      LOOP_EPOCH=$(date -j -f "%Y-%m-%dT%H:%M:%SZ" "$STARTED_AT" +%s 2>/dev/null || echo "0")
+    else
+      TRANSCRIPT_BIRTH=$(stat -c %W "$TRANSCRIPT_PATH" 2>/dev/null || echo "0")
+      LOOP_EPOCH=$(date -d "$STARTED_AT" +%s 2>/dev/null || echo "0")
+    fi
+    if [ "$LOOP_EPOCH" -gt 0 ] && [ "$TRANSCRIPT_BIRTH" -gt 0 ] && [ "$TRANSCRIPT_BIRTH" -gt "$LOOP_EPOCH" ]; then
+      cleanup_loop "$STATE_FILE"
+      exit 0
+    fi
+  fi
+fi
+
 # Validate iteration is a number
 if ! [[ "$ITERATION" =~ ^[0-9]+$ ]]; then
   # Invalid state - cleanup and allow exit


### PR DESCRIPTION
## Summary

- Stop hook was finding leftover `.loop.local.md` files from dead sessions and blocking exits (including `ExitPlanMode`) in new sessions
- Now compares the loop's `started_at` timestamp against the current transcript file's birth time — if the transcript is newer, the loop is stale and gets cleaned up
- Works on both macOS and Linux

## Test Plan

- [ ] Start a `/start-issue` session, let it create a loop state file, then kill the terminal
- [ ] Open a new session in the same project — stop hook should detect the stale file, clean it up, and not block
- [ ] Verify active loops in the same session still work as expected