### PR TITLE
refactor(loop): switch state files from YAML to JSON with jq parsing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,6 @@
 
 # Build artifacts
 dist/
+
+# Loop debug logs
+.claude/loop-debug.log

--- a/plugins/go-dev/lib/loop-state.sh
+++ b/plugins/go-dev/lib/loop-state.sh
@@ -1,79 +1,129 @@
 #!/bin/bash
-# Shared functions for loop state management
+# Shared functions for loop state management (JSON-based)
 # Used by stop-hook.sh and other loop-related scripts
+# Requires: jq
 
-# Read loop state from a state file
+# Debug log file location
+LOOP_DEBUG_LOG=".claude/loop-debug.log"
+
+# Write a timestamped entry to the debug log
+loop_log() {
+  local msg="$1"
+  local ts
+  ts=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+  mkdir -p .claude
+  echo "[$ts] $msg" >> "$LOOP_DEBUG_LOG"
+}
+
+# Read loop state from a JSON state file
 # Sets global variables: ITERATION, MAX_ITERATIONS, COMPLETION_PROMISE, LOOP_NAME, PHASE, ORIGINAL_PROMPT
 read_loop_state() {
   local state_file="$1"
-  ITERATION=$(grep '^iteration:' "$state_file" | sed 's/iteration: *//')
-  MAX_ITERATIONS=$(grep '^max_iterations:' "$state_file" | sed 's/max_iterations: *//')
-  COMPLETION_PROMISE=$(grep '^completion_promise:' "$state_file" | sed 's/completion_promise: *//')
-  LOOP_NAME=$(grep '^loop_name:' "$state_file" | sed 's/loop_name: *//')
-  PHASE=$(grep '^phase:' "$state_file" | sed 's/phase: *//' || true)
-  # Get content after the second --- (the prompt/body)
-  ORIGINAL_PROMPT=$(awk '/^---$/{p++; next} p==2' "$state_file")
+  ITERATION=$(jq -r '.iteration // 0' "$state_file")
+  MAX_ITERATIONS=$(jq -r '.max_iterations // empty' "$state_file")
+  COMPLETION_PROMISE=$(jq -r '.completion_promise // empty' "$state_file")
+  LOOP_NAME=$(jq -r '.loop_name // empty' "$state_file")
+  PHASE=$(jq -r '.phase // empty' "$state_file")
+  ORIGINAL_PROMPT=$(jq -r '.original_prompt // empty' "$state_file")
+  loop_log "read_loop_state: file=$state_file loop=$LOOP_NAME iter=$ITERATION phase=$PHASE"
 }
 
-# Increment the iteration counter in a state file
+# Increment the iteration counter in a state file (atomic write via temp file)
 increment_iteration() {
   local state_file="$1"
-  local new_iteration=$((ITERATION + 1))
-
-  # Use portable sed syntax (works on both macOS and Linux)
-  if [[ "$OSTYPE" == "darwin"* ]]; then
-    sed -i '' "s/^iteration: .*/iteration: $new_iteration/" "$state_file"
-  else
-    sed -i "s/^iteration: .*/iteration: $new_iteration/" "$state_file"
-  fi
+  local tmp_file="${state_file}.tmp"
+  jq '.iteration = (.iteration + 1)' "$state_file" > "$tmp_file" && mv "$tmp_file" "$state_file"
+  loop_log "increment_iteration: file=$state_file new_iteration=$((ITERATION + 1))"
 }
 
-# Set the phase field in a state file
+# Set the phase field in a state file (atomic write via temp file)
 set_loop_phase() {
   local state_file="$1"
   local new_phase="$2"
+  local tmp_file="${state_file}.tmp"
+  jq --arg phase "$new_phase" '.phase = $phase' "$state_file" > "$tmp_file" && mv "$tmp_file" "$state_file"
+  loop_log "set_loop_phase: file=$state_file phase=$new_phase"
+}
 
-  if grep -q '^phase:' "$state_file"; then
-    if [[ "$OSTYPE" == "darwin"* ]]; then
-      sed -i '' "s/^phase: .*/phase: $new_phase/" "$state_file"
-    else
-      sed -i "s/^phase: .*/phase: $new_phase/" "$state_file"
-    fi
-  else
-    if [[ "$OSTYPE" == "darwin"* ]]; then
-      sed -i '' "/^completion_promise:/a\\
-phase: $new_phase" "$state_file"
-    else
-      sed -i "/^completion_promise:/a phase: $new_phase" "$state_file"
-    fi
-  fi
+# Get a custom field from the state file
+get_loop_field() {
+  local state_file="$1"
+  local field="$2"
+  jq -r --arg f "$field" '.[$f] // empty' "$state_file"
+}
+
+# Set a custom field in the state file (atomic write via temp file)
+set_loop_field() {
+  local state_file="$1"
+  local field="$2"
+  local value="$3"
+  local tmp_file="${state_file}.tmp"
+  jq --arg f "$field" --arg v "$value" '.[$f] = $v' "$state_file" > "$tmp_file" && mv "$tmp_file" "$state_file"
 }
 
 # Remove a loop state file (cleanup)
 cleanup_loop() {
   local state_file="$1"
+  loop_log "cleanup_loop: file=$state_file"
   rm -f "$state_file"
 }
 
 # Check if the completion promise appears in recent transcript output
+# Checks ALL text blocks in last N assistant messages (not just the last one)
 # Returns 0 if found, 1 if not found
 check_completion_promise() {
   local promise="$1"
-  local transcript=".claude/transcript.jsonl"
+  local transcript="$2"
 
-  if [ -f "$transcript" ]; then
-    # Check the last 10 lines of transcript for the completion promise
-    # The promise should be wrapped in <done>...</done> tags
-    if tail -10 "$transcript" | grep -q "<done>$promise</done>"; then
-      return 0
-    fi
+  if [ -z "$transcript" ]; then
+    transcript=".claude/transcript.jsonl"
   fi
+
+  if [ ! -f "$transcript" ]; then
+    loop_log "check_completion_promise: transcript not found at $transcript"
+    return 1
+  fi
+
+  local last_lines
+  last_lines=$(grep '"role":"assistant"' "$transcript" 2>/dev/null | tail -n 100 || true)
+
+  if [ -z "$last_lines" ]; then
+    loop_log "check_completion_promise: no assistant messages in transcript"
+    return 1
+  fi
+
+  set +e
+  local all_text
+  all_text=$(echo "$last_lines" | jq -rs '
+    [.[] | .message.content[]? | select(.type == "text") | .text] | join("\n")
+  ' 2>/dev/null)
+  local jq_exit=$?
+  set -e
+
+  if [ $jq_exit -ne 0 ]; then
+    loop_log "check_completion_promise: jq failed with exit $jq_exit"
+    return 1
+  fi
+
+  # Trim whitespace and check for promise in any text block
+  if echo "$all_text" | grep -q "<done>${promise}</done>"; then
+    loop_log "check_completion_promise: FOUND promise '$promise'"
+    return 0
+  fi
+
+  # Also check with whitespace tolerance (promise may have surrounding spaces/newlines)
+  if echo "$all_text" | sed 's/^[[:space:]]*//;s/[[:space:]]*$//' | grep -q "<done>[[:space:]]*${promise}[[:space:]]*</done>"; then
+    loop_log "check_completion_promise: FOUND promise '$promise' (with whitespace)"
+    return 0
+  fi
+
+  loop_log "check_completion_promise: NOT found promise '$promise'"
   return 1
 }
 
 # Find all active loop state files
 find_active_loops() {
-  find .claude -name "*.loop.local.md" 2>/dev/null
+  find .claude -name "*.loop.local.json" 2>/dev/null
 }
 
 # Get the count of active loops

--- a/plugins/go-dev/scripts/cleanup-loop.sh
+++ b/plugins/go-dev/scripts/cleanup-loop.sh
@@ -12,7 +12,7 @@ LOOP_NAME="${1:-}"
 if [ -n "$LOOP_NAME" ]; then
   # Clean up specific loop
   SAFE_LOOP_NAME=$(echo "$LOOP_NAME" | sed 's/[^a-zA-Z0-9_-]/-/g')
-  STATE_FILE=".claude/${SAFE_LOOP_NAME}.loop.local.md"
+  STATE_FILE=".claude/${SAFE_LOOP_NAME}.loop.local.json"
 
   if [ -f "$STATE_FILE" ]; then
     rm -f "$STATE_FILE"
@@ -22,13 +22,13 @@ if [ -n "$LOOP_NAME" ]; then
   fi
 else
   # Clean up all loops
-  LOOP_FILES=$(find .claude -name "*.loop.local.md" 2>/dev/null || true)
+  LOOP_FILES=$(find .claude -name "*.loop.local.json" 2>/dev/null || true)
 
   if [ -z "$LOOP_FILES" ]; then
     echo "No active loops found."
   else
     echo "$LOOP_FILES" | while read -r file; do
-      loop_name=$(grep '^loop_name:' "$file" 2>/dev/null | sed 's/loop_name: *//' || echo "unknown")
+      loop_name=$(jq -r '.loop_name // "unknown"' "$file" 2>/dev/null || echo "unknown")
       rm -f "$file"
       echo "Cancelled loop: $loop_name"
     done

--- a/plugins/go-dev/scripts/setup-loop.sh
+++ b/plugins/go-dev/scripts/setup-loop.sh
@@ -1,28 +1,30 @@
 #!/bin/bash
-# Initialize a persistent loop for any command
-# Usage: setup-loop.sh <loop-name> <completion-promise> [max-iterations] [initial-phase]
+# Initialize a persistent loop for any command (JSON-based)
+# Usage: setup-loop.sh <loop-name> <completion-promise> [max-iterations] [initial-phase] [phase-messages-json]
 #
 # Example:
 #   setup-loop.sh "start-issue-123" "COMPLETE"
 #   setup-loop.sh "create-project" "DONE" 50
 #   setup-loop.sh "address-review-42" "COMPLETE" "" "fixing"
+#   setup-loop.sh "ship" "SHIPPED" 50 "" '{"reviewing":"Resume LLM review pass."}'
 
 set -euo pipefail
 
 LOOP_NAME="${1:-}"
 COMPLETION_PROMISE="${2:-COMPLETE}"
-MAX_ITERATIONS="${3:-}"  # Optional, defaults to unlimited
+MAX_ITERATIONS="${3:-}"  # Optional, defaults to null
 INITIAL_PHASE="${4:-}"   # Optional, defaults to empty
+PHASE_MESSAGES_JSON="${5:-}"  # Optional JSON object of phase->message mappings
 
 if [ -z "$LOOP_NAME" ]; then
   echo "Error: loop-name is required"
-  echo "Usage: setup-loop.sh <loop-name> <completion-promise> [max-iterations] [initial-phase]"
+  echo "Usage: setup-loop.sh <loop-name> <completion-promise> [max-iterations] [initial-phase] [phase-messages-json]"
   exit 1
 fi
 
 # Sanitize loop name for use in filename
 SAFE_LOOP_NAME=$(echo "$LOOP_NAME" | sed 's/[^a-zA-Z0-9_-]/-/g')
-STATE_FILE=".claude/${SAFE_LOOP_NAME}.loop.local.md"
+STATE_FILE=".claude/${SAFE_LOOP_NAME}.loop.local.json"
 
 # Create .claude directory if it doesn't exist
 mkdir -p .claude
@@ -31,37 +33,64 @@ mkdir -p .claude
 EXISTING_PHASE=""
 EXISTING_BASELINE=""
 if [ -f "$STATE_FILE" ]; then
-  EXISTING_PHASE=$(grep '^phase:' "$STATE_FILE" | sed 's/phase: *//' || true)
-  EXISTING_BASELINE=$(grep '^bot_review_baseline:' "$STATE_FILE" | sed 's/bot_review_baseline: *//' || true)
+  EXISTING_PHASE=$(jq -r '.phase // empty' "$STATE_FILE" 2>/dev/null || true)
+  EXISTING_BASELINE=$(jq -r '.bot_review_baseline // empty' "$STATE_FILE" 2>/dev/null || true)
   echo "Warning: Loop '$LOOP_NAME' already active. Resetting (preserving phase: ${EXISTING_PHASE:-<none>}, baseline: ${EXISTING_BASELINE:-<none>})..."
 fi
 
 # Preserve existing phase from state file, fall back to INITIAL_PHASE for fresh runs
-# This allows re-entry to maintain phase context (e.g., watching) across stop-hook restarts
-# while INITIAL_PHASE provides a default for first-time initialization
 PHASE="${EXISTING_PHASE:-$INITIAL_PHASE}"
 
-# Create state file with YAML frontmatter
-cat > "$STATE_FILE" << EOF
----
-loop_name: $LOOP_NAME
-iteration: 1
-max_iterations: $MAX_ITERATIONS
-completion_promise: $COMPLETION_PROMISE
-phase: $PHASE
-bot_review_baseline: $EXISTING_BASELINE
-started_at: $(date -u +"%Y-%m-%dT%H:%M:%SZ")
----
+# Derive session ID from transcript path or env
+SESSION_ID=""
+if [ -n "${CLAUDE_SESSION_ID:-}" ]; then
+  SESSION_ID="$CLAUDE_SESSION_ID"
+elif [ -d ".claude" ]; then
+  # Try to find the most recent transcript file and use its name as session ID
+  LATEST_TRANSCRIPT=$(find .claude -name "*.jsonl" -maxdepth 1 2>/dev/null | sort -t/ -k2 | tail -1 || true)
+  if [ -n "$LATEST_TRANSCRIPT" ]; then
+    SESSION_ID=$(basename "$LATEST_TRANSCRIPT" .jsonl)
+  fi
+fi
 
-Persistent loop initialized for: $LOOP_NAME
-Completion promise: $COMPLETION_PROMISE
-Max iterations: ${MAX_ITERATIONS:-unlimited}
+# Build max_iterations as number or null
+MAX_ITER_JSON="null"
+if [ -n "$MAX_ITERATIONS" ]; then
+  MAX_ITER_JSON="$MAX_ITERATIONS"
+fi
 
-This loop will continue until:
-1. The completion promise <done>$COMPLETION_PROMISE</done> is output
-2. Max iterations is reached (if set)
-3. User cancels with /cancel-loop
-EOF
+# Build phase_messages as object or empty object
+PHASE_MSGS_JSON="{}"
+if [ -n "$PHASE_MESSAGES_JSON" ]; then
+  # Validate it's valid JSON
+  if echo "$PHASE_MESSAGES_JSON" | jq empty 2>/dev/null; then
+    PHASE_MSGS_JSON="$PHASE_MESSAGES_JSON"
+  fi
+fi
+
+# Create JSON state file (atomic write via temp file)
+TMP_FILE="${STATE_FILE}.tmp"
+jq -n \
+  --arg loop_name "$LOOP_NAME" \
+  --argjson iteration 1 \
+  --argjson max_iterations "$MAX_ITER_JSON" \
+  --arg completion_promise "$COMPLETION_PROMISE" \
+  --arg phase "$PHASE" \
+  --arg bot_review_baseline "${EXISTING_BASELINE:-}" \
+  --arg started_at "$(date -u +"%Y-%m-%dT%H:%M:%SZ")" \
+  --arg session_id "$SESSION_ID" \
+  --argjson phase_messages "$PHASE_MSGS_JSON" \
+  '{
+    loop_name: $loop_name,
+    iteration: $iteration,
+    max_iterations: $max_iterations,
+    completion_promise: $completion_promise,
+    phase: $phase,
+    bot_review_baseline: $bot_review_baseline,
+    started_at: $started_at,
+    session_id: $session_id,
+    phase_messages: $phase_messages
+  }' > "$TMP_FILE" && mv "$TMP_FILE" "$STATE_FILE"
 
 echo "Loop initialized: $LOOP_NAME"
 echo "Output <done>$COMPLETION_PROMISE</done> when all completion criteria are met."

--- a/plugins/go-web/lib/loop-state.sh
+++ b/plugins/go-web/lib/loop-state.sh
@@ -1,79 +1,129 @@
 #!/bin/bash
-# Shared functions for loop state management
+# Shared functions for loop state management (JSON-based)
 # Used by stop-hook.sh and other loop-related scripts
+# Requires: jq
 
-# Read loop state from a state file
+# Debug log file location
+LOOP_DEBUG_LOG=".claude/loop-debug.log"
+
+# Write a timestamped entry to the debug log
+loop_log() {
+  local msg="$1"
+  local ts
+  ts=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+  mkdir -p .claude
+  echo "[$ts] $msg" >> "$LOOP_DEBUG_LOG"
+}
+
+# Read loop state from a JSON state file
 # Sets global variables: ITERATION, MAX_ITERATIONS, COMPLETION_PROMISE, LOOP_NAME, PHASE, ORIGINAL_PROMPT
 read_loop_state() {
   local state_file="$1"
-  ITERATION=$(grep '^iteration:' "$state_file" | sed 's/iteration: *//')
-  MAX_ITERATIONS=$(grep '^max_iterations:' "$state_file" | sed 's/max_iterations: *//')
-  COMPLETION_PROMISE=$(grep '^completion_promise:' "$state_file" | sed 's/completion_promise: *//')
-  LOOP_NAME=$(grep '^loop_name:' "$state_file" | sed 's/loop_name: *//')
-  PHASE=$(grep '^phase:' "$state_file" | sed 's/phase: *//' || true)
-  # Get content after the second --- (the prompt/body)
-  ORIGINAL_PROMPT=$(awk '/^---$/{p++; next} p==2' "$state_file")
+  ITERATION=$(jq -r '.iteration // 0' "$state_file")
+  MAX_ITERATIONS=$(jq -r '.max_iterations // empty' "$state_file")
+  COMPLETION_PROMISE=$(jq -r '.completion_promise // empty' "$state_file")
+  LOOP_NAME=$(jq -r '.loop_name // empty' "$state_file")
+  PHASE=$(jq -r '.phase // empty' "$state_file")
+  ORIGINAL_PROMPT=$(jq -r '.original_prompt // empty' "$state_file")
+  loop_log "read_loop_state: file=$state_file loop=$LOOP_NAME iter=$ITERATION phase=$PHASE"
 }
 
-# Increment the iteration counter in a state file
+# Increment the iteration counter in a state file (atomic write via temp file)
 increment_iteration() {
   local state_file="$1"
-  local new_iteration=$((ITERATION + 1))
-
-  # Use portable sed syntax (works on both macOS and Linux)
-  if [[ "$OSTYPE" == "darwin"* ]]; then
-    sed -i '' "s/^iteration: .*/iteration: $new_iteration/" "$state_file"
-  else
-    sed -i "s/^iteration: .*/iteration: $new_iteration/" "$state_file"
-  fi
+  local tmp_file="${state_file}.tmp"
+  jq '.iteration = (.iteration + 1)' "$state_file" > "$tmp_file" && mv "$tmp_file" "$state_file"
+  loop_log "increment_iteration: file=$state_file new_iteration=$((ITERATION + 1))"
 }
 
-# Set the phase field in a state file
+# Set the phase field in a state file (atomic write via temp file)
 set_loop_phase() {
   local state_file="$1"
   local new_phase="$2"
+  local tmp_file="${state_file}.tmp"
+  jq --arg phase "$new_phase" '.phase = $phase' "$state_file" > "$tmp_file" && mv "$tmp_file" "$state_file"
+  loop_log "set_loop_phase: file=$state_file phase=$new_phase"
+}
 
