### PR TITLE
fix(llm-tools): auto-detect base branch in codex review and review-loop

### DIFF
--- a/plugins/llm-tools/commands/codex.md
+++ b/plugins/llm-tools/commands/codex.md
@@ -171,7 +171,7 @@ After processing answers from R1, check if any selections require additional inp
   if [ -n "$PR_JSON" ] && [ "$PR_JSON" != "" ]; then
     BASE_BRANCH=`echo "$PR_JSON" | jq -r '.baseRefName'`
   else
-    BASE_BRANCH=`git symbolic-ref refs/remotes/origin/HEAD 2>/dev/null | sed 's|refs/remotes/origin/||' || git remote show -n origin 2>/dev/null | rg 'HEAD branch' | sed 's/.*: //' | grep . || echo "main"`
+    BASE_BRANCH=`(git symbolic-ref refs/remotes/origin/HEAD 2>/dev/null | sed 's|refs/remotes/origin/||' | grep .) || (git remote show -n origin 2>/dev/null | rg 'HEAD branch' | sed 's/.*: //' | grep .) || echo "main"`
   fi
   ```
 

--- a/plugins/llm-tools/commands/review-loop.md
+++ b/plugins/llm-tools/commands/review-loop.md
@@ -168,7 +168,7 @@ Reuse PR data from Step 4a if available, otherwise fall back to remote default:
 if [ -n "$PR_JSON" ]; then
   BASE_BRANCH=`echo "$PR_JSON" | jq -r '.baseRefName'`
 else
-  BASE_BRANCH=`git symbolic-ref refs/remotes/origin/HEAD 2>/dev/null | sed 's|refs/remotes/origin/||' || git remote show -n origin 2>/dev/null | grep 'HEAD branch' | sed 's/.*: //' | grep . || echo "main"`
+  BASE_BRANCH=`(git symbolic-ref refs/remotes/origin/HEAD 2>/dev/null | sed 's|refs/remotes/origin/||' | grep .) || (git remote show -n origin 2>/dev/null | grep 'HEAD branch' | sed 's/.*: //' | grep .) || echo "main"`
 fi
 echo "Detected base branch: $BASE_BRANCH"
 ```


### PR DESCRIPTION
## Summary

- Replace blocking "What is the base branch?" question with silent auto-detection in both `/codex review` (R1.5) and `/review-loop` (Step 4c)
- Auto-detection chain: `gh pr view --json baseRefName` → `git remote show origin` → fallback `main` — matches the pattern already used in `/ship`
- Skip `AskUserQuestion` entirely when base branch was the only follow-up needed
- Add `baseRefName` to all three PR detection strategies in review-loop 4a (zero additional API calls)

Fixes #110

## Test Plan

- `/codex review` on a branch with a PR → auto-detects PR's base branch, no question
- `/codex review` on a branch without a PR → detects remote default, no question
- `/review-loop` with "Changes vs branch" → same auto-detection, no question
- R1.5 `AskUserQuestion` skipped when base branch was the only follow-up needed