-  if grep -q '^phase:' "$state_file"; then
-    if [[ "$OSTYPE" == "darwin"* ]]; then
-      sed -i '' "s/^phase: .*/phase: $new_phase/" "$state_file"
-    else
-      sed -i "s/^phase: .*/phase: $new_phase/" "$state_file"
-    fi
-  else
-    if [[ "$OSTYPE" == "darwin"* ]]; then
-      sed -i '' "/^completion_promise:/a\\
-phase: $new_phase" "$state_file"
-    else
-      sed -i "/^completion_promise:/a phase: $new_phase" "$state_file"
-    fi
-  fi
+# Get a custom field from the state file
+get_loop_field() {
+  local state_file="$1"
+  local field="$2"
+  jq -r --arg f "$field" '.[$f] // empty' "$state_file"
+}
+
+# Set a custom field in the state file (atomic write via temp file)
+set_loop_field() {
+  local state_file="$1"
+  local field="$2"
+  local value="$3"
+  local tmp_file="${state_file}.tmp"
+  jq --arg f "$field" --arg v "$value" '.[$f] = $v' "$state_file" > "$tmp_file" && mv "$tmp_file" "$state_file"
 }
 
 # Remove a loop state file (cleanup)
 cleanup_loop() {
   local state_file="$1"
+  loop_log "cleanup_loop: file=$state_file"
   rm -f "$state_file"
 }
 
 # Check if the completion promise appears in recent transcript output
+# Checks ALL text blocks in last N assistant messages (not just the last one)
 # Returns 0 if found, 1 if not found
 check_completion_promise() {
   local promise="$1"
-  local transcript=".claude/transcript.jsonl"
+  local transcript="$2"
 
-  if [ -f "$transcript" ]; then
-    # Check the last 10 lines of transcript for the completion promise
-    # The promise should be wrapped in <done>...</done> tags
-    if tail -10 "$transcript" | grep -q "<done>$promise</done>"; then
-      return 0
-    fi
+  if [ -z "$transcript" ]; then
+    transcript=".claude/transcript.jsonl"
   fi
+
+  if [ ! -f "$transcript" ]; then
+    loop_log "check_completion_promise: transcript not found at $transcript"
+    return 1
+  fi
+
+  local last_lines
+  last_lines=$(grep '"role":"assistant"' "$transcript" 2>/dev/null | tail -n 100 || true)
+
+  if [ -z "$last_lines" ]; then
+    loop_log "check_completion_promise: no assistant messages in transcript"
+    return 1
+  fi
+
+  set +e
+  local all_text
+  all_text=$(echo "$last_lines" | jq -rs '
+    [.[] | .message.content[]? | select(.type == "text") | .text] | join("\n")
+  ' 2>/dev/null)
+  local jq_exit=$?
+  set -e
+
+  if [ $jq_exit -ne 0 ]; then
+    loop_log "check_completion_promise: jq failed with exit $jq_exit"
+    return 1
+  fi
+
+  # Trim whitespace and check for promise in any text block
+  if echo "$all_text" | grep -q "<done>${promise}</done>"; then
+    loop_log "check_completion_promise: FOUND promise '$promise'"
+    return 0
+  fi
+
+  # Also check with whitespace tolerance (promise may have surrounding spaces/newlines)
+  if echo "$all_text" | sed 's/^[[:space:]]*//;s/[[:space:]]*$//' | grep -q "<done>[[:space:]]*${promise}[[:space:]]*</done>"; then
+    loop_log "check_completion_promise: FOUND promise '$promise' (with whitespace)"
+    return 0
+  fi
+
+  loop_log "check_completion_promise: NOT found promise '$promise'"
   return 1
 }
 
 # Find all active loop state files
 find_active_loops() {
-  find .claude -name "*.loop.local.md" 2>/dev/null
+  find .claude -name "*.loop.local.json" 2>/dev/null
 }
 
 # Get the count of active loops

--- a/plugins/go-web/scripts/cleanup-loop.sh
+++ b/plugins/go-web/scripts/cleanup-loop.sh
@@ -12,7 +12,7 @@ LOOP_NAME="${1:-}"
 if [ -n "$LOOP_NAME" ]; then
   # Clean up specific loop
   SAFE_LOOP_NAME=$(echo "$LOOP_NAME" | sed 's/[^a-zA-Z0-9_-]/-/g')
-  STATE_FILE=".claude/${SAFE_LOOP_NAME}.loop.local.md"
+  STATE_FILE=".claude/${SAFE_LOOP_NAME}.loop.local.json"
 
   if [ -f "$STATE_FILE" ]; then
     rm -f "$STATE_FILE"
@@ -22,13 +22,13 @@ if [ -n "$LOOP_NAME" ]; then
   fi
 else
   # Clean up all loops
-  LOOP_FILES=$(find .claude -name "*.loop.local.md" 2>/dev/null || true)
+  LOOP_FILES=$(find .claude -name "*.loop.local.json" 2>/dev/null || true)
 
   if [ -z "$LOOP_FILES" ]; then
     echo "No active loops found."
   else
     echo "$LOOP_FILES" | while read -r file; do
-      loop_name=$(grep '^loop_name:' "$file" 2>/dev/null | sed 's/loop_name: *//' || echo "unknown")
+      loop_name=$(jq -r '.loop_name // "unknown"' "$file" 2>/dev/null || echo "unknown")
       rm -f "$file"
       echo "Cancelled loop: $loop_name"
     done

--- a/plugins/go-web/scripts/setup-loop.sh
+++ b/plugins/go-web/scripts/setup-loop.sh
@@ -1,28 +1,30 @@
 #!/bin/bash
-# Initialize a persistent loop for any command
-# Usage: setup-loop.sh <loop-name> <completion-promise> [max-iterations] [initial-phase]
+# Initialize a persistent loop for any command (JSON-based)
+# Usage: setup-loop.sh <loop-name> <completion-promise> [max-iterations] [initial-phase] [phase-messages-json]
 #
 # Example:
 #   setup-loop.sh "start-issue-123" "COMPLETE"
 #   setup-loop.sh "create-project" "DONE" 50
 #   setup-loop.sh "address-review-42" "COMPLETE" "" "fixing"
+#   setup-loop.sh "ship" "SHIPPED" 50 "" '{"reviewing":"Resume LLM review pass."}'
 
 set -euo pipefail
 
 LOOP_NAME="${1:-}"
 COMPLETION_PROMISE="${2:-COMPLETE}"
-MAX_ITERATIONS="${3:-}"  # Optional, defaults to unlimited
+MAX_ITERATIONS="${3:-}"  # Optional, defaults to null
 INITIAL_PHASE="${4:-}"   # Optional, defaults to empty
+PHASE_MESSAGES_JSON="${5:-}"  # Optional JSON object of phase->message mappings
 
 if [ -z "$LOOP_NAME" ]; then
   echo "Error: loop-name is required"
-  echo "Usage: setup-loop.sh <loop-name> <completion-promise> [max-iterations] [initial-phase]"
+  echo "Usage: setup-loop.sh <loop-name> <completion-promise> [max-iterations] [initial-phase] [phase-messages-json]"
   exit 1
 fi
 
 # Sanitize loop name for use in filename
 SAFE_LOOP_NAME=$(echo "$LOOP_NAME" | sed 's/[^a-zA-Z0-9_-]/-/g')
-STATE_FILE=".claude/${SAFE_LOOP_NAME}.loop.local.md"
+STATE_FILE=".claude/${SAFE_LOOP_NAME}.loop.local.json"
 
 # Create .claude directory if it doesn't exist
 mkdir -p .claude
@@ -31,37 +33,64 @@ mkdir -p .claude
 EXISTING_PHASE=""
 EXISTING_BASELINE=""
 if [ -f "$STATE_FILE" ]; then
-  EXISTING_PHASE=$(grep '^phase:' "$STATE_FILE" | sed 's/phase: *//' || true)
-  EXISTING_BASELINE=$(grep '^bot_review_baseline:' "$STATE_FILE" | sed 's/bot_review_baseline: *//' || true)
+  EXISTING_PHASE=$(jq -r '.phase // empty' "$STATE_FILE" 2>/dev/null || true)
+  EXISTING_BASELINE=$(jq -r '.bot_review_baseline // empty' "$STATE_FILE" 2>/dev/null || true)
   echo "Warning: Loop '$LOOP_NAME' already active. Resetting (preserving phase: ${EXISTING_PHASE:-<none>}, baseline: ${EXISTING_BASELINE:-<none>})..."
 fi
 
 # Preserve existing phase from state file, fall back to INITIAL_PHASE for fresh runs
-# This allows re-entry to maintain phase context (e.g., watching) across stop-hook restarts
-# while INITIAL_PHASE provides a default for first-time initialization
 PHASE="${EXISTING_PHASE:-$INITIAL_PHASE}"
 
-# Create state file with YAML frontmatter
-cat > "$STATE_FILE" << EOF
----
-loop_name: $LOOP_NAME
-iteration: 1
-max_iterations: $MAX_ITERATIONS
-completion_promise: $COMPLETION_PROMISE
-phase: $PHASE
-bot_review_baseline: $EXISTING_BASELINE
-started_at: $(date -u +"%Y-%m-%dT%H:%M:%SZ")
----
+# Derive session ID from transcript path or env
+SESSION_ID=""
+if [ -n "${CLAUDE_SESSION_ID:-}" ]; then
+  SESSION_ID="$CLAUDE_SESSION_ID"
+elif [ -d ".claude" ]; then
+  # Try to find the most recent transcript file and use its name as session ID
+  LATEST_TRANSCRIPT=$(find .claude -name "*.jsonl" -maxdepth 1 2>/dev/null | sort -t/ -k2 | tail -1 || true)
+  if [ -n "$LATEST_TRANSCRIPT" ]; then
+    SESSION_ID=$(basename "$LATEST_TRANSCRIPT" .jsonl)
+  fi
+fi
 
-Persistent loop initialized for: $LOOP_NAME
-Completion promise: $COMPLETION_PROMISE
-Max iterations: ${MAX_ITERATIONS:-unlimited}
+# Build max_iterations as number or null
+MAX_ITER_JSON="null"
+if [ -n "$MAX_ITERATIONS" ]; then
+  MAX_ITER_JSON="$MAX_ITERATIONS"
+fi
 
-This loop will continue until:
-1. The completion promise <done>$COMPLETION_PROMISE</done> is output
-2. Max iterations is reached (if set)
-3. User cancels with /cancel-loop
-EOF
+# Build phase_messages as object or empty object
+PHASE_MSGS_JSON="{}"
+if [ -n "$PHASE_MESSAGES_JSON" ]; then
+  # Validate it's valid JSON
+  if echo "$PHASE_MESSAGES_JSON" | jq empty 2>/dev/null; then
+    PHASE_MSGS_JSON="$PHASE_MESSAGES_JSON"
+  fi
+fi
+
+# Create JSON state file (atomic write via temp file)
+TMP_FILE="${STATE_FILE}.tmp"
+jq -n \
+  --arg loop_name "$LOOP_NAME" \
+  --argjson iteration 1 \
+  --argjson max_iterations "$MAX_ITER_JSON" \
+  --arg completion_promise "$COMPLETION_PROMISE" \
+  --arg phase "$PHASE" \
+  --arg bot_review_baseline "${EXISTING_BASELINE:-}" \
+  --arg started_at "$(date -u +"%Y-%m-%dT%H:%M:%SZ")" \
+  --arg session_id "$SESSION_ID" \
+  --argjson phase_messages "$PHASE_MSGS_JSON" \
+  '{
+    loop_name: $loop_name,
+    iteration: $iteration,
+    max_iterations: $max_iterations,
+    completion_promise: $completion_promise,
+    phase: $phase,
+    bot_review_baseline: $bot_review_baseline,
+    started_at: $started_at,
+    session_id: $session_id,
+    phase_messages: $phase_messages
+  }' > "$TMP_FILE" && mv "$TMP_FILE" "$STATE_FILE"
 
 echo "Loop initialized: $LOOP_NAME"
 echo "Output <done>$COMPLETION_PROMISE</done> when all completion criteria are met."

--- a/plugins/go-workflow/commands/ship.md
+++ b/plugins/go-workflow/commands/ship.md
@@ -12,9 +12,9 @@ Before calling setup-loop, check if a state file already exists with a non-empty
 If so, **skip** setup-loop to preserve custom fields (`args`, `pass`, `pr_number`, `base_branch`, `no_merge`, `llm`, `discovered_bots`).
 
 ```bash
-STATE_FILE=".claude/ship.loop.local.md"
+STATE_FILE=".claude/ship.loop.local.json"
 if [ -f "$STATE_FILE" ]; then
-  EXISTING_PHASE=$(grep '^phase:' "$STATE_FILE" | sed 's/phase: *//' || true)
+  EXISTING_PHASE=$(jq -r '.phase // empty' "$STATE_FILE" 2>/dev/null || true)
   if [ -n "$EXISTING_PHASE" ]; then
     echo "Re-entry detected (phase: $EXISTING_PHASE) — skipping setup-loop to preserve state."
   fi
@@ -23,7 +23,7 @@ fi
 
 **Only call setup-loop on fresh starts** (no state file or empty phase):
 
-!`if [ ! -f ".claude/ship.loop.local.md" ] || [ -z "$(grep '^phase:' .claude/ship.loop.local.md 2>/dev/null | sed 's/phase: *//')" ]; then "${CLAUDE_PLUGIN_ROOT}/scripts/setup-loop.sh" "ship" "SHIPPED" 50; fi`
+!`if [ ! -f ".claude/ship.loop.local.json" ] || [ -z "$(jq -r '.phase // empty' .claude/ship.loop.local.json 2>/dev/null)" ]; then "${CLAUDE_PLUGIN_ROOT}/scripts/setup-loop.sh" "ship" "SHIPPED" 50 "" '{"reviewing":"Resume LLM review pass.","fixing":"Continue fixing LLM review findings.","verifying":"Re-run verification: build, test, lint.","pushing":"Resume push and PR creation.","ci-watch":"Resume CI monitoring. Run gh pr checks and fix any failures.","bot-watching":"Resume bot approval polling (Step 11). Check discovered bots for approval status. If bots request changes, go to Step 12. If all approved, go to Step 13.","addressing":"Resume addressing bot review feedback (Steps 2-11 of address-review). After fixes, return to CI watch.","merging":"Verify CI green and bot approval, then merge the PR."}'; fi`
 
 ## 1. Parse Arguments
 
@@ -36,18 +36,16 @@ Parse `$ARGUMENTS` to extract:
 
 Store as `LLM_CHOICE`, `MAX_PASSES`, `NO_MERGE`.
 
-**Persist arguments to state file** for re-entry recovery. After parsing, append these fields to `.claude/ship.loop.local.md` if they don't already exist:
+**Persist arguments to state file** for re-entry recovery. After parsing, merge these fields into `.claude/ship.loop.local.json` using `jq`:
 
-```yaml
-args: <raw $ARGUMENTS string>
-llm: <LLM_CHOICE>
-pass: 0
-no_merge: <true|false>
-pr_number:
-base_branch:
-bot_review_baseline:
-discovered_bots:
-has_ci:
+```bash
+STATE_FILE=".claude/ship.loop.local.json"
+TMP="$STATE_FILE.tmp"
+jq --arg args "$ARGUMENTS" --arg llm "$LLM_CHOICE" --argjson pass 0 \
+   --arg no_merge "$NO_MERGE" --arg pr_number "" --arg base_branch "" \
+   --arg bot_review_baseline "" --arg discovered_bots "" --arg has_ci "" \
+   '. + {args: $args, llm: $llm, pass: $pass, no_merge: $no_merge, pr_number: $pr_number, base_branch: $base_branch, bot_review_baseline: $bot_review_baseline, discovered_bots: $discovered_bots, has_ci: $has_ci}' \
+   "$STATE_FILE" > "$TMP" && mv "$TMP" "$STATE_FILE"
 ```
 
 ## 2. Re-entry Check
@@ -56,16 +54,16 @@ Read the loop state file:
 
 ```bash
 source "${CLAUDE_PLUGIN_ROOT}/lib/loop-state.sh"
-STATE_FILE=".claude/ship.loop.local.md"
+STATE_FILE=".claude/ship.loop.local.json"
 if [ -f "$STATE_FILE" ]; then
   read_loop_state "$STATE_FILE"
 fi
 ```
 
-If `PHASE` is set (non-empty), this is a re-entry from the stop-hook. Recover state from persisted fields:
+If `PHASE` is set (non-empty), this is a re-entry from the stop-hook. Recover state from persisted fields using `jq`:
 
-1. Read `args:` field and re-parse to restore `LLM_CHOICE`, `MAX_PASSES`, `NO_MERGE`
-2. Read `pass:`, `pr_number:`, `base_branch:`, `bot_review_baseline:`, `llm:`, `discovered_bots:`, `has_ci:` fields
+1. Read `args` field and re-parse to restore `LLM_CHOICE`, `MAX_PASSES`, `NO_MERGE`
+2. Read `pass`, `pr_number`, `base_branch`, `bot_review_baseline`, `llm`, `discovered_bots`, `has_ci` fields via `jq -r '.field // empty' "$STATE_FILE"`
 
 Then skip to the corresponding phase:
 
@@ -147,8 +145,8 @@ Set phase to `reviewing`:
 
 ```bash
 source "${CLAUDE_PLUGIN_ROOT}/lib/loop-state.sh"
-set_loop_phase ".claude/ship.loop.local.md" "reviewing"
-PASS=$(grep '^pass:' ".claude/ship.loop.local.md" | sed 's/pass: *//')
+set_loop_phase ".claude/ship.loop.local.json" "reviewing"
+PASS=$(jq -r '.pass // 0' ".claude/ship.loop.local.json")
 ```
 
 **Note:** The pass counter is incremented in Step 8 (after the review completes and findings are committed), not here. This prevents burning a pass number if the session exits during the review and re-enters.
@@ -218,7 +216,7 @@ Capture the output as `FINDINGS`.
 Set phase to `fixing`:
 
 ```bash
-set_loop_phase ".claude/ship.loop.local.md" "fixing"
+set_loop_phase ".claude/ship.loop.local.json" "fixing"
 ```
 
 For each finding from Step 5c:
@@ -240,7 +238,7 @@ Track counts: `FIXED`, `SKIPPED` (with reasons).
 Set phase to `verifying`:
 
 ```bash
-set_loop_phase ".claude/ship.loop.local.md" "verifying"
+set_loop_phase ".claude/ship.loop.local.json" "verifying"
 ```
 
 Auto-detect project type and run appropriate verification:
@@ -289,13 +287,10 @@ git add <list of files modified during fix phase>
 **Increment the pass counter** now that the review-fix-verify cycle is complete:
 
 ```bash
-CURRENT_PASS=$(grep '^pass:' ".claude/ship.loop.local.md" | sed 's/pass: *//')
+CURRENT_PASS=$(jq -r '.pass // 0' ".claude/ship.loop.local.json")
 NEW_PASS=$((CURRENT_PASS + 1))
-if [[ "$OSTYPE" == "darwin"* ]]; then
-  sed -i '' "s/^pass: .*/pass: $NEW_PASS/" ".claude/ship.loop.local.md"
-else
-  sed -i "s/^pass: .*/pass: $NEW_PASS/" ".claude/ship.loop.local.md"
-fi
+TMP=".claude/ship.loop.local.json.tmp"
+jq --argjson p "$NEW_PASS" '.pass = $p' ".claude/ship.loop.local.json" > "$TMP" && mv "$TMP" ".claude/ship.loop.local.json"
 PASS=$NEW_PASS
 ```
 
@@ -321,7 +316,7 @@ Check if we should continue reviewing:
 Set phase to `pushing`:
 
 ```bash
-set_loop_phase ".claude/ship.loop.local.md" "pushing"
+set_loop_phase ".claude/ship.loop.local.json" "pushing"
 ```
 
 #### 9a. Push to remote
@@ -380,7 +375,7 @@ Persist `bot_review_baseline` in state file.
 Set phase to `ci-watch`:
 
 ```bash
-set_loop_phase ".claude/ship.loop.local.md" "ci-watch"
+set_loop_phase ".claude/ship.loop.local.json" "ci-watch"
 ```
 
 First, check if CI workflow files exist:
@@ -416,7 +411,7 @@ If CI fails:
 Set phase to `bot-watching` (distinct from address-review's `watching` phase to get ship-specific re-entry messages):
 
 ```bash
-set_loop_phase ".claude/ship.loop.local.md" "bot-watching"
+set_loop_phase ".claude/ship.loop.local.json" "bot-watching"
 ```
 
 #### 11a. Discover review bots
@@ -505,7 +500,7 @@ Follow Steps 12a-12d from watch-loop.md:
 Set phase to `addressing` (distinct from `fixing` to ensure correct re-entry routing):
 
 ```bash
-set_loop_phase ".claude/ship.loop.local.md" "addressing"
+set_loop_phase ".claude/ship.loop.local.json" "addressing"
 ```
 
 #### 12a. Fetch and rebase against base branch
@@ -548,7 +543,7 @@ Return to Step 10 (ci-watch) — set phase and re-watch CI before checking bot a
 Set phase to `merging`:
 
 ```bash
-set_loop_phase ".claude/ship.loop.local.md" "merging"
+set_loop_phase ".claude/ship.loop.local.json" "merging"
 ```
 
 #### 13a. Final checks

--- a/plugins/go-workflow/commands/start-issue.md
+++ b/plugins/go-workflow/commands/start-issue.md
@@ -45,7 +45,7 @@ First, validate input is numeric (prevent command injection):
 ## Loop Initialization
 
 Initialize persistent loop to ensure work continues until complete:
-!`"${CLAUDE_PLUGIN_ROOT}/scripts/setup-loop.sh" "start-issue-$ARGUMENTS" "COMPLETE"`
+!`"${CLAUDE_PLUGIN_ROOT}/scripts/setup-loop.sh" "start-issue-$ARGUMENTS" "COMPLETE" "" "" '{}'`
 
 ## Context
 

--- a/plugins/go-workflow/hooks/stop-hook.sh
+++ b/plugins/go-workflow/hooks/stop-hook.sh
@@ -1,10 +1,10 @@
 #!/bin/bash
-# Generic stop hook - works for any plugin using loop state files
+# Generic stop hook - works for any plugin using loop state files (JSON-based)
 # This hook intercepts session exit and re-feeds the prompt until completion criteria are met.
 #
 # How it works:
 # 1. Read hook input from stdin to get transcript path
-# 2. Check for any active loop state files (.claude/*.loop.local.md)
+# 2. Check for any active loop state files (.claude/*.loop.local.json)
 # 3. If no active loop, allow normal exit
 # 4. If loop active, check for completion (max iterations or completion promise in transcript)
 # 5. If not complete, block exit and re-feed the prompt
@@ -24,17 +24,18 @@ SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 LIB_PATH="$SCRIPT_DIR/../lib/loop-state.sh"
 
 if [ ! -f "$LIB_PATH" ]; then
-  # Library not found - allow exit to prevent broken state
   exit 0
 fi
 
 source "$LIB_PATH"
 
+loop_log "stop-hook: entered, transcript=$TRANSCRIPT_PATH"
+
 # Find any active loop state file
 STATE_FILES=$(find_active_loops)
 
 if [ -z "$STATE_FILES" ]; then
-  # No active loop - allow normal exit
+  loop_log "stop-hook: no active loops found"
   exit 0
 fi
 
@@ -43,6 +44,14 @@ STATE_FILE=$(echo "$STATE_FILES" | head -1)
 
 # Verify state file exists and is readable
 if [ ! -f "$STATE_FILE" ] || [ ! -r "$STATE_FILE" ]; then
+  loop_log "stop-hook: state file not readable: $STATE_FILE"
+  exit 0
+fi
+
+# Validate JSON before proceeding
+if ! jq empty "$STATE_FILE" 2>/dev/null; then
+  loop_log "stop-hook: invalid JSON in state file, cleaning up: $STATE_FILE"
+  cleanup_loop "$STATE_FILE"
   exit 0
 fi
 
@@ -50,10 +59,21 @@ fi
 read_loop_state "$STATE_FILE"
 
 # Check if loop is stale (from a previous session)
-# Compare state file's started_at against the current transcript file's creation time.
-# If the transcript is newer than the loop, the loop is from a dead session.
+# Primary: Compare session ID (portable, instant)
+STORED_SESSION_ID=$(jq -r '.session_id // empty' "$STATE_FILE")
+
+if [ -n "$STORED_SESSION_ID" ] && [ -n "$TRANSCRIPT_PATH" ]; then
+  CURRENT_SESSION_ID=$(basename "$TRANSCRIPT_PATH" .jsonl 2>/dev/null || true)
+  if [ -n "$CURRENT_SESSION_ID" ] && [ "$STORED_SESSION_ID" != "$CURRENT_SESSION_ID" ]; then
+    loop_log "stop-hook: stale session detected (stored=$STORED_SESSION_ID current=$CURRENT_SESSION_ID), cleaning up"
+    cleanup_loop "$STATE_FILE"
+    exit 0
+  fi
+fi
+
+# Fallback: Timestamp-based stale detection
 if [ -n "$TRANSCRIPT_PATH" ] && [ -f "$TRANSCRIPT_PATH" ]; then
-  STARTED_AT=$(grep '^started_at:' "$STATE_FILE" | sed 's/started_at: *//')
+  STARTED_AT=$(jq -r '.started_at // empty' "$STATE_FILE")
   if [ -n "$STARTED_AT" ]; then
     if [[ "$OSTYPE" == "darwin"* ]]; then
       TRANSCRIPT_BIRTH=$(stat -f %B "$TRANSCRIPT_PATH" 2>/dev/null || echo "0")
@@ -63,6 +83,7 @@ if [ -n "$TRANSCRIPT_PATH" ] && [ -f "$TRANSCRIPT_PATH" ]; then
       LOOP_EPOCH=$(date -d "$STARTED_AT" +%s 2>/dev/null || echo "0")
     fi
     if [ "$LOOP_EPOCH" -gt 0 ] && [ "$TRANSCRIPT_BIRTH" -gt 0 ] && [ "$TRANSCRIPT_BIRTH" -gt "$LOOP_EPOCH" ]; then
+      loop_log "stop-hook: stale loop detected via timestamp (loop=$STARTED_AT transcript_birth=$TRANSCRIPT_BIRTH)"
       cleanup_loop "$STATE_FILE"
       exit 0
     fi
@@ -71,7 +92,7 @@ fi
 
 # Validate iteration is a number
 if ! [[ "$ITERATION" =~ ^[0-9]+$ ]]; then
-  # Invalid state - cleanup and allow exit
+  loop_log "stop-hook: invalid iteration '$ITERATION', cleaning up"
   cleanup_loop "$STATE_FILE"
   exit 0
 fi
@@ -79,27 +100,19 @@ fi
 # Check if max iterations reached (if set)
 if [ -n "$MAX_ITERATIONS" ] && [[ "$MAX_ITERATIONS" =~ ^[0-9]+$ ]]; then
   if [ "$ITERATION" -ge "$MAX_ITERATIONS" ]; then
+    loop_log "stop-hook: max iterations reached ($ITERATION >= $MAX_ITERATIONS)"
     cleanup_loop "$STATE_FILE"
     exit 0
   fi
 fi
 
-# Check for completion promise in transcript
+# Check for completion promise in transcript (robust: all text blocks, whitespace-tolerant)
 if [ -n "$COMPLETION_PROMISE" ] && [ -n "$TRANSCRIPT_PATH" ] && [ -f "$TRANSCRIPT_PATH" ]; then
-  LAST_LINES=$(grep '"role":"assistant"' "$TRANSCRIPT_PATH" 2>/dev/null | tail -n 100 || true)
-
-  if [ -n "$LAST_LINES" ]; then
-    set +e
-    LAST_OUTPUT=$(echo "$LAST_LINES" | jq -rs '
-      map(.message.content[]? | select(.type == "text") | .text) | last // ""
-    ' 2>&1)
-    JQ_EXIT=$?
-    set -e
-
-    if [ $JQ_EXIT -eq 0 ] && echo "$LAST_OUTPUT" | grep -q "<done>$COMPLETION_PROMISE</done>"; then
-      cleanup_loop "$STATE_FILE"
-      exit 0
-    fi
+  loop_log "stop-hook: checking completion promise '$COMPLETION_PROMISE'"
+  if check_completion_promise "$COMPLETION_PROMISE" "$TRANSCRIPT_PATH"; then
+    loop_log "stop-hook: completion promise found, cleaning up"
+    cleanup_loop "$STATE_FILE"
+    exit 0
   fi
 fi
 
@@ -110,37 +123,61 @@ NEW_ITERATION=$((ITERATION + 1))
 # Build system message with iteration info and guidance
 SYSTEM_MSG="Iteration $NEW_ITERATION of loop '$LOOP_NAME'."
 
-# Phase-aware re-feed: use targeted message based on current phase
-if [ "$PHASE" = "watching" ]; then
-  REASON="Resume Step 12: Check bot approval status, poll if needed. Do NOT re-run Steps 1-11."
-  SYSTEM_MSG="$SYSTEM_MSG RESUME AT STEP 12a: The fix cycle (Steps 1-11) is already complete. Check bot approval status and poll for re-reviews. Do NOT restart the fix cycle."
-elif [ "$PHASE" = "reviewing" ]; then
-  REASON="Continue the review loop: run the next LLM review pass and address findings."
-  SYSTEM_MSG="$SYSTEM_MSG Resume the review-fix-verify cycle. Run the next review pass."
-elif [ "$PHASE" = "fixing" ]; then
-  REASON="Continue fixing: address remaining review findings, then verify."
-  SYSTEM_MSG="$SYSTEM_MSG Continue addressing review findings."
-elif [ "$PHASE" = "verifying" ]; then
-  REASON="Continue verification: run build, test, and lint on fixes."
-  SYSTEM_MSG="$SYSTEM_MSG Verify fixes pass build, test, and lint."
-elif [ "$PHASE" = "bot-watching" ]; then
-  REASON="Resume: poll for bot review approval or new feedback."
-  SYSTEM_MSG="$SYSTEM_MSG Resume bot approval polling (Step 11). Check discovered bots for approval status. If bots request changes, go to Step 12. If all approved, go to Step 13."
-elif [ "$PHASE" = "addressing" ]; then
-  REASON="Resume: address bot review feedback, then re-watch CI and bots."
-  SYSTEM_MSG="$SYSTEM_MSG Resume addressing bot review feedback (Steps 2-11 of address-review). After fixes, return to CI watch."
-elif [ "$PHASE" = "pushing" ]; then
-  REASON="Resume: push changes and ensure PR exists."
-  SYSTEM_MSG="$SYSTEM_MSG Resume pushing changes to remote and PR creation/detection."
-elif [ "$PHASE" = "ci-watch" ]; then
-  REASON="Resume: watch CI status and fix failures."
-  SYSTEM_MSG="$SYSTEM_MSG Resume CI monitoring. Run gh pr checks and fix any failures."
-elif [ "$PHASE" = "merging" ]; then
-  REASON="Resume: merge the PR."
-  SYSTEM_MSG="$SYSTEM_MSG Verify CI green and bot approval, then merge the PR."
+# Phase-aware re-feed: look up phase message from state file, fall back to generic
+PHASE_MSG=""
+if [ -n "$PHASE" ]; then
+  PHASE_MSG=$(jq -r --arg p "$PHASE" '.phase_messages[$p] // empty' "$STATE_FILE" 2>/dev/null || true)
+fi
+
+if [ -n "$PHASE_MSG" ]; then
+  REASON="$PHASE_MSG"
+  SYSTEM_MSG="$SYSTEM_MSG $PHASE_MSG"
+  loop_log "stop-hook: phase '$PHASE' matched phase_messages entry"
 else
-  REASON="$ORIGINAL_PROMPT"
-  SYSTEM_MSG="$SYSTEM_MSG Continue working on the task."
+  # Fallback to generic phase messages for backward compatibility
+  case "$PHASE" in
+    watching)
+      REASON="Resume Step 12: Check bot approval status, poll if needed. Do NOT re-run Steps 1-11."
+      SYSTEM_MSG="$SYSTEM_MSG RESUME AT STEP 12a: The fix cycle (Steps 1-11) is already complete. Check bot approval status and poll for re-reviews. Do NOT restart the fix cycle."
+      ;;
+    reviewing)
+      REASON="Continue the review loop: run the next LLM review pass and address findings."
+      SYSTEM_MSG="$SYSTEM_MSG Resume the review-fix-verify cycle. Run the next review pass."
+      ;;
+    fixing)
+      REASON="Continue fixing: address remaining review findings, then verify."
+      SYSTEM_MSG="$SYSTEM_MSG Continue addressing review findings."
+      ;;
+    verifying)
+      REASON="Continue verification: run build, test, and lint on fixes."
+      SYSTEM_MSG="$SYSTEM_MSG Verify fixes pass build, test, and lint."
+      ;;
+    bot-watching)
+      REASON="Resume: poll for bot review approval or new feedback."
+      SYSTEM_MSG="$SYSTEM_MSG Resume bot approval polling (Step 11). Check discovered bots for approval status. If bots request changes, go to Step 12. If all approved, go to Step 13."
+      ;;
+    addressing)
+      REASON="Resume: address bot review feedback, then re-watch CI and bots."
+      SYSTEM_MSG="$SYSTEM_MSG Resume addressing bot review feedback (Steps 2-11 of address-review). After fixes, return to CI watch."
+      ;;
+    pushing)
+      REASON="Resume: push changes and ensure PR exists."
+      SYSTEM_MSG="$SYSTEM_MSG Resume pushing changes to remote and PR creation/detection."
+      ;;
+    ci-watch)
+      REASON="Resume: watch CI status and fix failures."
+      SYSTEM_MSG="$SYSTEM_MSG Resume CI monitoring. Run gh pr checks and fix any failures."
+      ;;
+    merging)
+      REASON="Resume: merge the PR."
+      SYSTEM_MSG="$SYSTEM_MSG Verify CI green and bot approval, then merge the PR."
+      ;;
+    *)
+      REASON="$ORIGINAL_PROMPT"
+      SYSTEM_MSG="$SYSTEM_MSG Continue working on the task."
+      ;;
+  esac
+  loop_log "stop-hook: phase '$PHASE' used fallback message"
 fi
 
 # Add guidance after many iterations
@@ -149,6 +186,8 @@ if [ "$NEW_ITERATION" -ge 15 ]; then
 fi
 
 SYSTEM_MSG="$SYSTEM_MSG Output <done>$COMPLETION_PROMISE</done> ONLY when ALL completion criteria are met."
+
+loop_log "stop-hook: blocking exit, reason='$REASON'"
 
 # Block exit and re-feed prompt
 jq -n --arg reason "$REASON" --arg msg "$SYSTEM_MSG" \

--- a/plugins/go-workflow/lib/loop-state.sh
+++ b/plugins/go-workflow/lib/loop-state.sh
@@ -1,79 +1,129 @@
 #!/bin/bash
-# Shared functions for loop state management
+# Shared functions for loop state management (JSON-based)
 # Used by stop-hook.sh and other loop-related scripts
+# Requires: jq
 
-# Read loop state from a state file
+# Debug log file location
+LOOP_DEBUG_LOG=".claude/loop-debug.log"
+
+# Write a timestamped entry to the debug log
+loop_log() {
+  local msg="$1"
+  local ts
+  ts=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+  mkdir -p .claude
+  echo "[$ts] $msg" >> "$LOOP_DEBUG_LOG"
+}
+
+# Read loop state from a JSON state file
 # Sets global variables: ITERATION, MAX_ITERATIONS, COMPLETION_PROMISE, LOOP_NAME, PHASE, ORIGINAL_PROMPT
 read_loop_state() {
   local state_file="$1"
-  ITERATION=$(grep '^iteration:' "$state_file" | sed 's/iteration: *//')
-  MAX_ITERATIONS=$(grep '^max_iterations:' "$state_file" | sed 's/max_iterations: *//')
-  COMPLETION_PROMISE=$(grep '^completion_promise:' "$state_file" | sed 's/completion_promise: *//')
-  LOOP_NAME=$(grep '^loop_name:' "$state_file" | sed 's/loop_name: *//')
-  PHASE=$(grep '^phase:' "$state_file" | sed 's/phase: *//' || true)
-  # Get content after the second --- (the prompt/body)
-  ORIGINAL_PROMPT=$(awk '/^---$/{p++; next} p==2' "$state_file")
+  ITERATION=$(jq -r '.iteration // 0' "$state_file")
+  MAX_ITERATIONS=$(jq -r '.max_iterations // empty' "$state_file")
+  COMPLETION_PROMISE=$(jq -r '.completion_promise // empty' "$state_file")
+  LOOP_NAME=$(jq -r '.loop_name // empty' "$state_file")
+  PHASE=$(jq -r '.phase // empty' "$state_file")
+  ORIGINAL_PROMPT=$(jq -r '.original_prompt // empty' "$state_file")
+  loop_log "read_loop_state: file=$state_file loop=$LOOP_NAME iter=$ITERATION phase=$PHASE"
 }
 
-# Increment the iteration counter in a state file
+# Increment the iteration counter in a state file (atomic write via temp file)
 increment_iteration() {
   local state_file="$1"
-  local new_iteration=$((ITERATION + 1))
-
-  # Use portable sed syntax (works on both macOS and Linux)
-  if [[ "$OSTYPE" == "darwin"* ]]; then
-    sed -i '' "s/^iteration: .*/iteration: $new_iteration/" "$state_file"
-  else
-    sed -i "s/^iteration: .*/iteration: $new_iteration/" "$state_file"
-  fi
+  local tmp_file="${state_file}.tmp"
+  jq '.iteration = (.iteration + 1)' "$state_file" > "$tmp_file" && mv "$tmp_file" "$state_file"
+  loop_log "increment_iteration: file=$state_file new_iteration=$((ITERATION + 1))"
 }
 
-# Set the phase field in a state file
+# Set the phase field in a state file (atomic write via temp file)
 set_loop_phase() {
   local state_file="$1"
   local new_phase="$2"
+  local tmp_file="${state_file}.tmp"
+  jq --arg phase "$new_phase" '.phase = $phase' "$state_file" > "$tmp_file" && mv "$tmp_file" "$state_file"
+  loop_log "set_loop_phase: file=$state_file phase=$new_phase"
+}
 
-  if grep -q '^phase:' "$state_file"; then
-    if [[ "$OSTYPE" == "darwin"* ]]; then
-      sed -i '' "s/^phase: .*/phase: $new_phase/" "$state_file"
-    else
-      sed -i "s/^phase: .*/phase: $new_phase/" "$state_file"
-    fi
-  else
-    if [[ "$OSTYPE" == "darwin"* ]]; then
-      sed -i '' "/^completion_promise:/a\\
-phase: $new_phase" "$state_file"
-    else
-      sed -i "/^completion_promise:/a phase: $new_phase" "$state_file"
-    fi
-  fi
+# Get a custom field from the state file
+get_loop_field() {
+  local state_file="$1"
+  local field="$2"
+  jq -r --arg f "$field" '.[$f] // empty' "$state_file"
+}
+
+# Set a custom field in the state file (atomic write via temp file)
+set_loop_field() {
+  local state_file="$1"
+  local field="$2"
+  local value="$3"
+  local tmp_file="${state_file}.tmp"
+  jq --arg f "$field" --arg v "$value" '.[$f] = $v' "$state_file" > "$tmp_file" && mv "$tmp_file" "$state_file"
 }
 
 # Remove a loop state file (cleanup)
 cleanup_loop() {
   local state_file="$1"
+  loop_log "cleanup_loop: file=$state_file"
   rm -f "$state_file"
 }
 
 # Check if the completion promise appears in recent transcript output
+# Checks ALL text blocks in last N assistant messages (not just the last one)
 # Returns 0 if found, 1 if not found
 check_completion_promise() {
   local promise="$1"
-  local transcript=".claude/transcript.jsonl"
+  local transcript="$2"
 
-  if [ -f "$transcript" ]; then
-    # Check the last 10 lines of transcript for the completion promise
-    # The promise should be wrapped in <done>...</done> tags
-    if tail -10 "$transcript" | grep -q "<done>$promise</done>"; then
-      return 0
-    fi
+  if [ -z "$transcript" ]; then
+    transcript=".claude/transcript.jsonl"
   fi
+
+  if [ ! -f "$transcript" ]; then
+    loop_log "check_completion_promise: transcript not found at $transcript"
+    return 1
+  fi
+
+  local last_lines
+  last_lines=$(grep '"role":"assistant"' "$transcript" 2>/dev/null | tail -n 100 || true)
+
+  if [ -z "$last_lines" ]; then
+    loop_log "check_completion_promise: no assistant messages in transcript"
+    return 1
+  fi
+
+  set +e
+  local all_text
+  all_text=$(echo "$last_lines" | jq -rs '
+    [.[] | .message.content[]? | select(.type == "text") | .text] | join("\n")
+  ' 2>/dev/null)
+  local jq_exit=$?
+  set -e
+
+  if [ $jq_exit -ne 0 ]; then
+    loop_log "check_completion_promise: jq failed with exit $jq_exit"
+    return 1
+  fi
+
+  # Trim whitespace and check for promise in any text block
+  if echo "$all_text" | grep -q "<done>${promise}</done>"; then
+    loop_log "check_completion_promise: FOUND promise '$promise'"
+    return 0
+  fi
+
+  # Also check with whitespace tolerance (promise may have surrounding spaces/newlines)
+  if echo "$all_text" | sed 's/^[[:space:]]*//;s/[[:space:]]*$//' | grep -q "<done>[[:space:]]*${promise}[[:space:]]*</done>"; then
+    loop_log "check_completion_promise: FOUND promise '$promise' (with whitespace)"
+    return 0
+  fi
+
+  loop_log "check_completion_promise: NOT found promise '$promise'"
   return 1
 }
 
 # Find all active loop state files
 find_active_loops() {
-  find .claude -name "*.loop.local.md" 2>/dev/null
+  find .claude -name "*.loop.local.json" 2>/dev/null
 }
 
 # Get the count of active loops

--- a/plugins/go-workflow/scripts/cleanup-loop.sh
+++ b/plugins/go-workflow/scripts/cleanup-loop.sh
@@ -12,7 +12,7 @@ LOOP_NAME="${1:-}"
 if [ -n "$LOOP_NAME" ]; then
   # Clean up specific loop
   SAFE_LOOP_NAME=$(echo "$LOOP_NAME" | sed 's/[^a-zA-Z0-9_-]/-/g')
-  STATE_FILE=".claude/${SAFE_LOOP_NAME}.loop.local.md"
+  STATE_FILE=".claude/${SAFE_LOOP_NAME}.loop.local.json"
 
   if [ -f "$STATE_FILE" ]; then
     rm -f "$STATE_FILE"
@@ -22,13 +22,13 @@ if [ -n "$LOOP_NAME" ]; then
   fi
 else
   # Clean up all loops
-  LOOP_FILES=$(find .claude -name "*.loop.local.md" 2>/dev/null || true)
+  LOOP_FILES=$(find .claude -name "*.loop.local.json" 2>/dev/null || true)
 
   if [ -z "$LOOP_FILES" ]; then
     echo "No active loops found."
   else
     echo "$LOOP_FILES" | while read -r file; do
-      loop_name=$(grep '^loop_name:' "$file" 2>/dev/null | sed 's/loop_name: *//' || echo "unknown")
+      loop_name=$(jq -r '.loop_name // "unknown"' "$file" 2>/dev/null || echo "unknown")
       rm -f "$file"
       echo "Cancelled loop: $loop_name"
     done

--- a/plugins/go-workflow/scripts/setup-loop.sh
+++ b/plugins/go-workflow/scripts/setup-loop.sh
@@ -1,28 +1,30 @@
 #!/bin/bash
-# Initialize a persistent loop for any command
-# Usage: setup-loop.sh <loop-name> <completion-promise> [max-iterations] [initial-phase]
+# Initialize a persistent loop for any command (JSON-based)
+# Usage: setup-loop.sh <loop-name> <completion-promise> [max-iterations] [initial-phase] [phase-messages-json]
 #
 # Example:
 #   setup-loop.sh "start-issue-123" "COMPLETE"
 #   setup-loop.sh "create-project" "DONE" 50
 #   setup-loop.sh "address-review-42" "COMPLETE" "" "fixing"
+#   setup-loop.sh "ship" "SHIPPED" 50 "" '{"reviewing":"Resume LLM review pass."}'
 
 set -euo pipefail
 
 LOOP_NAME="${1:-}"
 COMPLETION_PROMISE="${2:-COMPLETE}"
-MAX_ITERATIONS="${3:-}"  # Optional, defaults to unlimited
+MAX_ITERATIONS="${3:-}"  # Optional, defaults to null
 INITIAL_PHASE="${4:-}"   # Optional, defaults to empty
+PHASE_MESSAGES_JSON="${5:-}"  # Optional JSON object of phase->message mappings
 
 if [ -z "$LOOP_NAME" ]; then
   echo "Error: loop-name is required"
-  echo "Usage: setup-loop.sh <loop-name> <completion-promise> [max-iterations] [initial-phase]"
+  echo "Usage: setup-loop.sh <loop-name> <completion-promise> [max-iterations] [initial-phase] [phase-messages-json]"
   exit 1
 fi
 
 # Sanitize loop name for use in filename
 SAFE_LOOP_NAME=$(echo "$LOOP_NAME" | sed 's/[^a-zA-Z0-9_-]/-/g')
-STATE_FILE=".claude/${SAFE_LOOP_NAME}.loop.local.md"
+STATE_FILE=".claude/${SAFE_LOOP_NAME}.loop.local.json"
 
 # Create .claude directory if it doesn't exist
 mkdir -p .claude
@@ -31,37 +33,64 @@ mkdir -p .claude
 EXISTING_PHASE=""
 EXISTING_BASELINE=""
 if [ -f "$STATE_FILE" ]; then
-  EXISTING_PHASE=$(grep '^phase:' "$STATE_FILE" | sed 's/phase: *//' || true)
-  EXISTING_BASELINE=$(grep '^bot_review_baseline:' "$STATE_FILE" | sed 's/bot_review_baseline: *//' || true)
+  EXISTING_PHASE=$(jq -r '.phase // empty' "$STATE_FILE" 2>/dev/null || true)
+  EXISTING_BASELINE=$(jq -r '.bot_review_baseline // empty' "$STATE_FILE" 2>/dev/null || true)
   echo "Warning: Loop '$LOOP_NAME' already active. Resetting (preserving phase: ${EXISTING_PHASE:-<none>}, baseline: ${EXISTING_BASELINE:-<none>})..."
 fi
 
 # Preserve existing phase from state file, fall back to INITIAL_PHASE for fresh runs
-# This allows re-entry to maintain phase context (e.g., watching) across stop-hook restarts
-# while INITIAL_PHASE provides a default for first-time initialization
 PHASE="${EXISTING_PHASE:-$INITIAL_PHASE}"
 
-# Create state file with YAML frontmatter
-cat > "$STATE_FILE" << EOF
----
-loop_name: $LOOP_NAME
-iteration: 1
-max_iterations: $MAX_ITERATIONS
-completion_promise: $COMPLETION_PROMISE
-phase: $PHASE
-bot_review_baseline: $EXISTING_BASELINE
-started_at: $(date -u +"%Y-%m-%dT%H:%M:%SZ")
----
+# Derive session ID from transcript path or env
+SESSION_ID=""
+if [ -n "${CLAUDE_SESSION_ID:-}" ]; then
+  SESSION_ID="$CLAUDE_SESSION_ID"
+elif [ -d ".claude" ]; then
+  # Try to find the most recent transcript file and use its name as session ID
+  LATEST_TRANSCRIPT=$(find .claude -name "*.jsonl" -maxdepth 1 2>/dev/null | sort -t/ -k2 | tail -1 || true)
+  if [ -n "$LATEST_TRANSCRIPT" ]; then
+    SESSION_ID=$(basename "$LATEST_TRANSCRIPT" .jsonl)
+  fi
+fi
 
-Persistent loop initialized for: $LOOP_NAME
-Completion promise: $COMPLETION_PROMISE
-Max iterations: ${MAX_ITERATIONS:-unlimited}
+# Build max_iterations as number or null
+MAX_ITER_JSON="null"
+if [ -n "$MAX_ITERATIONS" ]; then
+  MAX_ITER_JSON="$MAX_ITERATIONS"
+fi
 
-This loop will continue until:
-1. The completion promise <done>$COMPLETION_PROMISE</done> is output
-2. Max iterations is reached (if set)
-3. User cancels with /cancel-loop
-EOF
+# Build phase_messages as object or empty object
+PHASE_MSGS_JSON="{}"
+if [ -n "$PHASE_MESSAGES_JSON" ]; then
+  # Validate it's valid JSON
+  if echo "$PHASE_MESSAGES_JSON" | jq empty 2>/dev/null; then
+    PHASE_MSGS_JSON="$PHASE_MESSAGES_JSON"
+  fi
+fi
+
+# Create JSON state file (atomic write via temp file)
+TMP_FILE="${STATE_FILE}.tmp"
+jq -n \
+  --arg loop_name "$LOOP_NAME" \
+  --argjson iteration 1 \
+  --argjson max_iterations "$MAX_ITER_JSON" \
+  --arg completion_promise "$COMPLETION_PROMISE" \
+  --arg phase "$PHASE" \
+  --arg bot_review_baseline "${EXISTING_BASELINE:-}" \
+  --arg started_at "$(date -u +"%Y-%m-%dT%H:%M:%SZ")" \
+  --arg session_id "$SESSION_ID" \
+  --argjson phase_messages "$PHASE_MSGS_JSON" \
+  '{
+    loop_name: $loop_name,
+    iteration: $iteration,
+    max_iterations: $max_iterations,
+    completion_promise: $completion_promise,
+    phase: $phase,
+    bot_review_baseline: $bot_review_baseline,
+    started_at: $started_at,
+    session_id: $session_id,
+    phase_messages: $phase_messages
+  }' > "$TMP_FILE" && mv "$TMP_FILE" "$STATE_FILE"
 
 echo "Loop initialized: $LOOP_NAME"
 echo "Output <done>$COMPLETION_PROMISE</done> when all completion criteria are met."

--- a/plugins/go-workflow/skills/address-review/SKILL.md
+++ b/plugins/go-workflow/skills/address-review/SKILL.md
@@ -74,10 +74,11 @@ Check if resuming from a previous watching phase:
 
 ```bash
 SAFE_LOOP_NAME=$(echo "address-review-${RESOLVED_PR:-auto}" | sed 's/[^a-zA-Z0-9_-]/-/g')
-LOOP_STATE_FILE=".claude/${SAFE_LOOP_NAME}.loop.local.md"
+LOOP_STATE_FILE=".claude/${SAFE_LOOP_NAME}.loop.local.json"
 CURRENT_PHASE=""
 if [ -f "$LOOP_STATE_FILE" ]; then
-  CURRENT_PHASE=$(grep '^phase:' "$LOOP_STATE_FILE" | sed 's/phase: *//' || true)
+  source "${CLAUDE_PLUGIN_ROOT}/lib/loop-state.sh"
+  CURRENT_PHASE=$(jq -r '.phase // empty' "$LOOP_STATE_FILE" 2>/dev/null || true)
 fi
 echo "Current phase: ${CURRENT_PHASE:-<none>}"
 ```
@@ -87,14 +88,13 @@ echo "Current phase: ${CURRENT_PHASE:-<none>}"
 ```bash
 BOT_REVIEW_BASELINE=""
 if [ -f "$LOOP_STATE_FILE" ]; then
-  BOT_REVIEW_BASELINE=$(grep '^bot_review_baseline:' "$LOOP_STATE_FILE" | sed 's/bot_review_baseline: *//' || true)
+  BOT_REVIEW_BASELINE=$(jq -r '.bot_review_baseline // empty' "$LOOP_STATE_FILE" 2>/dev/null || true)
 fi
 if [ -z "$BOT_REVIEW_BASELINE" ]; then
   BOT_REVIEW_BASELINE=$(date -u +%Y-%m-%dT%H:%M:%SZ)
   echo "Bot review baseline (fallback): $BOT_REVIEW_BASELINE"
   if [ -f "$LOOP_STATE_FILE" ]; then
-    sed -i '' "/^phase:/a\\
-bot_review_baseline: $BOT_REVIEW_BASELINE" "$LOOP_STATE_FILE" 2>/dev/null || sed -i "/^phase:/a bot_review_baseline: $BOT_REVIEW_BASELINE" "$LOOP_STATE_FILE"
+    set_loop_field "$LOOP_STATE_FILE" "bot_review_baseline" "$BOT_REVIEW_BASELINE"
   fi
 else
   echo "Bot review baseline (restored): $BOT_REVIEW_BASELINE"
@@ -107,7 +107,7 @@ Do NOT re-run the fix cycle. Skip to watch loop (read `watch-loop.md`).
 
 ```bash
 if [ -f "$LOOP_STATE_FILE" ]; then
-  sed -i '' "s/^phase: .*/phase: /" "$LOOP_STATE_FILE" 2>/dev/null || sed -i "s/^phase: .*/phase: /" "$LOOP_STATE_FILE"
+  set_loop_phase "$LOOP_STATE_FILE" ""
   echo "Phase cleared (--no-watch mode)"
 fi
 ```
@@ -290,14 +290,10 @@ gh pr view "$PR_NUM" --json reviews --jq '.reviews[] | select(.state == "CHANGES
 - **If `CURRENT_PHASE` is `fixing` AND `WATCH_MODE` is `true` AND bots detected:** Set phase to `watching`, skip to Step 12:
   ```bash
   SAFE_LOOP_NAME=$(echo "address-review-${RESOLVED_PR:-auto}" | sed 's/[^a-zA-Z0-9_-]/-/g')
-  LOOP_STATE_FILE=".claude/${SAFE_LOOP_NAME}.loop.local.md"
+  LOOP_STATE_FILE=".claude/${SAFE_LOOP_NAME}.loop.local.json"
   if [ -f "$LOOP_STATE_FILE" ]; then
-    if grep -q '^phase:' "$LOOP_STATE_FILE"; then
-      sed -i '' "s/^phase: .*/phase: watching/" "$LOOP_STATE_FILE" 2>/dev/null || sed -i "s/^phase: .*/phase: watching/" "$LOOP_STATE_FILE"
-    else
-      sed -i '' "/^completion_promise:/a\\
-  phase: watching" "$LOOP_STATE_FILE" 2>/dev/null || sed -i "/^completion_promise:/a phase: watching" "$LOOP_STATE_FILE"
-    fi
+    source "${CLAUDE_PLUGIN_ROOT}/lib/loop-state.sh"
+    set_loop_phase "$LOOP_STATE_FILE" "watching"
     echo "Phase set to: watching (post-fix-cycle path)"
   fi
   ```
@@ -317,9 +313,10 @@ Address feedback, but note: "This PR has pending review feedback that cannot be 
 
 ```bash
 SAFE_LOOP_NAME=$(echo "address-review-${RESOLVED_PR:-auto}" | sed 's/[^a-zA-Z0-9_-]/-/g')
-LOOP_STATE_FILE=".claude/${SAFE_LOOP_NAME}.loop.local.md"
+LOOP_STATE_FILE=".claude/${SAFE_LOOP_NAME}.loop.local.json"
 if [ -f "$LOOP_STATE_FILE" ]; then
-  sed -i '' "s/^phase: .*/phase: fixing/" "$LOOP_STATE_FILE" 2>/dev/null || sed -i "s/^phase: .*/phase: fixing/" "$LOOP_STATE_FILE"
+  source "${CLAUDE_PLUGIN_ROOT}/lib/loop-state.sh"
+  set_loop_phase "$LOOP_STATE_FILE" "fixing"
 fi
 ```
 

--- a/plugins/go-workflow/skills/address-review/watch-loop.md
+++ b/plugins/go-workflow/skills/address-review/watch-loop.md
@@ -6,14 +6,10 @@ Before entering the watch loop, update the loop state phase so that any stop-hoo
 
 ```bash
 SAFE_LOOP_NAME=$(echo "address-review-${RESOLVED_PR:-auto}" | sed 's/[^a-zA-Z0-9_-]/-/g')
-LOOP_STATE_FILE=".claude/${SAFE_LOOP_NAME}.loop.local.md"
+LOOP_STATE_FILE=".claude/${SAFE_LOOP_NAME}.loop.local.json"
 if [ -f "$LOOP_STATE_FILE" ]; then
-  if grep -q '^phase:' "$LOOP_STATE_FILE"; then
-    sed -i '' "s/^phase: .*/phase: watching/" "$LOOP_STATE_FILE" 2>/dev/null || sed -i "s/^phase: .*/phase: watching/" "$LOOP_STATE_FILE"
-  else
-    sed -i '' "/^completion_promise:/a\\
-phase: watching" "$LOOP_STATE_FILE" 2>/dev/null || sed -i "/^completion_promise:/a phase: watching" "$LOOP_STATE_FILE"
-  fi
+  source "${CLAUDE_PLUGIN_ROOT}/lib/loop-state.sh"
+  set_loop_phase "$LOOP_STATE_FILE" "watching"
   echo "Phase set to: watching"
 fi
 ```
@@ -29,12 +25,7 @@ if [ -z "$BOT_REVIEW_BASELINE" ]; then
 fi
 
 if [ -f "$LOOP_STATE_FILE" ]; then
-  if grep -q '^bot_review_baseline:' "$LOOP_STATE_FILE"; then
-    sed -i '' "s/^bot_review_baseline: .*/bot_review_baseline: $BOT_REVIEW_BASELINE/" "$LOOP_STATE_FILE" 2>/dev/null || sed -i "s/^bot_review_baseline: .*/bot_review_baseline: $BOT_REVIEW_BASELINE/" "$LOOP_STATE_FILE"
-  else
-    sed -i '' "/^phase:/a\\
-bot_review_baseline: $BOT_REVIEW_BASELINE" "$LOOP_STATE_FILE" 2>/dev/null || sed -i "/^phase:/a bot_review_baseline: $BOT_REVIEW_BASELINE" "$LOOP_STATE_FILE"
-  fi
+  set_loop_field "$LOOP_STATE_FILE" "bot_review_baseline" "$BOT_REVIEW_BASELINE"
   echo "Bot review baseline persisted: $BOT_REVIEW_BASELINE"
 fi
 ```
@@ -92,9 +83,10 @@ After the quiet period ends and new unresolved comments/threads exist:
 
 ```bash
 SAFE_LOOP_NAME=$(echo "address-review-${RESOLVED_PR:-auto}" | sed 's/[^a-zA-Z0-9_-]/-/g')
-LOOP_STATE_FILE=".claude/${SAFE_LOOP_NAME}.loop.local.md"
+LOOP_STATE_FILE=".claude/${SAFE_LOOP_NAME}.loop.local.json"
 if [ -f "$LOOP_STATE_FILE" ]; then
-  sed -i '' "s/^phase: .*/phase: fixing/" "$LOOP_STATE_FILE" 2>/dev/null || sed -i "s/^phase: .*/phase: fixing/" "$LOOP_STATE_FILE"
+  source "${CLAUDE_PLUGIN_ROOT}/lib/loop-state.sh"
+  set_loop_phase "$LOOP_STATE_FILE" "fixing"
   echo "Phase reset to: fixing (new bot feedback detected)"
 fi
 ```

--- a/plugins/llm-tools/commands/review-loop.md
+++ b/plugins/llm-tools/commands/review-loop.md
@@ -6,7 +6,7 @@ allowed-tools: ["Bash", "Read", "Glob", "Grep", "Edit", "Write", "AskUserQuestio
 
 # Iterative LLM Review Loop
 
-!`"${CLAUDE_PLUGIN_ROOT}/scripts/setup-loop.sh" "review-loop" "REVIEW_CLEAN" 25`
+!`"${CLAUDE_PLUGIN_ROOT}/scripts/setup-loop.sh" "review-loop" "REVIEW_CLEAN" 25 "" '{"reviewing":"Resume the review-fix-verify cycle. Run the next review pass.","fixing":"Continue fixing: address remaining review findings, then verify.","verifying":"Continue verification: run build, test, and lint on fixes."}'`
 
 ## 1. Parse Arguments
 
@@ -18,11 +18,13 @@ Parse `$ARGUMENTS` to extract:
 
 Store as `LLM_CHOICE`, `MAX_PASSES`, and `SCOPE_HINT`.
 
-**Persist arguments to state file** for re-entry recovery. After parsing, append these fields to `.claude/review-loop.loop.local.md` if they don't already exist:
+**Persist arguments to state file** for re-entry recovery. After parsing, merge these fields into `.claude/review-loop.loop.local.json` using `jq`:
 
-```yaml
-args: <raw $ARGUMENTS string>
-pass: 0
+```bash
+STATE_FILE=".claude/review-loop.loop.local.json"
+TMP="$STATE_FILE.tmp"
+jq --arg args "$ARGUMENTS" --argjson pass 0 \
+   '. + {args: $args, pass: $pass}' "$STATE_FILE" > "$TMP" && mv "$TMP" "$STATE_FILE"
 ```
 
 This ensures stop-hook re-entry can restore the original configuration.
@@ -52,21 +54,21 @@ Do NOT continue the loop. Output `<done>REVIEW_CLEAN</done>` to signal completio
 
 ## 3. Re-entry Check
 
-Read the loop state file at `.claude/review-loop.loop.local.md`:
+Read the loop state file at `.claude/review-loop.loop.local.json`:
 
 ```bash
 source "${CLAUDE_PLUGIN_ROOT}/lib/loop-state.sh"
-STATE_FILE=".claude/review-loop.loop.local.md"
+STATE_FILE=".claude/review-loop.loop.local.json"
 if [ -f "$STATE_FILE" ]; then
   read_loop_state "$STATE_FILE"
 fi
 ```
 
-If `PHASE` is set (non-empty), this is a re-entry from the stop-hook. Recover state from the persisted fields in the state file:
+If `PHASE` is set (non-empty), this is a re-entry from the stop-hook. Recover state from the persisted fields using `jq`:
 
-1. Read `args:` field and re-parse to restore `LLM_CHOICE`, `MAX_PASSES`, `SCOPE_HINT`
-2. Read `pass:` field to restore the current pass count
-3. Read `scope:`, `base_branch:`, `model:`, `file_paths:` fields to restore `REVIEW_SCOPE`, `BASE_BRANCH`, `MODEL`, `FILE_PATHS`
+1. Read `args` field and re-parse to restore `LLM_CHOICE`, `MAX_PASSES`, `SCOPE_HINT`
+2. Read `pass` field via `jq -r '.pass // 0' "$STATE_FILE"` to restore the current pass count
+3. Read `scope`, `base_branch`, `model`, `file_paths` fields via `jq -r '.field // empty' "$STATE_FILE"` to restore `REVIEW_SCOPE`, `BASE_BRANCH`, `MODEL`, `FILE_PATHS`
 
 Then skip to the corresponding phase:
 
@@ -163,13 +165,15 @@ If "Custom" model was selected, ask for the model name.
 
 Store all selections: `REVIEW_SCOPE`, `BASE_BRANCH`, `MODEL`, `FILE_PATHS`.
 
-**Persist scope/model to state file** for re-entry recovery. Append these fields to `.claude/review-loop.loop.local.md`:
+**Persist scope/model to state file** for re-entry recovery. Merge these fields into `.claude/review-loop.loop.local.json`:
 
-```yaml
-scope: <REVIEW_SCOPE>
-base_branch: <BASE_BRANCH>
-model: <MODEL>
-file_paths: <FILE_PATHS or empty>
+```bash
+STATE_FILE=".claude/review-loop.loop.local.json"
+TMP="$STATE_FILE.tmp"
+jq --arg scope "$REVIEW_SCOPE" --arg base_branch "$BASE_BRANCH" \
+   --arg model "$MODEL" --arg file_paths "${FILE_PATHS:-}" \
+   '. + {scope: $scope, base_branch: $base_branch, model: $model, file_paths: $file_paths}' \
+   "$STATE_FILE" > "$TMP" && mv "$TMP" "$STATE_FILE"
 ```
 
 The `pass:` field in the state file was initialized to 0 in Step 1.
@@ -180,7 +184,7 @@ Set phase to `reviewing` and increment the `pass:` field in the state file:
 
 ```bash
 source "${CLAUDE_PLUGIN_ROOT}/lib/loop-state.sh"
-set_loop_phase ".claude/review-loop.loop.local.md" "reviewing"
+set_loop_phase ".claude/review-loop.loop.local.json" "reviewing"
 # Increment pass counter in state file (read current value, increment, write back)
 ```
 
@@ -275,7 +279,7 @@ After capturing the LLM review output:
 Set phase to `fixing`:
 
 ```bash
-set_loop_phase ".claude/review-loop.loop.local.md" "fixing"
+set_loop_phase ".claude/review-loop.loop.local.json" "fixing"
 ```
 
 For each finding from Step 6:
@@ -297,7 +301,7 @@ Track counts: `FIXED`, `SKIPPED` (with reasons).
 Set phase to `verifying`:
 
 ```bash
-set_loop_phase ".claude/review-loop.loop.local.md" "verifying"
+set_loop_phase ".claude/review-loop.loop.local.json" "verifying"
 ```
 
 Auto-detect project type and run appropriate verification:

--- a/plugins/llm-tools/lib/loop-state.sh
+++ b/plugins/llm-tools/lib/loop-state.sh
@@ -1,79 +1,129 @@
 #!/bin/bash
-# Shared functions for loop state management
+# Shared functions for loop state management (JSON-based)
 # Used by stop-hook.sh and other loop-related scripts
+# Requires: jq
 
-# Read loop state from a state file
+# Debug log file location
+LOOP_DEBUG_LOG=".claude/loop-debug.log"
+
+# Write a timestamped entry to the debug log
+loop_log() {
+  local msg="$1"
+  local ts
+  ts=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+  mkdir -p .claude
+  echo "[$ts] $msg" >> "$LOOP_DEBUG_LOG"
+}
+
+# Read loop state from a JSON state file
 # Sets global variables: ITERATION, MAX_ITERATIONS, COMPLETION_PROMISE, LOOP_NAME, PHASE, ORIGINAL_PROMPT
 read_loop_state() {
   local state_file="$1"
-  ITERATION=$(grep '^iteration:' "$state_file" | sed 's/iteration: *//')
-  MAX_ITERATIONS=$(grep '^max_iterations:' "$state_file" | sed 's/max_iterations: *//')
-  COMPLETION_PROMISE=$(grep '^completion_promise:' "$state_file" | sed 's/completion_promise: *//')
-  LOOP_NAME=$(grep '^loop_name:' "$state_file" | sed 's/loop_name: *//')
-  PHASE=$(grep '^phase:' "$state_file" | sed 's/phase: *//' || true)
-  # Get content after the second --- (the prompt/body)
-  ORIGINAL_PROMPT=$(awk '/^---$/{p++; next} p==2' "$state_file")
+  ITERATION=$(jq -r '.iteration // 0' "$state_file")
+  MAX_ITERATIONS=$(jq -r '.max_iterations // empty' "$state_file")
+  COMPLETION_PROMISE=$(jq -r '.completion_promise // empty' "$state_file")
+  LOOP_NAME=$(jq -r '.loop_name // empty' "$state_file")
+  PHASE=$(jq -r '.phase // empty' "$state_file")
+  ORIGINAL_PROMPT=$(jq -r '.original_prompt // empty' "$state_file")
+  loop_log "read_loop_state: file=$state_file loop=$LOOP_NAME iter=$ITERATION phase=$PHASE"
 }
 
-# Increment the iteration counter in a state file
+# Increment the iteration counter in a state file (atomic write via temp file)
 increment_iteration() {
   local state_file="$1"
-  local new_iteration=$((ITERATION + 1))
-
-  # Use portable sed syntax (works on both macOS and Linux)
-  if [[ "$OSTYPE" == "darwin"* ]]; then
-    sed -i '' "s/^iteration: .*/iteration: $new_iteration/" "$state_file"
-  else
-    sed -i "s/^iteration: .*/iteration: $new_iteration/" "$state_file"
-  fi
+  local tmp_file="${state_file}.tmp"
+  jq '.iteration = (.iteration + 1)' "$state_file" > "$tmp_file" && mv "$tmp_file" "$state_file"
+  loop_log "increment_iteration: file=$state_file new_iteration=$((ITERATION + 1))"
 }
 
-# Set the phase field in a state file
+# Set the phase field in a state file (atomic write via temp file)
 set_loop_phase() {
   local state_file="$1"
   local new_phase="$2"
+  local tmp_file="${state_file}.tmp"
+  jq --arg phase "$new_phase" '.phase = $phase' "$state_file" > "$tmp_file" && mv "$tmp_file" "$state_file"
+  loop_log "set_loop_phase: file=$state_file phase=$new_phase"
+}
 
-  if grep -q '^phase:' "$state_file"; then
-    if [[ "$OSTYPE" == "darwin"* ]]; then
-      sed -i '' "s/^phase: .*/phase: $new_phase/" "$state_file"
-    else
-      sed -i "s/^phase: .*/phase: $new_phase/" "$state_file"
-    fi
-  else
-    if [[ "$OSTYPE" == "darwin"* ]]; then
-      sed -i '' "/^completion_promise:/a\\
-phase: $new_phase" "$state_file"
-    else
-      sed -i "/^completion_promise:/a phase: $new_phase" "$state_file"
-    fi
-  fi
+# Get a custom field from the state file
+get_loop_field() {
+  local state_file="$1"
+  local field="$2"
+  jq -r --arg f "$field" '.[$f] // empty' "$state_file"
+}
+
+# Set a custom field in the state file (atomic write via temp file)
+set_loop_field() {
+  local state_file="$1"
+  local field="$2"
+  local value="$3"
+  local tmp_file="${state_file}.tmp"
+  jq --arg f "$field" --arg v "$value" '.[$f] = $v' "$state_file" > "$tmp_file" && mv "$tmp_file" "$state_file"
 }
 
 # Remove a loop state file (cleanup)
 cleanup_loop() {
   local state_file="$1"
+  loop_log "cleanup_loop: file=$state_file"
   rm -f "$state_file"
 }
 
 # Check if the completion promise appears in recent transcript output
+# Checks ALL text blocks in last N assistant messages (not just the last one)
 # Returns 0 if found, 1 if not found
 check_completion_promise() {
   local promise="$1"
-  local transcript=".claude/transcript.jsonl"
+  local transcript="$2"
 
-  if [ -f "$transcript" ]; then
-    # Check the last 10 lines of transcript for the completion promise
-    # The promise should be wrapped in <done>...</done> tags
-    if tail -10 "$transcript" | grep -q "<done>$promise</done>"; then
-      return 0
-    fi
+  if [ -z "$transcript" ]; then
+    transcript=".claude/transcript.jsonl"
   fi
+
+  if [ ! -f "$transcript" ]; then
+    loop_log "check_completion_promise: transcript not found at $transcript"
+    return 1
+  fi
+
+  local last_lines
+  last_lines=$(grep '"role":"assistant"' "$transcript" 2>/dev/null | tail -n 100 || true)
+
+  if [ -z "$last_lines" ]; then
+    loop_log "check_completion_promise: no assistant messages in transcript"
+    return 1
+  fi
+
+  set +e
+  local all_text
+  all_text=$(echo "$last_lines" | jq -rs '
+    [.[] | .message.content[]? | select(.type == "text") | .text] | join("\n")
+  ' 2>/dev/null)
+  local jq_exit=$?
+  set -e
+
+  if [ $jq_exit -ne 0 ]; then
+    loop_log "check_completion_promise: jq failed with exit $jq_exit"
+    return 1
+  fi
+
+  # Trim whitespace and check for promise in any text block
+  if echo "$all_text" | grep -q "<done>${promise}</done>"; then
+    loop_log "check_completion_promise: FOUND promise '$promise'"
+    return 0
+  fi
+
+  # Also check with whitespace tolerance (promise may have surrounding spaces/newlines)
+  if echo "$all_text" | sed 's/^[[:space:]]*//;s/[[:space:]]*$//' | grep -q "<done>[[:space:]]*${promise}[[:space:]]*</done>"; then
+    loop_log "check_completion_promise: FOUND promise '$promise' (with whitespace)"
+    return 0
+  fi
+
+  loop_log "check_completion_promise: NOT found promise '$promise'"
   return 1
 }
 
 # Find all active loop state files
 find_active_loops() {
-  find .claude -name "*.loop.local.md" 2>/dev/null
+  find .claude -name "*.loop.local.json" 2>/dev/null
 }
 
 # Get the count of active loops

--- a/plugins/llm-tools/scripts/cleanup-loop.sh
+++ b/plugins/llm-tools/scripts/cleanup-loop.sh
@@ -12,7 +12,7 @@ LOOP_NAME="${1:-}"
 if [ -n "$LOOP_NAME" ]; then
   # Clean up specific loop
   SAFE_LOOP_NAME=$(echo "$LOOP_NAME" | sed 's/[^a-zA-Z0-9_-]/-/g')
-  STATE_FILE=".claude/${SAFE_LOOP_NAME}.loop.local.md"
+  STATE_FILE=".claude/${SAFE_LOOP_NAME}.loop.local.json"
 
   if [ -f "$STATE_FILE" ]; then
     rm -f "$STATE_FILE"
@@ -22,13 +22,13 @@ if [ -n "$LOOP_NAME" ]; then
   fi
 else
   # Clean up all loops
-  LOOP_FILES=$(find .claude -name "*.loop.local.md" 2>/dev/null || true)
+  LOOP_FILES=$(find .claude -name "*.loop.local.json" 2>/dev/null || true)
 
   if [ -z "$LOOP_FILES" ]; then
     echo "No active loops found."
   else
     echo "$LOOP_FILES" | while read -r file; do
-      loop_name=$(grep '^loop_name:' "$file" 2>/dev/null | sed 's/loop_name: *//' || echo "unknown")
+      loop_name=$(jq -r '.loop_name // "unknown"' "$file" 2>/dev/null || echo "unknown")
       rm -f "$file"
       echo "Cancelled loop: $loop_name"
     done

--- a/plugins/llm-tools/scripts/setup-loop.sh
+++ b/plugins/llm-tools/scripts/setup-loop.sh
@@ -1,28 +1,30 @@
 #!/bin/bash
-# Initialize a persistent loop for any command
-# Usage: setup-loop.sh <loop-name> <completion-promise> [max-iterations] [initial-phase]
+# Initialize a persistent loop for any command (JSON-based)
+# Usage: setup-loop.sh <loop-name> <completion-promise> [max-iterations] [initial-phase] [phase-messages-json]
 #
 # Example:
 #   setup-loop.sh "start-issue-123" "COMPLETE"
 #   setup-loop.sh "create-project" "DONE" 50
 #   setup-loop.sh "address-review-42" "COMPLETE" "" "fixing"
+#   setup-loop.sh "ship" "SHIPPED" 50 "" '{"reviewing":"Resume LLM review pass."}'
 
 set -euo pipefail
 
 LOOP_NAME="${1:-}"
 COMPLETION_PROMISE="${2:-COMPLETE}"
-MAX_ITERATIONS="${3:-}"  # Optional, defaults to unlimited
+MAX_ITERATIONS="${3:-}"  # Optional, defaults to null
 INITIAL_PHASE="${4:-}"   # Optional, defaults to empty
+PHASE_MESSAGES_JSON="${5:-}"  # Optional JSON object of phase->message mappings
 
 if [ -z "$LOOP_NAME" ]; then
   echo "Error: loop-name is required"
-  echo "Usage: setup-loop.sh <loop-name> <completion-promise> [max-iterations] [initial-phase]"
+  echo "Usage: setup-loop.sh <loop-name> <completion-promise> [max-iterations] [initial-phase] [phase-messages-json]"
   exit 1
 fi
 
 # Sanitize loop name for use in filename
 SAFE_LOOP_NAME=$(echo "$LOOP_NAME" | sed 's/[^a-zA-Z0-9_-]/-/g')
-STATE_FILE=".claude/${SAFE_LOOP_NAME}.loop.local.md"
+STATE_FILE=".claude/${SAFE_LOOP_NAME}.loop.local.json"
 
 # Create .claude directory if it doesn't exist
 mkdir -p .claude
@@ -31,37 +33,64 @@ mkdir -p .claude
 EXISTING_PHASE=""
 EXISTING_BASELINE=""
 if [ -f "$STATE_FILE" ]; then
-  EXISTING_PHASE=$(grep '^phase:' "$STATE_FILE" | sed 's/phase: *//' || true)
-  EXISTING_BASELINE=$(grep '^bot_review_baseline:' "$STATE_FILE" | sed 's/bot_review_baseline: *//' || true)
+  EXISTING_PHASE=$(jq -r '.phase // empty' "$STATE_FILE" 2>/dev/null || true)
+  EXISTING_BASELINE=$(jq -r '.bot_review_baseline // empty' "$STATE_FILE" 2>/dev/null || true)
   echo "Warning: Loop '$LOOP_NAME' already active. Resetting (preserving phase: ${EXISTING_PHASE:-<none>}, baseline: ${EXISTING_BASELINE:-<none>})..."
 fi
 
 # Preserve existing phase from state file, fall back to INITIAL_PHASE for fresh runs
-# This allows re-entry to maintain phase context (e.g., watching) across stop-hook restarts
-# while INITIAL_PHASE provides a default for first-time initialization
 PHASE="${EXISTING_PHASE:-$INITIAL_PHASE}"
 
-# Create state file with YAML frontmatter
-cat > "$STATE_FILE" << EOF
----
-loop_name: $LOOP_NAME
-iteration: 1
-max_iterations: $MAX_ITERATIONS
-completion_promise: $COMPLETION_PROMISE
-phase: $PHASE
-bot_review_baseline: $EXISTING_BASELINE
-started_at: $(date -u +"%Y-%m-%dT%H:%M:%SZ")
----
+# Derive session ID from transcript path or env
+SESSION_ID=""
+if [ -n "${CLAUDE_SESSION_ID:-}" ]; then
+  SESSION_ID="$CLAUDE_SESSION_ID"
+elif [ -d ".claude" ]; then
+  # Try to find the most recent transcript file and use its name as session ID
+  LATEST_TRANSCRIPT=$(find .claude -name "*.jsonl" -maxdepth 1 2>/dev/null | sort -t/ -k2 | tail -1 || true)
+  if [ -n "$LATEST_TRANSCRIPT" ]; then
+    SESSION_ID=$(basename "$LATEST_TRANSCRIPT" .jsonl)
+  fi
+fi
 
-Persistent loop initialized for: $LOOP_NAME
-Completion promise: $COMPLETION_PROMISE
-Max iterations: ${MAX_ITERATIONS:-unlimited}
+# Build max_iterations as number or null
+MAX_ITER_JSON="null"
+if [ -n "$MAX_ITERATIONS" ]; then
+  MAX_ITER_JSON="$MAX_ITERATIONS"
+fi
 
-This loop will continue until:
-1. The completion promise <done>$COMPLETION_PROMISE</done> is output
-2. Max iterations is reached (if set)
-3. User cancels with /cancel-loop
-EOF
+# Build phase_messages as object or empty object
+PHASE_MSGS_JSON="{}"
+if [ -n "$PHASE_MESSAGES_JSON" ]; then
+  # Validate it's valid JSON
+  if echo "$PHASE_MESSAGES_JSON" | jq empty 2>/dev/null; then
+    PHASE_MSGS_JSON="$PHASE_MESSAGES_JSON"
+  fi
+fi
+
+# Create JSON state file (atomic write via temp file)
+TMP_FILE="${STATE_FILE}.tmp"
+jq -n \
+  --arg loop_name "$LOOP_NAME" \
+  --argjson iteration 1 \
+  --argjson max_iterations "$MAX_ITER_JSON" \
+  --arg completion_promise "$COMPLETION_PROMISE" \
+  --arg phase "$PHASE" \
+  --arg bot_review_baseline "${EXISTING_BASELINE:-}" \
+  --arg started_at "$(date -u +"%Y-%m-%dT%H:%M:%SZ")" \
+  --arg session_id "$SESSION_ID" \
+  --argjson phase_messages "$PHASE_MSGS_JSON" \
+  '{
+    loop_name: $loop_name,
+    iteration: $iteration,
+    max_iterations: $max_iterations,
+    completion_promise: $completion_promise,
+    phase: $phase,
+    bot_review_baseline: $bot_review_baseline,
+    started_at: $started_at,
+    session_id: $session_id,
+    phase_messages: $phase_messages
+  }' > "$TMP_FILE" && mv "$TMP_FILE" "$STATE_FILE"
 
 echo "Loop initialized: $LOOP_NAME"
 echo "Output <done>$COMPLETION_PROMISE</done> when all completion criteria are met."

--- a/plugins/tailwind/lib/loop-state.sh
+++ b/plugins/tailwind/lib/loop-state.sh
@@ -1,79 +1,129 @@
 #!/bin/bash
-# Shared functions for loop state management
+# Shared functions for loop state management (JSON-based)
 # Used by stop-hook.sh and other loop-related scripts
+# Requires: jq
 
-# Read loop state from a state file
+# Debug log file location
+LOOP_DEBUG_LOG=".claude/loop-debug.log"
+
+# Write a timestamped entry to the debug log
+loop_log() {
+  local msg="$1"
+  local ts
+  ts=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+  mkdir -p .claude
+  echo "[$ts] $msg" >> "$LOOP_DEBUG_LOG"
+}
+
+# Read loop state from a JSON state file
 # Sets global variables: ITERATION, MAX_ITERATIONS, COMPLETION_PROMISE, LOOP_NAME, PHASE, ORIGINAL_PROMPT
 read_loop_state() {
   local state_file="$1"
-  ITERATION=$(grep '^iteration:' "$state_file" | sed 's/iteration: *//')
-  MAX_ITERATIONS=$(grep '^max_iterations:' "$state_file" | sed 's/max_iterations: *//')
-  COMPLETION_PROMISE=$(grep '^completion_promise:' "$state_file" | sed 's/completion_promise: *//')
-  LOOP_NAME=$(grep '^loop_name:' "$state_file" | sed 's/loop_name: *//')
-  PHASE=$(grep '^phase:' "$state_file" | sed 's/phase: *//' || true)
-  # Get content after the second --- (the prompt/body)
-  ORIGINAL_PROMPT=$(awk '/^---$/{p++; next} p==2' "$state_file")
+  ITERATION=$(jq -r '.iteration // 0' "$state_file")
+  MAX_ITERATIONS=$(jq -r '.max_iterations // empty' "$state_file")
+  COMPLETION_PROMISE=$(jq -r '.completion_promise // empty' "$state_file")
+  LOOP_NAME=$(jq -r '.loop_name // empty' "$state_file")
+  PHASE=$(jq -r '.phase // empty' "$state_file")
+  ORIGINAL_PROMPT=$(jq -r '.original_prompt // empty' "$state_file")
+  loop_log "read_loop_state: file=$state_file loop=$LOOP_NAME iter=$ITERATION phase=$PHASE"
 }
 
-# Increment the iteration counter in a state file
+# Increment the iteration counter in a state file (atomic write via temp file)
 increment_iteration() {
   local state_file="$1"
-  local new_iteration=$((ITERATION + 1))
-
-  # Use portable sed syntax (works on both macOS and Linux)
-  if [[ "$OSTYPE" == "darwin"* ]]; then
-    sed -i '' "s/^iteration: .*/iteration: $new_iteration/" "$state_file"
-  else
-    sed -i "s/^iteration: .*/iteration: $new_iteration/" "$state_file"
-  fi
+  local tmp_file="${state_file}.tmp"
+  jq '.iteration = (.iteration + 1)' "$state_file" > "$tmp_file" && mv "$tmp_file" "$state_file"
+  loop_log "increment_iteration: file=$state_file new_iteration=$((ITERATION + 1))"
 }
 
-# Set the phase field in a state file
+# Set the phase field in a state file (atomic write via temp file)
 set_loop_phase() {
   local state_file="$1"
   local new_phase="$2"
+  local tmp_file="${state_file}.tmp"
+  jq --arg phase "$new_phase" '.phase = $phase' "$state_file" > "$tmp_file" && mv "$tmp_file" "$state_file"
+  loop_log "set_loop_phase: file=$state_file phase=$new_phase"
+}
 
-  if grep -q '^phase:' "$state_file"; then
-    if [[ "$OSTYPE" == "darwin"* ]]; then
-      sed -i '' "s/^phase: .*/phase: $new_phase/" "$state_file"
-    else
-      sed -i "s/^phase: .*/phase: $new_phase/" "$state_file"
-    fi
-  else
-    if [[ "$OSTYPE" == "darwin"* ]]; then
-      sed -i '' "/^completion_promise:/a\\
-phase: $new_phase" "$state_file"
-    else
-      sed -i "/^completion_promise:/a phase: $new_phase" "$state_file"
-    fi
-  fi
+# Get a custom field from the state file
+get_loop_field() {
+  local state_file="$1"
+  local field="$2"
+  jq -r --arg f "$field" '.[$f] // empty' "$state_file"
+}
+
+# Set a custom field in the state file (atomic write via temp file)
+set_loop_field() {
+  local state_file="$1"
+  local field="$2"
+  local value="$3"
+  local tmp_file="${state_file}.tmp"
+  jq --arg f "$field" --arg v "$value" '.[$f] = $v' "$state_file" > "$tmp_file" && mv "$tmp_file" "$state_file"
 }
 
 # Remove a loop state file (cleanup)
 cleanup_loop() {
   local state_file="$1"
+  loop_log "cleanup_loop: file=$state_file"
   rm -f "$state_file"
 }
 
 # Check if the completion promise appears in recent transcript output
+# Checks ALL text blocks in last N assistant messages (not just the last one)
 # Returns 0 if found, 1 if not found
 check_completion_promise() {
   local promise="$1"
-  local transcript=".claude/transcript.jsonl"
+  local transcript="$2"
 
-  if [ -f "$transcript" ]; then
-    # Check the last 10 lines of transcript for the completion promise
-    # The promise should be wrapped in <done>...</done> tags
-    if tail -10 "$transcript" | grep -q "<done>$promise</done>"; then
-      return 0
-    fi
+  if [ -z "$transcript" ]; then
+    transcript=".claude/transcript.jsonl"
   fi
+
+  if [ ! -f "$transcript" ]; then
+    loop_log "check_completion_promise: transcript not found at $transcript"
+    return 1
+  fi
+
+  local last_lines
+  last_lines=$(grep '"role":"assistant"' "$transcript" 2>/dev/null | tail -n 100 || true)
+
+  if [ -z "$last_lines" ]; then
+    loop_log "check_completion_promise: no assistant messages in transcript"
+    return 1
+  fi
+
+  set +e
+  local all_text
+  all_text=$(echo "$last_lines" | jq -rs '
+    [.[] | .message.content[]? | select(.type == "text") | .text] | join("\n")
+  ' 2>/dev/null)
+  local jq_exit=$?
+  set -e
+
+  if [ $jq_exit -ne 0 ]; then
+    loop_log "check_completion_promise: jq failed with exit $jq_exit"
+    return 1
+  fi
+
+  # Trim whitespace and check for promise in any text block
+  if echo "$all_text" | grep -q "<done>${promise}</done>"; then
+    loop_log "check_completion_promise: FOUND promise '$promise'"
+    return 0
+  fi
+
+  # Also check with whitespace tolerance (promise may have surrounding spaces/newlines)
+  if echo "$all_text" | sed 's/^[[:space:]]*//;s/[[:space:]]*$//' | grep -q "<done>[[:space:]]*${promise}[[:space:]]*</done>"; then
+    loop_log "check_completion_promise: FOUND promise '$promise' (with whitespace)"
+    return 0
+  fi
+
+  loop_log "check_completion_promise: NOT found promise '$promise'"
   return 1
 }
 
 # Find all active loop state files
 find_active_loops() {
-  find .claude -name "*.loop.local.md" 2>/dev/null
+  find .claude -name "*.loop.local.json" 2>/dev/null
 }
 
 # Get the count of active loops

--- a/plugins/tailwind/scripts/cleanup-loop.sh
+++ b/plugins/tailwind/scripts/cleanup-loop.sh
@@ -12,7 +12,7 @@ LOOP_NAME="${1:-}"
 if [ -n "$LOOP_NAME" ]; then
   # Clean up specific loop
   SAFE_LOOP_NAME=$(echo "$LOOP_NAME" | sed 's/[^a-zA-Z0-9_-]/-/g')
-  STATE_FILE=".claude/${SAFE_LOOP_NAME}.loop.local.md"
+  STATE_FILE=".claude/${SAFE_LOOP_NAME}.loop.local.json"
 
   if [ -f "$STATE_FILE" ]; then
     rm -f "$STATE_FILE"
@@ -22,13 +22,13 @@ if [ -n "$LOOP_NAME" ]; then
   fi
 else
   # Clean up all loops
-  LOOP_FILES=$(find .claude -name "*.loop.local.md" 2>/dev/null || true)
+  LOOP_FILES=$(find .claude -name "*.loop.local.json" 2>/dev/null || true)
 
   if [ -z "$LOOP_FILES" ]; then
     echo "No active loops found."
   else
     echo "$LOOP_FILES" | while read -r file; do
-      loop_name=$(grep '^loop_name:' "$file" 2>/dev/null | sed 's/loop_name: *//' || echo "unknown")
+      loop_name=$(jq -r '.loop_name // "unknown"' "$file" 2>/dev/null || echo "unknown")
       rm -f "$file"
       echo "Cancelled loop: $loop_name"
     done

--- a/plugins/tailwind/scripts/setup-loop.sh
+++ b/plugins/tailwind/scripts/setup-loop.sh
@@ -1,28 +1,30 @@
 #!/bin/bash
-# Initialize a persistent loop for any command
-# Usage: setup-loop.sh <loop-name> <completion-promise> [max-iterations] [initial-phase]
+# Initialize a persistent loop for any command (JSON-based)
+# Usage: setup-loop.sh <loop-name> <completion-promise> [max-iterations] [initial-phase] [phase-messages-json]
 #
 # Example:
 #   setup-loop.sh "start-issue-123" "COMPLETE"
 #   setup-loop.sh "create-project" "DONE" 50
 #   setup-loop.sh "address-review-42" "COMPLETE" "" "fixing"
+#   setup-loop.sh "ship" "SHIPPED" 50 "" '{"reviewing":"Resume LLM review pass."}'
 
 set -euo pipefail
 
 LOOP_NAME="${1:-}"
 COMPLETION_PROMISE="${2:-COMPLETE}"
-MAX_ITERATIONS="${3:-}"  # Optional, defaults to unlimited
+MAX_ITERATIONS="${3:-}"  # Optional, defaults to null
 INITIAL_PHASE="${4:-}"   # Optional, defaults to empty
+PHASE_MESSAGES_JSON="${5:-}"  # Optional JSON object of phase->message mappings
 
 if [ -z "$LOOP_NAME" ]; then
   echo "Error: loop-name is required"
-  echo "Usage: setup-loop.sh <loop-name> <completion-promise> [max-iterations] [initial-phase]"
+  echo "Usage: setup-loop.sh <loop-name> <completion-promise> [max-iterations] [initial-phase] [phase-messages-json]"
   exit 1
 fi
 
 # Sanitize loop name for use in filename
 SAFE_LOOP_NAME=$(echo "$LOOP_NAME" | sed 's/[^a-zA-Z0-9_-]/-/g')
-STATE_FILE=".claude/${SAFE_LOOP_NAME}.loop.local.md"
+STATE_FILE=".claude/${SAFE_LOOP_NAME}.loop.local.json"
 
 # Create .claude directory if it doesn't exist
 mkdir -p .claude
@@ -31,37 +33,64 @@ mkdir -p .claude
 EXISTING_PHASE=""
 EXISTING_BASELINE=""
 if [ -f "$STATE_FILE" ]; then
-  EXISTING_PHASE=$(grep '^phase:' "$STATE_FILE" | sed 's/phase: *//' || true)
-  EXISTING_BASELINE=$(grep '^bot_review_baseline:' "$STATE_FILE" | sed 's/bot_review_baseline: *//' || true)
+  EXISTING_PHASE=$(jq -r '.phase // empty' "$STATE_FILE" 2>/dev/null || true)
+  EXISTING_BASELINE=$(jq -r '.bot_review_baseline // empty' "$STATE_FILE" 2>/dev/null || true)
   echo "Warning: Loop '$LOOP_NAME' already active. Resetting (preserving phase: ${EXISTING_PHASE:-<none>}, baseline: ${EXISTING_BASELINE:-<none>})..."
 fi
 
 # Preserve existing phase from state file, fall back to INITIAL_PHASE for fresh runs
-# This allows re-entry to maintain phase context (e.g., watching) across stop-hook restarts
-# while INITIAL_PHASE provides a default for first-time initialization
 PHASE="${EXISTING_PHASE:-$INITIAL_PHASE}"
 
-# Create state file with YAML frontmatter
-cat > "$STATE_FILE" << EOF
----
-loop_name: $LOOP_NAME
-iteration: 1
-max_iterations: $MAX_ITERATIONS
-completion_promise: $COMPLETION_PROMISE
-phase: $PHASE
-bot_review_baseline: $EXISTING_BASELINE
-started_at: $(date -u +"%Y-%m-%dT%H:%M:%SZ")
----
+# Derive session ID from transcript path or env
+SESSION_ID=""
+if [ -n "${CLAUDE_SESSION_ID:-}" ]; then
+  SESSION_ID="$CLAUDE_SESSION_ID"
+elif [ -d ".claude" ]; then
+  # Try to find the most recent transcript file and use its name as session ID
+  LATEST_TRANSCRIPT=$(find .claude -name "*.jsonl" -maxdepth 1 2>/dev/null | sort -t/ -k2 | tail -1 || true)
+  if [ -n "$LATEST_TRANSCRIPT" ]; then
+    SESSION_ID=$(basename "$LATEST_TRANSCRIPT" .jsonl)
+  fi
+fi
 
-Persistent loop initialized for: $LOOP_NAME
-Completion promise: $COMPLETION_PROMISE
-Max iterations: ${MAX_ITERATIONS:-unlimited}
+# Build max_iterations as number or null
+MAX_ITER_JSON="null"
+if [ -n "$MAX_ITERATIONS" ]; then
+  MAX_ITER_JSON="$MAX_ITERATIONS"
+fi
 
-This loop will continue until:
-1. The completion promise <done>$COMPLETION_PROMISE</done> is output
-2. Max iterations is reached (if set)
-3. User cancels with /cancel-loop
-EOF
+# Build phase_messages as object or empty object
+PHASE_MSGS_JSON="{}"
+if [ -n "$PHASE_MESSAGES_JSON" ]; then
+  # Validate it's valid JSON
+  if echo "$PHASE_MESSAGES_JSON" | jq empty 2>/dev/null; then
+    PHASE_MSGS_JSON="$PHASE_MESSAGES_JSON"
+  fi
+fi
+
+# Create JSON state file (atomic write via temp file)
+TMP_FILE="${STATE_FILE}.tmp"
+jq -n \
+  --arg loop_name "$LOOP_NAME" \
+  --argjson iteration 1 \
+  --argjson max_iterations "$MAX_ITER_JSON" \
+  --arg completion_promise "$COMPLETION_PROMISE" \
+  --arg phase "$PHASE" \
+  --arg bot_review_baseline "${EXISTING_BASELINE:-}" \
+  --arg started_at "$(date -u +"%Y-%m-%dT%H:%M:%SZ")" \
+  --arg session_id "$SESSION_ID" \
+  --argjson phase_messages "$PHASE_MSGS_JSON" \
+  '{
+    loop_name: $loop_name,
+    iteration: $iteration,
+    max_iterations: $max_iterations,
+    completion_promise: $completion_promise,
+    phase: $phase,
+    bot_review_baseline: $bot_review_baseline,
+    started_at: $started_at,
+    session_id: $session_id,
+    phase_messages: $phase_messages
+  }' > "$TMP_FILE" && mv "$TMP_FILE" "$STATE_FILE"
 
 echo "Loop initialized: $LOOP_NAME"
 echo "Output <done>$COMPLETION_PROMISE</done> when all completion criteria are met."

--- a/scripts/test-loop-state.sh
+++ b/scripts/test-loop-state.sh
@@ -1,0 +1,131 @@
+#!/bin/bash
+# Test script for JSON-based loop state functions
+# Exercises read/write/increment/phase-set on JSON state files
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+cd "$ROOT_DIR"
+
+source shared/lib/loop-state.sh
+
+PASS=0
+FAIL=0
+
+assert_eq() {
+  local label="$1" expected="$2" actual="$3"
+  if [ "$expected" = "$actual" ]; then
+    echo "  PASS: $label"
+    PASS=$((PASS + 1))
+  else
+    echo "  FAIL: $label (expected='$expected', actual='$actual')"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+echo "=== Loop State JSON Tests ==="
+echo ""
+
+# --- Test 1: setup-loop creates valid JSON ---
+echo "Test 1: setup-loop.sh creates valid JSON"
+rm -f .claude/test-loop.loop.local.json
+./shared/scripts/setup-loop.sh "test-loop" "TEST_DONE" 10 "init" '{"init":"Start the task.","fixing":"Fix the issues."}' > /dev/null
+assert_eq "state file exists" "true" "$([ -f .claude/test-loop.loop.local.json ] && echo true || echo false)"
+assert_eq "valid JSON" "true" "$(jq empty .claude/test-loop.loop.local.json 2>/dev/null && echo true || echo false)"
+assert_eq "loop_name" "test-loop" "$(jq -r '.loop_name' .claude/test-loop.loop.local.json)"
+assert_eq "iteration" "1" "$(jq -r '.iteration' .claude/test-loop.loop.local.json)"
+assert_eq "max_iterations" "10" "$(jq -r '.max_iterations' .claude/test-loop.loop.local.json)"
+assert_eq "completion_promise" "TEST_DONE" "$(jq -r '.completion_promise' .claude/test-loop.loop.local.json)"
+assert_eq "phase" "init" "$(jq -r '.phase' .claude/test-loop.loop.local.json)"
+assert_eq "session_id field exists" "true" "$(jq -e 'has("session_id")' .claude/test-loop.loop.local.json >/dev/null 2>&1 && echo true || echo false)"
+assert_eq "phase_messages.init" "Start the task." "$(jq -r '.phase_messages.init' .claude/test-loop.loop.local.json)"
+assert_eq "phase_messages.fixing" "Fix the issues." "$(jq -r '.phase_messages.fixing' .claude/test-loop.loop.local.json)"
+echo ""
+
+# --- Test 2: read_loop_state ---
+echo "Test 2: read_loop_state reads JSON correctly"
+read_loop_state ".claude/test-loop.loop.local.json"
+assert_eq "LOOP_NAME" "test-loop" "$LOOP_NAME"
+assert_eq "ITERATION" "1" "$ITERATION"
+assert_eq "MAX_ITERATIONS" "10" "$MAX_ITERATIONS"
+assert_eq "COMPLETION_PROMISE" "TEST_DONE" "$COMPLETION_PROMISE"
+assert_eq "PHASE" "init" "$PHASE"
+echo ""
+
+# --- Test 3: increment_iteration ---
+echo "Test 3: increment_iteration"
+increment_iteration ".claude/test-loop.loop.local.json"
+assert_eq "iteration after increment" "2" "$(jq -r '.iteration' .claude/test-loop.loop.local.json)"
+increment_iteration ".claude/test-loop.loop.local.json"
+assert_eq "iteration after 2nd increment" "3" "$(jq -r '.iteration' .claude/test-loop.loop.local.json)"
+echo ""
+
+# --- Test 4: set_loop_phase ---
+echo "Test 4: set_loop_phase"
+set_loop_phase ".claude/test-loop.loop.local.json" "fixing"
+assert_eq "phase after set" "fixing" "$(jq -r '.phase' .claude/test-loop.loop.local.json)"
+set_loop_phase ".claude/test-loop.loop.local.json" "watching"
+assert_eq "phase after 2nd set" "watching" "$(jq -r '.phase' .claude/test-loop.loop.local.json)"
+echo ""
+
+# --- Test 5: get/set custom fields ---
+echo "Test 5: get_loop_field / set_loop_field"
+set_loop_field ".claude/test-loop.loop.local.json" "pr_number" "42"
+assert_eq "pr_number set" "42" "$(get_loop_field .claude/test-loop.loop.local.json pr_number)"
+set_loop_field ".claude/test-loop.loop.local.json" "discovered_bots" "coderabbitai[bot],copilot[bot]"
+assert_eq "discovered_bots" "coderabbitai[bot],copilot[bot]" "$(get_loop_field .claude/test-loop.loop.local.json discovered_bots)"
+echo ""
+
+# --- Test 6: find_active_loops ---
+echo "Test 6: find_active_loops"
+COUNT=$(count_active_loops)
+assert_eq "at least 1 active loop" "true" "$([ "$COUNT" -ge 1 ] && echo true || echo false)"
+echo ""
+
+# --- Test 7: cleanup_loop ---
+echo "Test 7: cleanup_loop"
+cleanup_loop ".claude/test-loop.loop.local.json"
+assert_eq "state file removed" "false" "$([ -f .claude/test-loop.loop.local.json ] && echo true || echo false)"
+echo ""
+
+# --- Test 8: cleanup-loop.sh by name ---
+echo "Test 8: cleanup-loop.sh specific loop"
+./shared/scripts/setup-loop.sh "cleanup-test" "DONE" > /dev/null
+assert_eq "created" "true" "$([ -f .claude/cleanup-test.loop.local.json ] && echo true || echo false)"
+./shared/scripts/cleanup-loop.sh "cleanup-test" > /dev/null
+assert_eq "removed" "false" "$([ -f .claude/cleanup-test.loop.local.json ] && echo true || echo false)"
+echo ""
+
+# --- Test 9: setup-loop preserves phase on re-init ---
+echo "Test 9: setup-loop preserves phase on re-init"
+./shared/scripts/setup-loop.sh "reinit-test" "DONE" 5 "initial" > /dev/null
+set_loop_phase ".claude/reinit-test.loop.local.json" "watching"
+./shared/scripts/setup-loop.sh "reinit-test" "DONE" 5 "initial" > /dev/null 2>&1
+assert_eq "phase preserved" "watching" "$(jq -r '.phase' .claude/reinit-test.loop.local.json)"
+cleanup_loop ".claude/reinit-test.loop.local.json"
+echo ""
+
+# --- Test 10: atomic writes don't corrupt on concurrent access ---
+echo "Test 10: no .tmp files left behind"
+./shared/scripts/setup-loop.sh "tmp-test" "DONE" > /dev/null
+set_loop_phase ".claude/tmp-test.loop.local.json" "phase1"
+increment_iteration ".claude/tmp-test.loop.local.json"
+set_loop_field ".claude/tmp-test.loop.local.json" "custom" "value"
+TMP_COUNT=$(find .claude -name "*.tmp" 2>/dev/null | wc -l | tr -d ' ')
+assert_eq "no tmp files" "0" "$TMP_COUNT"
+cleanup_loop ".claude/tmp-test.loop.local.json"
+echo ""
+
+# --- Cleanup debug log ---
+rm -f .claude/loop-debug.log
+
+# --- Summary ---
+echo "==========================="
+echo "Results: $PASS passed, $FAIL failed"
+if [ "$FAIL" -gt 0 ]; then
+  echo "TESTS FAILED"
+  exit 1
+fi
+echo "ALL TESTS PASSED"

--- a/shared/hooks/stop-hook.sh
+++ b/shared/hooks/stop-hook.sh
@@ -1,10 +1,10 @@
 #!/bin/bash
-# Generic stop hook - works for any plugin using loop state files
+# Generic stop hook - works for any plugin using loop state files (JSON-based)
 # This hook intercepts session exit and re-feeds the prompt until completion criteria are met.
 #
 # How it works:
 # 1. Read hook input from stdin to get transcript path
-# 2. Check for any active loop state files (.claude/*.loop.local.md)
+# 2. Check for any active loop state files (.claude/*.loop.local.json)
 # 3. If no active loop, allow normal exit
 # 4. If loop active, check for completion (max iterations or completion promise in transcript)
 # 5. If not complete, block exit and re-feed the prompt
@@ -24,17 +24,18 @@ SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 LIB_PATH="$SCRIPT_DIR/../lib/loop-state.sh"
 
 if [ ! -f "$LIB_PATH" ]; then
-  # Library not found - allow exit to prevent broken state
   exit 0
 fi
 
 source "$LIB_PATH"
 
+loop_log "stop-hook: entered, transcript=$TRANSCRIPT_PATH"
+
 # Find any active loop state file
 STATE_FILES=$(find_active_loops)
 
 if [ -z "$STATE_FILES" ]; then
-  # No active loop - allow normal exit
+  loop_log "stop-hook: no active loops found"
   exit 0
 fi
 
@@ -43,6 +44,14 @@ STATE_FILE=$(echo "$STATE_FILES" | head -1)
 
 # Verify state file exists and is readable
 if [ ! -f "$STATE_FILE" ] || [ ! -r "$STATE_FILE" ]; then
+  loop_log "stop-hook: state file not readable: $STATE_FILE"
+  exit 0
+fi
+
+# Validate JSON before proceeding
+if ! jq empty "$STATE_FILE" 2>/dev/null; then
+  loop_log "stop-hook: invalid JSON in state file, cleaning up: $STATE_FILE"
+  cleanup_loop "$STATE_FILE"
   exit 0
 fi
 
@@ -50,10 +59,21 @@ fi
 read_loop_state "$STATE_FILE"
 
 # Check if loop is stale (from a previous session)
-# Compare state file's started_at against the current transcript file's creation time.
-# If the transcript is newer than the loop, the loop is from a dead session.
+# Primary: Compare session ID (portable, instant)
+STORED_SESSION_ID=$(jq -r '.session_id // empty' "$STATE_FILE")
+
+if [ -n "$STORED_SESSION_ID" ] && [ -n "$TRANSCRIPT_PATH" ]; then
+  CURRENT_SESSION_ID=$(basename "$TRANSCRIPT_PATH" .jsonl 2>/dev/null || true)
+  if [ -n "$CURRENT_SESSION_ID" ] && [ "$STORED_SESSION_ID" != "$CURRENT_SESSION_ID" ]; then
+    loop_log "stop-hook: stale session detected (stored=$STORED_SESSION_ID current=$CURRENT_SESSION_ID), cleaning up"
+    cleanup_loop "$STATE_FILE"
+    exit 0
+  fi
+fi
+
+# Fallback: Timestamp-based stale detection
 if [ -n "$TRANSCRIPT_PATH" ] && [ -f "$TRANSCRIPT_PATH" ]; then
-  STARTED_AT=$(grep '^started_at:' "$STATE_FILE" | sed 's/started_at: *//')
+  STARTED_AT=$(jq -r '.started_at // empty' "$STATE_FILE")
   if [ -n "$STARTED_AT" ]; then
     if [[ "$OSTYPE" == "darwin"* ]]; then
       TRANSCRIPT_BIRTH=$(stat -f %B "$TRANSCRIPT_PATH" 2>/dev/null || echo "0")
@@ -63,6 +83,7 @@ if [ -n "$TRANSCRIPT_PATH" ] && [ -f "$TRANSCRIPT_PATH" ]; then
       LOOP_EPOCH=$(date -d "$STARTED_AT" +%s 2>/dev/null || echo "0")
     fi
     if [ "$LOOP_EPOCH" -gt 0 ] && [ "$TRANSCRIPT_BIRTH" -gt 0 ] && [ "$TRANSCRIPT_BIRTH" -gt "$LOOP_EPOCH" ]; then
+      loop_log "stop-hook: stale loop detected via timestamp (loop=$STARTED_AT transcript_birth=$TRANSCRIPT_BIRTH)"
       cleanup_loop "$STATE_FILE"
       exit 0
     fi
@@ -71,7 +92,7 @@ fi
 
 # Validate iteration is a number
 if ! [[ "$ITERATION" =~ ^[0-9]+$ ]]; then
-  # Invalid state - cleanup and allow exit
+  loop_log "stop-hook: invalid iteration '$ITERATION', cleaning up"
   cleanup_loop "$STATE_FILE"
   exit 0
 fi
@@ -79,27 +100,19 @@ fi
 # Check if max iterations reached (if set)
 if [ -n "$MAX_ITERATIONS" ] && [[ "$MAX_ITERATIONS" =~ ^[0-9]+$ ]]; then
   if [ "$ITERATION" -ge "$MAX_ITERATIONS" ]; then
+    loop_log "stop-hook: max iterations reached ($ITERATION >= $MAX_ITERATIONS)"
     cleanup_loop "$STATE_FILE"
     exit 0
   fi
 fi
 
-# Check for completion promise in transcript
+# Check for completion promise in transcript (robust: all text blocks, whitespace-tolerant)
 if [ -n "$COMPLETION_PROMISE" ] && [ -n "$TRANSCRIPT_PATH" ] && [ -f "$TRANSCRIPT_PATH" ]; then
-  LAST_LINES=$(grep '"role":"assistant"' "$TRANSCRIPT_PATH" 2>/dev/null | tail -n 100 || true)
-
-  if [ -n "$LAST_LINES" ]; then
-    set +e
-    LAST_OUTPUT=$(echo "$LAST_LINES" | jq -rs '
-      map(.message.content[]? | select(.type == "text") | .text) | last // ""
-    ' 2>&1)
-    JQ_EXIT=$?
-    set -e
-
-    if [ $JQ_EXIT -eq 0 ] && echo "$LAST_OUTPUT" | grep -q "<done>$COMPLETION_PROMISE</done>"; then
-      cleanup_loop "$STATE_FILE"
-      exit 0
-    fi
+  loop_log "stop-hook: checking completion promise '$COMPLETION_PROMISE'"
+  if check_completion_promise "$COMPLETION_PROMISE" "$TRANSCRIPT_PATH"; then
+    loop_log "stop-hook: completion promise found, cleaning up"
+    cleanup_loop "$STATE_FILE"
+    exit 0
   fi
 fi
 
@@ -110,37 +123,61 @@ NEW_ITERATION=$((ITERATION + 1))
 # Build system message with iteration info and guidance
 SYSTEM_MSG="Iteration $NEW_ITERATION of loop '$LOOP_NAME'."
 
-# Phase-aware re-feed: use targeted message based on current phase
-if [ "$PHASE" = "watching" ]; then
-  REASON="Resume Step 12: Check bot approval status, poll if needed. Do NOT re-run Steps 1-11."
-  SYSTEM_MSG="$SYSTEM_MSG RESUME AT STEP 12a: The fix cycle (Steps 1-11) is already complete. Check bot approval status and poll for re-reviews. Do NOT restart the fix cycle."
-elif [ "$PHASE" = "reviewing" ]; then
-  REASON="Continue the review loop: run the next LLM review pass and address findings."
-  SYSTEM_MSG="$SYSTEM_MSG Resume the review-fix-verify cycle. Run the next review pass."
-elif [ "$PHASE" = "fixing" ]; then
-  REASON="Continue fixing: address remaining review findings, then verify."
-  SYSTEM_MSG="$SYSTEM_MSG Continue addressing review findings."
-elif [ "$PHASE" = "verifying" ]; then
-  REASON="Continue verification: run build, test, and lint on fixes."
-  SYSTEM_MSG="$SYSTEM_MSG Verify fixes pass build, test, and lint."
-elif [ "$PHASE" = "bot-watching" ]; then
-  REASON="Resume: poll for bot review approval or new feedback."
-  SYSTEM_MSG="$SYSTEM_MSG Resume bot approval polling (Step 11). Check discovered bots for approval status. If bots request changes, go to Step 12. If all approved, go to Step 13."
-elif [ "$PHASE" = "addressing" ]; then
-  REASON="Resume: address bot review feedback, then re-watch CI and bots."
-  SYSTEM_MSG="$SYSTEM_MSG Resume addressing bot review feedback (Steps 2-11 of address-review). After fixes, return to CI watch."
-elif [ "$PHASE" = "pushing" ]; then
-  REASON="Resume: push changes and ensure PR exists."
-  SYSTEM_MSG="$SYSTEM_MSG Resume pushing changes to remote and PR creation/detection."
-elif [ "$PHASE" = "ci-watch" ]; then
-  REASON="Resume: watch CI status and fix failures."
-  SYSTEM_MSG="$SYSTEM_MSG Resume CI monitoring. Run gh pr checks and fix any failures."
-elif [ "$PHASE" = "merging" ]; then
-  REASON="Resume: merge the PR."
-  SYSTEM_MSG="$SYSTEM_MSG Verify CI green and bot approval, then merge the PR."
+# Phase-aware re-feed: look up phase message from state file, fall back to generic
+PHASE_MSG=""
+if [ -n "$PHASE" ]; then
+  PHASE_MSG=$(jq -r --arg p "$PHASE" '.phase_messages[$p] // empty' "$STATE_FILE" 2>/dev/null || true)
+fi
+
+if [ -n "$PHASE_MSG" ]; then
+  REASON="$PHASE_MSG"
+  SYSTEM_MSG="$SYSTEM_MSG $PHASE_MSG"
+  loop_log "stop-hook: phase '$PHASE' matched phase_messages entry"
 else
-  REASON="$ORIGINAL_PROMPT"
-  SYSTEM_MSG="$SYSTEM_MSG Continue working on the task."
+  # Fallback to generic phase messages for backward compatibility
+  case "$PHASE" in
+    watching)
+      REASON="Resume Step 12: Check bot approval status, poll if needed. Do NOT re-run Steps 1-11."
+      SYSTEM_MSG="$SYSTEM_MSG RESUME AT STEP 12a: The fix cycle (Steps 1-11) is already complete. Check bot approval status and poll for re-reviews. Do NOT restart the fix cycle."
+      ;;
+    reviewing)
+      REASON="Continue the review loop: run the next LLM review pass and address findings."
+      SYSTEM_MSG="$SYSTEM_MSG Resume the review-fix-verify cycle. Run the next review pass."
+      ;;
+    fixing)
+      REASON="Continue fixing: address remaining review findings, then verify."
+      SYSTEM_MSG="$SYSTEM_MSG Continue addressing review findings."
+      ;;
+    verifying)
+      REASON="Continue verification: run build, test, and lint on fixes."
+      SYSTEM_MSG="$SYSTEM_MSG Verify fixes pass build, test, and lint."
+      ;;
+    bot-watching)
+      REASON="Resume: poll for bot review approval or new feedback."
+      SYSTEM_MSG="$SYSTEM_MSG Resume bot approval polling (Step 11). Check discovered bots for approval status. If bots request changes, go to Step 12. If all approved, go to Step 13."
+      ;;
+    addressing)
+      REASON="Resume: address bot review feedback, then re-watch CI and bots."
+      SYSTEM_MSG="$SYSTEM_MSG Resume addressing bot review feedback (Steps 2-11 of address-review). After fixes, return to CI watch."
+      ;;
+    pushing)
+      REASON="Resume: push changes and ensure PR exists."
+      SYSTEM_MSG="$SYSTEM_MSG Resume pushing changes to remote and PR creation/detection."
+      ;;
+    ci-watch)
+      REASON="Resume: watch CI status and fix failures."
+      SYSTEM_MSG="$SYSTEM_MSG Resume CI monitoring. Run gh pr checks and fix any failures."
+      ;;
+    merging)
+      REASON="Resume: merge the PR."
+      SYSTEM_MSG="$SYSTEM_MSG Verify CI green and bot approval, then merge the PR."
+      ;;
+    *)
+      REASON="$ORIGINAL_PROMPT"
+      SYSTEM_MSG="$SYSTEM_MSG Continue working on the task."
+      ;;
+  esac
+  loop_log "stop-hook: phase '$PHASE' used fallback message"
 fi
 
 # Add guidance after many iterations
@@ -149,6 +186,8 @@ if [ "$NEW_ITERATION" -ge 15 ]; then
 fi
 
 SYSTEM_MSG="$SYSTEM_MSG Output <done>$COMPLETION_PROMISE</done> ONLY when ALL completion criteria are met."
+
+loop_log "stop-hook: blocking exit, reason='$REASON'"
 
 # Block exit and re-feed prompt
 jq -n --arg reason "$REASON" --arg msg "$SYSTEM_MSG" \

--- a/shared/lib/loop-state.sh
+++ b/shared/lib/loop-state.sh
@@ -1,79 +1,129 @@
 #!/bin/bash
-# Shared functions for loop state management
+# Shared functions for loop state management (JSON-based)
 # Used by stop-hook.sh and other loop-related scripts
+# Requires: jq
 
-# Read loop state from a state file
+# Debug log file location
+LOOP_DEBUG_LOG=".claude/loop-debug.log"
+
+# Write a timestamped entry to the debug log
+loop_log() {
+  local msg="$1"
+  local ts
+  ts=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+  mkdir -p .claude
+  echo "[$ts] $msg" >> "$LOOP_DEBUG_LOG"
+}
+
+# Read loop state from a JSON state file
 # Sets global variables: ITERATION, MAX_ITERATIONS, COMPLETION_PROMISE, LOOP_NAME, PHASE, ORIGINAL_PROMPT
 read_loop_state() {
   local state_file="$1"
-  ITERATION=$(grep '^iteration:' "$state_file" | sed 's/iteration: *//')
-  MAX_ITERATIONS=$(grep '^max_iterations:' "$state_file" | sed 's/max_iterations: *//')
-  COMPLETION_PROMISE=$(grep '^completion_promise:' "$state_file" | sed 's/completion_promise: *//')
-  LOOP_NAME=$(grep '^loop_name:' "$state_file" | sed 's/loop_name: *//')
-  PHASE=$(grep '^phase:' "$state_file" | sed 's/phase: *//' || true)
-  # Get content after the second --- (the prompt/body)
-  ORIGINAL_PROMPT=$(awk '/^---$/{p++; next} p==2' "$state_file")
+  ITERATION=$(jq -r '.iteration // 0' "$state_file")
+  MAX_ITERATIONS=$(jq -r '.max_iterations // empty' "$state_file")
+  COMPLETION_PROMISE=$(jq -r '.completion_promise // empty' "$state_file")
+  LOOP_NAME=$(jq -r '.loop_name // empty' "$state_file")
+  PHASE=$(jq -r '.phase // empty' "$state_file")
+  ORIGINAL_PROMPT=$(jq -r '.original_prompt // empty' "$state_file")
+  loop_log "read_loop_state: file=$state_file loop=$LOOP_NAME iter=$ITERATION phase=$PHASE"
 }
 
-# Increment the iteration counter in a state file
+# Increment the iteration counter in a state file (atomic write via temp file)
 increment_iteration() {
   local state_file="$1"
-  local new_iteration=$((ITERATION + 1))
-
-  # Use portable sed syntax (works on both macOS and Linux)
-  if [[ "$OSTYPE" == "darwin"* ]]; then
-    sed -i '' "s/^iteration: .*/iteration: $new_iteration/" "$state_file"
-  else
-    sed -i "s/^iteration: .*/iteration: $new_iteration/" "$state_file"
-  fi
+  local tmp_file="${state_file}.tmp"
+  jq '.iteration = (.iteration + 1)' "$state_file" > "$tmp_file" && mv "$tmp_file" "$state_file"
+  loop_log "increment_iteration: file=$state_file new_iteration=$((ITERATION + 1))"
 }
 
-# Set the phase field in a state file
+# Set the phase field in a state file (atomic write via temp file)
 set_loop_phase() {
   local state_file="$1"
   local new_phase="$2"
+  local tmp_file="${state_file}.tmp"
+  jq --arg phase "$new_phase" '.phase = $phase' "$state_file" > "$tmp_file" && mv "$tmp_file" "$state_file"
+  loop_log "set_loop_phase: file=$state_file phase=$new_phase"
+}
 
-  if grep -q '^phase:' "$state_file"; then
-    if [[ "$OSTYPE" == "darwin"* ]]; then
-      sed -i '' "s/^phase: .*/phase: $new_phase/" "$state_file"
-    else
-      sed -i "s/^phase: .*/phase: $new_phase/" "$state_file"
-    fi
-  else
-    if [[ "$OSTYPE" == "darwin"* ]]; then
-      sed -i '' "/^completion_promise:/a\\
-phase: $new_phase" "$state_file"
-    else
-      sed -i "/^completion_promise:/a phase: $new_phase" "$state_file"
-    fi
-  fi
+# Get a custom field from the state file
+get_loop_field() {
+  local state_file="$1"
+  local field="$2"
+  jq -r --arg f "$field" '.[$f] // empty' "$state_file"
+}
+
+# Set a custom field in the state file (atomic write via temp file)
+set_loop_field() {
+  local state_file="$1"
+  local field="$2"
+  local value="$3"
+  local tmp_file="${state_file}.tmp"
+  jq --arg f "$field" --arg v "$value" '.[$f] = $v' "$state_file" > "$tmp_file" && mv "$tmp_file" "$state_file"
 }
 
 # Remove a loop state file (cleanup)
 cleanup_loop() {
   local state_file="$1"
+  loop_log "cleanup_loop: file=$state_file"
   rm -f "$state_file"
 }
 
 # Check if the completion promise appears in recent transcript output
+# Checks ALL text blocks in last N assistant messages (not just the last one)
 # Returns 0 if found, 1 if not found
 check_completion_promise() {
   local promise="$1"
-  local transcript=".claude/transcript.jsonl"
+  local transcript="$2"
 
-  if [ -f "$transcript" ]; then
-    # Check the last 10 lines of transcript for the completion promise
-    # The promise should be wrapped in <done>...</done> tags
-    if tail -10 "$transcript" | grep -q "<done>$promise</done>"; then
-      return 0
-    fi
+  if [ -z "$transcript" ]; then
+    transcript=".claude/transcript.jsonl"
   fi
+
+  if [ ! -f "$transcript" ]; then
+    loop_log "check_completion_promise: transcript not found at $transcript"
+    return 1
+  fi
+
+  local last_lines
+  last_lines=$(grep '"role":"assistant"' "$transcript" 2>/dev/null | tail -n 100 || true)
+
+  if [ -z "$last_lines" ]; then
+    loop_log "check_completion_promise: no assistant messages in transcript"
+    return 1
+  fi
+
+  set +e
+  local all_text
+  all_text=$(echo "$last_lines" | jq -rs '
+    [.[] | .message.content[]? | select(.type == "text") | .text] | join("\n")
+  ' 2>/dev/null)
+  local jq_exit=$?
+  set -e
+
+  if [ $jq_exit -ne 0 ]; then
+    loop_log "check_completion_promise: jq failed with exit $jq_exit"
+    return 1
+  fi
+
+  # Trim whitespace and check for promise in any text block
+  if echo "$all_text" | grep -q "<done>${promise}</done>"; then
+    loop_log "check_completion_promise: FOUND promise '$promise'"
+    return 0
+  fi
+
+  # Also check with whitespace tolerance (promise may have surrounding spaces/newlines)
+  if echo "$all_text" | sed 's/^[[:space:]]*//;s/[[:space:]]*$//' | grep -q "<done>[[:space:]]*${promise}[[:space:]]*</done>"; then
+    loop_log "check_completion_promise: FOUND promise '$promise' (with whitespace)"
+    return 0
+  fi
+
+  loop_log "check_completion_promise: NOT found promise '$promise'"
   return 1
 }
 
 # Find all active loop state files
 find_active_loops() {
-  find .claude -name "*.loop.local.md" 2>/dev/null
+  find .claude -name "*.loop.local.json" 2>/dev/null
 }
 
 # Get the count of active loops

--- a/shared/scripts/cleanup-loop.sh
+++ b/shared/scripts/cleanup-loop.sh
@@ -12,7 +12,7 @@ LOOP_NAME="${1:-}"
 if [ -n "$LOOP_NAME" ]; then
   # Clean up specific loop
   SAFE_LOOP_NAME=$(echo "$LOOP_NAME" | sed 's/[^a-zA-Z0-9_-]/-/g')
-  STATE_FILE=".claude/${SAFE_LOOP_NAME}.loop.local.md"
+  STATE_FILE=".claude/${SAFE_LOOP_NAME}.loop.local.json"
 
   if [ -f "$STATE_FILE" ]; then
     rm -f "$STATE_FILE"
@@ -22,13 +22,13 @@ if [ -n "$LOOP_NAME" ]; then
   fi
 else
   # Clean up all loops
-  LOOP_FILES=$(find .claude -name "*.loop.local.md" 2>/dev/null || true)
+  LOOP_FILES=$(find .claude -name "*.loop.local.json" 2>/dev/null || true)
 
   if [ -z "$LOOP_FILES" ]; then
     echo "No active loops found."
   else
     echo "$LOOP_FILES" | while read -r file; do
-      loop_name=$(grep '^loop_name:' "$file" 2>/dev/null | sed 's/loop_name: *//' || echo "unknown")
+      loop_name=$(jq -r '.loop_name // "unknown"' "$file" 2>/dev/null || echo "unknown")
       rm -f "$file"
       echo "Cancelled loop: $loop_name"
     done

--- a/shared/scripts/setup-loop.sh
+++ b/shared/scripts/setup-loop.sh
@@ -1,28 +1,30 @@
 #!/bin/bash
-# Initialize a persistent loop for any command
-# Usage: setup-loop.sh <loop-name> <completion-promise> [max-iterations] [initial-phase]
+# Initialize a persistent loop for any command (JSON-based)
+# Usage: setup-loop.sh <loop-name> <completion-promise> [max-iterations] [initial-phase] [phase-messages-json]
 #
 # Example:
 #   setup-loop.sh "start-issue-123" "COMPLETE"
 #   setup-loop.sh "create-project" "DONE" 50
 #   setup-loop.sh "address-review-42" "COMPLETE" "" "fixing"
+#   setup-loop.sh "ship" "SHIPPED" 50 "" '{"reviewing":"Resume LLM review pass."}'
 
 set -euo pipefail
 
 LOOP_NAME="${1:-}"
 COMPLETION_PROMISE="${2:-COMPLETE}"
-MAX_ITERATIONS="${3:-}"  # Optional, defaults to unlimited
+MAX_ITERATIONS="${3:-}"  # Optional, defaults to null
 INITIAL_PHASE="${4:-}"   # Optional, defaults to empty
+PHASE_MESSAGES_JSON="${5:-}"  # Optional JSON object of phase->message mappings
 
 if [ -z "$LOOP_NAME" ]; then
   echo "Error: loop-name is required"
-  echo "Usage: setup-loop.sh <loop-name> <completion-promise> [max-iterations] [initial-phase]"
+  echo "Usage: setup-loop.sh <loop-name> <completion-promise> [max-iterations] [initial-phase] [phase-messages-json]"
   exit 1
 fi
 
 # Sanitize loop name for use in filename
 SAFE_LOOP_NAME=$(echo "$LOOP_NAME" | sed 's/[^a-zA-Z0-9_-]/-/g')
-STATE_FILE=".claude/${SAFE_LOOP_NAME}.loop.local.md"
+STATE_FILE=".claude/${SAFE_LOOP_NAME}.loop.local.json"
 
 # Create .claude directory if it doesn't exist
 mkdir -p .claude
@@ -31,37 +33,64 @@ mkdir -p .claude
 EXISTING_PHASE=""
 EXISTING_BASELINE=""
 if [ -f "$STATE_FILE" ]; then
-  EXISTING_PHASE=$(grep '^phase:' "$STATE_FILE" | sed 's/phase: *//' || true)
-  EXISTING_BASELINE=$(grep '^bot_review_baseline:' "$STATE_FILE" | sed 's/bot_review_baseline: *//' || true)
+  EXISTING_PHASE=$(jq -r '.phase // empty' "$STATE_FILE" 2>/dev/null || true)
+  EXISTING_BASELINE=$(jq -r '.bot_review_baseline // empty' "$STATE_FILE" 2>/dev/null || true)
   echo "Warning: Loop '$LOOP_NAME' already active. Resetting (preserving phase: ${EXISTING_PHASE:-<none>}, baseline: ${EXISTING_BASELINE:-<none>})..."
 fi
 
 # Preserve existing phase from state file, fall back to INITIAL_PHASE for fresh runs
-# This allows re-entry to maintain phase context (e.g., watching) across stop-hook restarts
-# while INITIAL_PHASE provides a default for first-time initialization
 PHASE="${EXISTING_PHASE:-$INITIAL_PHASE}"
 
-# Create state file with YAML frontmatter
-cat > "$STATE_FILE" << EOF
----
-loop_name: $LOOP_NAME
-iteration: 1
-max_iterations: $MAX_ITERATIONS
-completion_promise: $COMPLETION_PROMISE
-phase: $PHASE
-bot_review_baseline: $EXISTING_BASELINE
-started_at: $(date -u +"%Y-%m-%dT%H:%M:%SZ")
----
+# Derive session ID from transcript path or env
+SESSION_ID=""
+if [ -n "${CLAUDE_SESSION_ID:-}" ]; then
+  SESSION_ID="$CLAUDE_SESSION_ID"
+elif [ -d ".claude" ]; then
+  # Try to find the most recent transcript file and use its name as session ID
+  LATEST_TRANSCRIPT=$(find .claude -name "*.jsonl" -maxdepth 1 2>/dev/null | sort -t/ -k2 | tail -1 || true)
+  if [ -n "$LATEST_TRANSCRIPT" ]; then
+    SESSION_ID=$(basename "$LATEST_TRANSCRIPT" .jsonl)
+  fi
+fi
 
-Persistent loop initialized for: $LOOP_NAME
-Completion promise: $COMPLETION_PROMISE
-Max iterations: ${MAX_ITERATIONS:-unlimited}
+# Build max_iterations as number or null
+MAX_ITER_JSON="null"
+if [ -n "$MAX_ITERATIONS" ]; then
+  MAX_ITER_JSON="$MAX_ITERATIONS"
+fi
 
-This loop will continue until:
-1. The completion promise <done>$COMPLETION_PROMISE</done> is output
-2. Max iterations is reached (if set)
-3. User cancels with /cancel-loop
-EOF
+# Build phase_messages as object or empty object
+PHASE_MSGS_JSON="{}"
+if [ -n "$PHASE_MESSAGES_JSON" ]; then
+  # Validate it's valid JSON
+  if echo "$PHASE_MESSAGES_JSON" | jq empty 2>/dev/null; then
+    PHASE_MSGS_JSON="$PHASE_MESSAGES_JSON"
+  fi
+fi
+
+# Create JSON state file (atomic write via temp file)
+TMP_FILE="${STATE_FILE}.tmp"
+jq -n \
+  --arg loop_name "$LOOP_NAME" \
+  --argjson iteration 1 \
+  --argjson max_iterations "$MAX_ITER_JSON" \
+  --arg completion_promise "$COMPLETION_PROMISE" \
+  --arg phase "$PHASE" \
+  --arg bot_review_baseline "${EXISTING_BASELINE:-}" \
+  --arg started_at "$(date -u +"%Y-%m-%dT%H:%M:%SZ")" \
+  --arg session_id "$SESSION_ID" \
+  --argjson phase_messages "$PHASE_MSGS_JSON" \
+  '{
+    loop_name: $loop_name,
+    iteration: $iteration,
+    max_iterations: $max_iterations,
+    completion_promise: $completion_promise,
+    phase: $phase,
+    bot_review_baseline: $bot_review_baseline,
+    started_at: $started_at,
+    session_id: $session_id,
+    phase_messages: $phase_messages
+  }' > "$TMP_FILE" && mv "$TMP_FILE" "$STATE_FILE"
 
 echo "Loop initialized: $LOOP_NAME"
 echo "Output <done>$COMPLETION_PROMISE</done> when all completion criteria are met."


### PR DESCRIPTION
## Summary

- Replace fragile grep/sed YAML parsing with jq-based JSON state files (`.loop.local.json`), eliminating the root cause of recurring loop bugs (#73, #86, #89)
- Add session ID for portable stale detection, robust completion detection across all text blocks, per-command phase messages in state file, and debug logging to `.claude/loop-debug.log`
- Include 27-test suite (`scripts/test-loop-state.sh`) covering all state functions

## Root Causes Addressed

| Problem | Old Approach | New Approach |
|---------|-------------|--------------|
| State parsing failures | `grep`/`sed` on YAML (whitespace-sensitive, no validation) | `jq` on JSON (schema-aware, atomic writes via temp+mv) |
| Stale loop detection | Platform-specific `stat` birth time + `date` parsing | Session ID comparison (instant, portable), timestamp fallback |
| Completion detection misses | Only checked last text block, no whitespace tolerance | Checks ALL text blocks in last 100 assistant messages, whitespace-tolerant |
| Phase routing maintenance | Hardcoded `if/elif` chain in stop-hook | `phase_messages` object in state file, fallback to hardcoded for backward compat |
| No observability | Silent failures | `loop_log()` writes to `.claude/loop-debug.log` |

## Files Changed (27)

**Core (shared/):** `lib/loop-state.sh`, `hooks/stop-hook.sh`, `scripts/setup-loop.sh`, `scripts/cleanup-loop.sh`

**Commands/Skills:** `ship.md`, `start-issue.md`, `review-loop.md`, `address-review/SKILL.md`, `address-review/watch-loop.md`

**Synced copies:** All loop plugins (go-workflow, go-web, go-dev, tailwind, llm-tools) via `sync-shared.sh`

**New:** `scripts/test-loop-state.sh`, `.gitignore` entry for debug log

## Test Plan

- [x] 27-test suite passes (`scripts/test-loop-state.sh`) covering: JSON creation, read/write/increment/phase-set, custom fields, find/cleanup, re-init phase preservation, atomic writes (no .tmp files left)
- [x] `check-shared-sync.sh` confirms all plugins in sync
- [x] Zero remaining `.loop.local.md` references in codebase
- [ ] Manual: Run `/start-issue` on a test issue, verify loop persists across stop-hook cycles
- [ ] Manual: Run `/cancel-loop` and verify JSON cleanup