### PR TITLE
docs(codex): simplify install/update and align with current conventions

### DIFF
--- a/.agents/skills/address-review/SKILL.md
+++ b/.agents/skills/address-review/SKILL.md
@@ -1,0 +1,511 @@
+---
+name: address-review
+description: |
+  Address PR review comments, fix reviewer feedback, and resolve review threads on GitHub
+  pull requests. Use when the user wants to handle, fix, or respond to feedback left by
+  human reviewers or review bots (CodeRabbit, Copilot, Greptile, Claude) on a PR. Covers
+  fixing flagged issues, resolving unresolved threads, addressing CHANGES_REQUESTED reviews,
+  and requesting re-review after fixes. Triggers for any mention of PR review comments,
+  reviewer suggestions, review feedback, or unresolved review threads needing action.
+  NOT for: creating new PRs, performing your own code review, general coding tasks, or
+  closing/managing PRs without review context.
+argument-hint: "[PR-number] [--no-watch]"
+allowed-tools: ["Bash", "Read", "Glob", "Grep", "Edit", "Write", "Task", "AskUserQuestion", "Agent"]
+---
+
+# Address PR Review Comments
+
+**If `$ARGUMENTS` is empty or not provided:**
+
+Auto-detect PR from current branch:
+
+```bash
+gh pr view --json number --jq '.number' 2>/dev/null
+```
+
+If no PR found, display usage and ask:
+
+**Usage:** `/address-review [PR-number] [--no-watch]`
+
+**Example:** `/address-review 123` or just `/address-review` on a PR branch. Add `--no-watch` to exit after one fix cycle instead of watching for bot re-reviews.
+
+Ask the user: "No PR found for current branch. What PR number would you like to address?"
+
+---
+
+**If PR number is available (from `$ARGUMENTS` or auto-detected):**
+
+## Parse Arguments
+
+```bash
+WATCH_MODE=true
+PR_ARG=""
+for arg in $ARGUMENTS; do
+  case "$arg" in
+    --no-watch) WATCH_MODE=false ;;
+    *) PR_ARG="$arg" ;;
+  esac
+done
+echo "WATCH_MODE=$WATCH_MODE PR_ARG=$PR_ARG"
+```
+
+- `WATCH_MODE`: `true` (default) enables watch loop; `false` exits after one fix cycle. `PR_ARG`: The PR number (may be empty for auto-detect).
+
+## Security Validation
+
+!if [ -n "$PR_ARG" ] && ! echo "$PR_ARG" | grep -qE '^[0-9]+$'; then echo "Error: PR number must be numeric"; exit 1; fi
+
+## Resolve PR Number
+
+Always resolve BEFORE loop initialization to ensure PR-specific loop state:
+
+```bash
+RESOLVED_PR="${PR_ARG:-$(gh pr view --json number --jq '.number' 2>/dev/null || echo 'auto')}"
+echo "Resolved PR: $RESOLVED_PR"
+```
+
+## Loop Initialization
+
+!`"${CLAUDE_PLUGIN_ROOT}/scripts/setup-loop.sh" "address-review-${RESOLVED_PR:-auto}" "COMPLETE"`
+
+## Re-entry Check
+
+Check if resuming from a previous watching phase:
+
+```bash
+SAFE_LOOP_NAME=$(echo "address-review-${RESOLVED_PR:-auto}" | sed 's/[^a-zA-Z0-9_-]/-/g')
+LOOP_STATE_FILE=".claude/${SAFE_LOOP_NAME}.loop.local.json"
+CURRENT_PHASE=""
+if [ -f "$LOOP_STATE_FILE" ]; then
+  source "${CLAUDE_PLUGIN_ROOT}/lib/loop-state.sh"
+  CURRENT_PHASE=$(jq -r '.phase // empty' "$LOOP_STATE_FILE" 2>/dev/null || true)
+fi
+echo "Current phase: ${CURRENT_PHASE:-<none>}"
+```
+
+**If `CURRENT_PHASE` is `watching` AND `WATCH_MODE` is `true`:** Fix cycle already completed. Restore `BOT_REVIEW_BASELINE` from state file:
+
+```bash
+BOT_REVIEW_BASELINE=""
+if [ -f "$LOOP_STATE_FILE" ]; then
+  BOT_REVIEW_BASELINE=$(jq -r '.bot_review_baseline // empty' "$LOOP_STATE_FILE" 2>/dev/null || true)
+fi
+if [ -z "$BOT_REVIEW_BASELINE" ]; then
+  BOT_REVIEW_BASELINE=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+  echo "Bot review baseline (fallback): $BOT_REVIEW_BASELINE"
+  if [ -f "$LOOP_STATE_FILE" ]; then
+    set_loop_field "$LOOP_STATE_FILE" "bot_review_baseline" "$BOT_REVIEW_BASELINE"
+  fi
+else
+  echo "Bot review baseline (restored): $BOT_REVIEW_BASELINE"
+fi
+```
+
+Do NOT re-run the fix cycle. Skip to watch loop (read `watch-loop.md`).
+
+**If `CURRENT_PHASE` is `watching` AND `WATCH_MODE` is `false`:** Clear stale phase:
+
+```bash
+if [ -f "$LOOP_STATE_FILE" ]; then
+  set_loop_phase "$LOOP_STATE_FILE" ""
+  echo "Phase cleared (--no-watch mode)"
+fi
+```
+
+Continue with full fix cycle. **Otherwise:** Continue normally.
+
+## Context
+
+- PR details: !`PR_NUM="${PR_ARG:-\`gh pr view --json number --jq '.number' 2>/dev/null\`}"; gh pr view "$PR_NUM" --json title,state,body,headRefName,baseRefName --jq '.' 2>/dev/null || echo "PR not found"`
+- Current branch: !`git branch --show-current 2>&1 || echo "unknown"`
+- Default branch: !`git remote show origin 2>/dev/null | grep 'HEAD branch' | sed 's/.*: //' || echo "main"`
+- PR number: !`echo "${PR_ARG:-\`gh pr view --json number --jq '.number' 2>/dev/null\`}"`
+
+## Mode Banner and Bot Discovery
+
+**Display mode banner:**
+
+If `WATCH_MODE` is `true`: `🔄 Watch mode enabled (default) — will loop until all review bots approve. Tip: Use /address-review [PR] --no-watch to exit after one fix cycle.`
+
+If `WATCH_MODE` is `false`: `⏩ No-watch mode — will fix comments once and exit.`
+
+**Discover review bots** (only when `WATCH_MODE` is `true`):
+
+```bash
+OWNER=$(gh repo view --json owner --jq '.owner.login')
+REPO=$(gh repo view --json name --jq '.name')
+PR_NUM="${PR_ARG:-$(gh pr view --json number --jq '.number')}"
+
+BOT_AUTHORS=$(gh api graphql -f query='
+  query($owner: String!, $repo: String!, $pr: Int!) {
+    repository(owner: $owner, name: $repo) {
+      pullRequest(number: $pr) {
+        reviews(first: 100) {
+          nodes {
+            author { login }
+            state
+          }
+        }
+        reviewThreads(first: 100) {
+          nodes {
+            comments(first: 50) {
+              nodes {
+                author { login }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+' -f owner="$OWNER" -f repo="$REPO" -F pr="$PR_NUM" | jq -r '
+  [
+    .data.repository.pullRequest.reviews.nodes[].author.login,
+    .data.repository.pullRequest.reviewThreads.nodes[].comments.nodes[].author.login
+  ] | unique | .[]
+')
+
+echo "All unique authors on PR: $BOT_AUTHORS"
+```
+
+Match authors against the bot registry (read `bot-registry.md` for the full table). Display discovered bots or "No review bots detected on this PR." If no bots found: complete fix cycle (Steps 1-11) but skip Step 12.
+
+---
+
+## Step 1: Checkout PR Branch and Rebase
+
+**Do NOT skip ahead to fetching review comments.**
+
+### 1a. Checkout
+
+```bash
+PR_NUM="${PR_ARG:-$(gh pr view --json number --jq '.number')}"
+echo "Working on PR #$PR_NUM"
+gh pr checkout "$PR_NUM"
+```
+
+Idempotent — handles same-repo PRs, fork PRs, and branch tracking.
+
+### 1b. Check if behind base branch and rebase
+
+```bash
+BASE_BRANCH=$(gh pr view "$PR_NUM" --json baseRefName --jq '.baseRefName')
+BASE_OWNER_REPO=$(gh repo view --json owner,name --jq '"\(.owner.login)/\(.name)"')
+
+BASE_REMOTE=""
+for remote in $(git remote); do
+  REMOTE_URL=$(git remote get-url "$remote")
+  REMOTE_OWNER_REPO=$(echo "$REMOTE_URL" | sed 's|\.git$||' | sed -E 's|^https?://[^/]+/||' | sed -E 's|^ssh://[^/]+/||' | sed -E 's|^[^@]+@[^:]+:||')
+  if [ "$REMOTE_OWNER_REPO" = "$BASE_OWNER_REPO" ]; then
+    BASE_REMOTE="$remote"
+    break
+  fi
+done
+
+if [ -z "$BASE_REMOTE" ]; then
+  echo "Error: No remote found pointing to base repository ($BASE_OWNER_REPO)"
+  exit 1
+fi
+
+git fetch "$BASE_REMOTE" "$BASE_BRANCH"
+BEHIND=$(git rev-list --count "HEAD..${BASE_REMOTE}/${BASE_BRANCH}")
+echo "Commits behind ${BASE_REMOTE}/${BASE_BRANCH}: $BEHIND"
+```
+
+**If `$BEHIND` is 0:** Proceed to Step 2.
+
+**If `$BEHIND` > 0:**
+1. Check `git status --porcelain`. **If dirty, STOP** — ask user how to proceed.
+2. `git rebase "${BASE_REMOTE}/${BASE_BRANCH}"` — resolve conflicts intelligently or ask user if too complex.
+3. Force-push:
+   ```bash
+   PR_HEAD_BRANCH=$(gh pr view "$PR_NUM" --json headRefName --jq '.headRefName')
+   BRANCH_REMOTE=$(git config "branch.$(git branch --show-current).remote")
+   git push --force-with-lease "$BRANCH_REMOTE" "HEAD:$PR_HEAD_BRANCH"
+   ```
+
+### 1c. Wait for CI after rebase (only if rebased)
+
+```bash
+for i in 1 2 3 4 5; do sleep 10 && gh pr checks "$PR_NUM" --watch && break; done
+```
+
+Verify with `gh pr checks "$PR_NUM"`. Fix any failures before proceeding.
+
+---
+
+## Step 2: Fetch All Review Feedback
+
+GitHub has two types: **review threads** (line-specific, auto-resolvable) and **review comments** (general CHANGES_REQUESTED, not auto-resolvable).
+
+### 2a. Fetch review threads
+
+```bash
+OWNER=$(gh repo view --json owner --jq '.owner.login')
+REPO=$(gh repo view --json name --jq '.name')
+
+gh api graphql -f query='
+  query($owner: String!, $repo: String!, $pr: Int!) {
+    repository(owner: $owner, name: $repo) {
+      pullRequest(number: $pr) {
+        reviewThreads(first: 100) {
+          nodes {
+            id
+            isResolved
+            path
+            line
+            comments(first: 50) {
+              nodes {
+                body
+                author { login }
+                createdAt
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+' -f owner="$OWNER" -f repo="$REPO" -F pr="$PR_NUM"
+```
+
+### 2b. Fetch pending reviews
+
+```bash
+gh pr view "$PR_NUM" --json reviews --jq '.reviews[] | select(.state == "CHANGES_REQUESTED")'
+```
+
+---
+
+## Step 3: Display and Categorize Comments
+
+**Group A — Resolvable threads** (from `reviewThreads`): Track thread ID, file/line, body, author.
+
+**Group B — Pending reviews** (`CHANGES_REQUESTED`): Track review body, author. Cannot be auto-resolved.
+
+**Track unique reviewers** from both groups for Step 10.
+
+### If no feedback found:
+
+- **If `CURRENT_PHASE` is `fixing` AND `WATCH_MODE` is `true` AND bots detected:** Set phase to `watching`, skip to Step 12:
+  ```bash
+  SAFE_LOOP_NAME=$(echo "address-review-${RESOLVED_PR:-auto}" | sed 's/[^a-zA-Z0-9_-]/-/g')
+  LOOP_STATE_FILE=".claude/${SAFE_LOOP_NAME}.loop.local.json"
+  if [ -f "$LOOP_STATE_FILE" ]; then
+    source "${CLAUDE_PLUGIN_ROOT}/lib/loop-state.sh"
+    set_loop_phase "$LOOP_STATE_FILE" "watching"
+    echo "Phase set to: watching (post-fix-cycle path)"
+  fi
+  ```
+- **If fresh run (no phase set):** PR already clean → `<done>COMPLETE</done>`.
+- **If `WATCH_MODE` is `true` AND no bots:** → `<done>COMPLETE</done>`.
+- **If `WATCH_MODE` is `false`:** → `<done>COMPLETE</done>`.
+
+### If only pending reviews (no threads):
+
+Address feedback, but note: "This PR has pending review feedback that cannot be auto-resolved. After pushing fixes, you'll need to request re-review from the reviewer."
+
+---
+
+## Step 4: Address Each Comment
+
+**Set phase to `fixing`:**
+
+```bash
+SAFE_LOOP_NAME=$(echo "address-review-${RESOLVED_PR:-auto}" | sed 's/[^a-zA-Z0-9_-]/-/g')
+LOOP_STATE_FILE=".claude/${SAFE_LOOP_NAME}.loop.local.json"
+if [ -f "$LOOP_STATE_FILE" ]; then
+  source "${CLAUDE_PLUGIN_ROOT}/lib/loop-state.sh"
+  set_loop_phase "$LOOP_STATE_FILE" "fixing"
+fi
+```
+
+### Parallel Fix Dispatch (when 3+ comments target different files)
+
+When there are 3 or more unresolved comments targeting **different files**, dispatch parallel Implementer subagents:
+
+1. **Group comments by file** — comments in the same file are handled by one subagent
+2. **Group by shared test files** — if two source files are in the same package and share a `_test.go`, they must be in the same group to avoid write conflicts
+3. **For each file group**, dispatch an Agent subagent (sonnet) with:
+   - "You are addressing PR review comments in `{FILE_PATH}`. Working directory: `{PROJECT_ROOT}`."
+   - All comments for that file (reviewer text, line number, suggested change)
+   - "For each comment: understand the request, locate the code, make the minimal fix, validate against feedback. Report: files changed, fixes applied, testability of each fix."
+3. **Dispatch all file-group agents in parallel** using `run_in_background: true`
+4. **Collect results** — proceed to Step 4.5 (test generation) with combined fix list
+
+**Fall back to sequential processing** when fewer than 3 comments or all target the same file.
+
+For each unresolved review comment (sequential mode, or when parallel dispatch is not used):
+
+### 4a. Understand the Request
+Determine what change is requested: code style, logic, docs, test, refactoring? Is it testable (alters observable behavior)?
+
+### 4b. Locate the Code
+Use file path and line number from the thread.
+
+### 4c. Make the Fix
+Make the **minimal change** that addresses the comment. Follow existing patterns.
+
+### 4d. Validate Fix Against Feedback
+1. Re-read the reviewer's comment
+2. Compare your change against reviewer's intent
+3. Check for completeness
+4. Avoid mechanical edits that miss the underlying concern
+
+### 4e. Track the Fix
+Note: thread ID, what was fixed, brief explanation, testability (`testable`/`not-testable`), source file/function/package if testable.
+
+## Step 4.5: Generate Tests for Testable Fixes
+
+Read `test-generation.md` for full test generation guidelines including testability rules, existing test detection, pattern matching, and test writing procedures.
+
+---
+
+## Step 5: Verify Fixes Locally
+
+**All must pass before proceeding:**
+- `go build ./...`
+- `go test ./...`
+- `golangci-lint run` (if available)
+- Check dev server logs for errors if applicable
+
+Fix any failures and re-run until all green.
+
+---
+
+## Step 6: Commit and Push
+
+```bash
+git add -A
+git commit -m "address review comments
+
+- [brief summary of each fix]
+- [tests added for testable fixes, if any]"
+git push
+```
+
+**CRITICAL: Capture bot review baseline IMMEDIATELY after pushing:**
+
+```bash
+BOT_REVIEW_BASELINE=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+echo "Bot review baseline captured: $BOT_REVIEW_BASELINE"
+```
+
+Store this value for all Step 12 bot checks. Do NOT recompute later.
+
+---
+
+## Step 7: Watch CI
+
+```bash
+gh pr checks "$PR_NUM" --watch
+```
+
+If "no checks reported" — retry up to 3 times with 10s delays:
+```bash
+for i in 1 2 3; do sleep 10 && gh pr checks "$PR_NUM" --watch && break; done
+```
+
+If still no checks after retries, verify CI workflow files exist (`find .github/workflows -name '*.yml' -o -name '*.yaml'`). If no workflow files exist, proceed — repo has no CI. If CI fails: analyze, fix, commit, push, re-watch. **Do not proceed until CI is green (or confirmed no CI configured).**
+
+---
+
+## Step 8: Reply to Each Comment
+
+```bash
+gh pr comment "$PR_NUM" --body "Fixed in latest commit: [brief explanation]"
+```
+
+Keep replies brief and professional.
+
+---
+
+## Step 9: Resolve Review Threads (Group A only)
+
+**Only resolve after CI passes and fixes are pushed.** Only for line-specific threads (Group A).
+
+```bash
+gh api graphql -f query='
+  mutation($threadId: ID!) {
+    resolveReviewThread(input: {threadId: $threadId}) {
+      thread { isResolved }
+    }
+  }
+' -f threadId="THREAD_ID_HERE"
+```
+
+Repeat for each unresolved thread.
+
+---
+
+## Step 10: Request Re-review
+
+Read `bot-registry.md` for the full re-review procedure (Steps 10a-10e) including bot detection, opt-out checks, and data-driven re-review triggering.
+
+---
+
+## Step 11: Verify Completion
+
+Confirm all resolvable threads are resolved:
+
+```bash
+OWNER=$(gh repo view --json owner --jq '.owner.login')
+REPO=$(gh repo view --json name --jq '.name')
+
+gh api graphql -f query='
+  query($owner: String!, $repo: String!, $pr: Int!) {
+    repository(owner: $owner, name: $repo) {
+      pullRequest(number: $pr) {
+        reviewThreads(first: 100) {
+          nodes {
+            isResolved
+          }
+        }
+      }
+    }
+  }
+' -f owner="$OWNER" -f repo="$REPO" -F pr="$PR_NUM" | jq '.data.repository.pullRequest.reviewThreads.nodes | map(select(.isResolved == false)) | length'
+```
+
+Confirm CI is passing: `gh pr checks "$PR_NUM"`
+
+---
+
+## Step 12: Watch for Bot Re-review (Phase Transition + Watch Loop)
+
+**Skip if `WATCH_MODE` is `false` or no review bots were detected.**
+
+Read `watch-loop.md` for the complete Phase Transition logic, bot polling (12a-12d), quiet period detection, timeout handling, and re-trigger procedures.
+
+---
+
+## Completion Criteria
+
+### With `--no-watch`:
+Output `<done>COMPLETE</done>` when ALL are true:
+1. PR branch rebased onto latest base branch (or already up to date)
+2. All review feedback addressed with code changes
+3. Each fix validated against reviewer's intent
+4. Local verification passes (`go build`, `go test`, `golangci-lint`)
+5. Changes committed and pushed
+6. CI checks pass
+7. Replies posted to each comment
+8. All resolvable threads resolved via GraphQL
+9. Re-review requested from actual reviewers (data-driven per `bot-registry.md`)
+
+### Default (watch mode):
+All above, PLUS:
+10. All detected review bots signaled approval per Bot Registry
+11. If no bots detected, skip Step 12 (fix cycle still completes fully)
+
+**Note:** Pending reviews (CHANGES_REQUESTED) cannot be auto-resolved. Do NOT request review from bots that never reviewed this PR.
+
+**When ALL criteria are met, output exactly:** `<done>COMPLETE</done>`
+
+**Safety note:** If you've iterated 15+ times without success, document what's blocking and ask the user for guidance. Use extended thinking for complex analysis.
+
+## Supporting Files
+
+- `bot-registry.md` — Bot registry table, detection logic, and Step 10 re-review procedures
+- `test-generation.md` — Step 4.5 test generation guidelines and testability rules
+- `watch-loop.md` — Phase Transition logic and Step 12 watch loop procedures

--- a/.agents/skills/address-review/bot-registry.md
+++ b/.agents/skills/address-review/bot-registry.md
@@ -1,0 +1,109 @@
+# Bot Registry & Re-review Logic
+
+## Bot Registry
+
+Reference table of known review bots. Used ONLY for matching against bots actually found on the PR — never for proactively contacting bots. **CRITICAL: Most PRs have ZERO bots. If Bot Discovery found no bots, ignore this entire table. Never trigger a bot that has not already reviewed this PR.**
+
+| Login | Approval Signal | Has Issues Signal | Re-review Trigger |
+|---|---|---|---|
+| `coderabbitai[bot]` | Formal `APPROVED` review state (requires `request_changes_workflow` in `.coderabbit.yaml`) | `CHANGES_REQUESTED` review with inline comments | `@coderabbitai full review` |
+| `greptileai` | Greptile status check passes + no inline comments posted | Inline comments on specific file changes | `@greptileai` |
+| `copilot-pull-request-review[bot]` | `COMMENTED` review with no inline file comments ("did not comment on any files") | `COMMENTED` review with inline suggestions | Re-request review button in PR sidebar _(no `@` mention trigger)_ |
+| `claude[bot]` | `COMMENTED` review or issue comment: `"No issues found."` (or silent) | `COMMENTED` review with inline comments scored by confidence | `@claude` |
+
+## Bot Detection Logic
+
+- **CodeRabbit**: Only bot that uses formal GitHub review states. Query latest review from `coderabbitai[bot]` — if `state == "APPROVED"` → done. This is the most reliable signal.
+- **Greptile**: Uses a **status check** (not review states). Check `gh pr checks` for a Greptile check — if it passes and no new inline comments were posted, Greptile is satisfied.
+- **Copilot**: Always posts `COMMENTED` reviews (never `APPROVED` or `CHANGES_REQUESTED`). If its review body says it "did not comment on any files" or has no inline comments → no issues found. Cannot be re-triggered via comment — must use the re-request review button in the GitHub PR sidebar.
+- **Claude**: Posts `COMMENTED` reviews. If no inline comments above confidence threshold → "No issues found" or no review posted at all. Re-trigger via `@claude` mention.
+
+**Ignore list:** `github-actions[bot]`, `dependabot[bot]`, `renovate[bot]`, `netlify[bot]`, `vercel[bot]` — these are CI/deploy bots, not reviewers.
+
+## Step 10: Request Re-review From Actual Reviewers Only (Data-Driven)
+
+**CRITICAL: This step is entirely data-driven. You iterate the reviewer list from Step 3 and look up trigger commands in the Bot Registry. You NEVER iterate the Bot Registry to find bots to contact.**
+
+### 10a. Query actual reviewers from the PR
+
+Fetch the current list of unique authors who left reviews or thread comments on this PR:
+
+```bash
+OWNER=$(gh repo view --json owner --jq '.owner.login')
+REPO=$(gh repo view --json name --jq '.name')
+
+ACTUAL_REVIEWERS=$(gh api graphql -f query='
+  query($owner: String!, $repo: String!, $pr: Int!) {
+    repository(owner: $owner, name: $repo) {
+      pullRequest(number: $pr) {
+        reviews(first: 100) {
+          nodes {
+            author { login }
+            state
+          }
+        }
+        reviewThreads(first: 100) {
+          nodes {
+            comments(first: 50) {
+              nodes {
+                author { login }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+' -f owner="$OWNER" -f repo="$REPO" -F pr="$PR_NUM" | jq -r '
+  [
+    .data.repository.pullRequest.reviews.nodes[].author.login,
+    .data.repository.pullRequest.reviewThreads.nodes[].comments.nodes[].author.login
+  ] | unique | .[]
+')
+
+echo "Actual reviewers on PR: $ACTUAL_REVIEWERS"
+```
+
+Cross-reference this list with the Step 3 reviewer list. Only proceed with reviewers that appear in BOTH.
+
+If the reviewer list is empty (no reviewers left feedback), skip this entire step.
+
+### 10b. Check for bot re-review opt-out
+
+```bash
+REPO_ROOT=$(git rev-parse --show-toplevel)
+if [ -f "$REPO_ROOT/CLAUDE.md" ] && grep -q "DISABLE_BOT_REREVIEW=true" "$REPO_ROOT/CLAUDE.md"; then
+  echo "Bot re-review disabled by project settings"
+fi
+```
+
+**If `DISABLE_BOT_REREVIEW=true` is found:** Skip bot re-reviews. Only request re-review from human reviewers.
+
+### 10c. Request re-review from bot reviewers (data-driven lookup)
+
+**FORBIDDEN: Do NOT post trigger commands for bots that are not in the Step 3 reviewer list. If a bot never reviewed this PR, triggering it posts spam on the repository.**
+
+**For each reviewer in the actual reviewer list from 10a:**
+
+1. Check if the login matches any entry in the Bot Registry table above
+2. If it matches AND has a re-review trigger command → post the trigger:
+   ```bash
+   gh pr comment "$PR_NUM" --body "<trigger command from registry>"
+   ```
+3. If it matches but has no trigger command (e.g., `copilot-pull-request-review[bot]`) → skip, log: "Skipping <login>: no re-trigger mechanism available"
+4. If it's on the ignore list (`github-actions[bot]`, `dependabot[bot]`, etc.) → skip silently
+5. If it doesn't match any registry entry and looks like a bot (contains `[bot]` or `bot` suffix) → skip, log: "Skipping unknown bot <login>: no trigger command known"
+
+**Never iterate the Bot Registry to find bots. Always iterate actual reviewers and look up triggers.**
+
+### 10d. Request re-review from human reviewers who left feedback
+
+For human reviewers from your Step 3 list who left CHANGES_REQUESTED:
+
+```bash
+gh pr edit "$PR_NUM" --add-reviewer "REVIEWER_USERNAME"
+```
+
+### 10e. Inform the user
+
+After requesting re-reviews, list who was contacted and why. If no re-reviews were requested, say so.

--- a/.agents/skills/address-review/test-generation.md
+++ b/.agents/skills/address-review/test-generation.md
@@ -1,0 +1,86 @@
+# Test Generation for Review Fixes
+
+## Step 4.5: Generate Tests for Testable Fixes
+
+After all fixes are applied (Step 4 complete), generate tests for fixes classified as `testable` in Step 4e.
+
+### Testability Guidelines
+
+**DO write tests for:**
+- Bug fixes that change function/method output or behavior
+- Logic changes (conditionals, error handling, edge cases)
+- New or modified validation rules
+- Data transformation or parsing changes
+- API response changes
+- Concurrency or race condition fixes
+- Any change that alters what a function returns, how it mutates state, or what side effects it produces
+
+**DO NOT write tests for:**
+- Removing or adding comments
+- Adding/changing log statements
+- Formatting or whitespace changes
+- Import reordering
+- Variable/function renames (unless public API)
+- Documentation updates
+- Config file tweaks that don't affect runtime behavior
+- Typo fixes in non-user-facing strings
+
+**Rule of thumb:** If the change affects something a caller or user could observe — a return value, an error, a side effect, an HTTP response — it's testable and should get a test. If it's purely cosmetic or informational, skip it.
+
+### 4.5a. Identify Testable Fixes
+
+Review the tracking notes from Step 4e. Collect all fixes marked `testable` along with their affected function/method and package.
+
+If no fixes are testable, skip to Step 5.
+
+### 4.5b. Check for Existing Tests
+
+For each testable fix, check if a test file already exists:
+
+```bash
+ls "${FILE%.*}_test.go" 2>/dev/null || ls "$(dirname "$FILE")"/*_test.go 2>/dev/null
+```
+
+If a test file exists, look for existing table-driven tests for the affected function across ALL `*_test.go` files in the package (tests may be split across multiple files):
+
+```bash
+grep -n "func Test.*${FUNCTION_NAME}" "$(dirname "$FILE")"/*_test.go 2>/dev/null
+```
+
+### 4.5c. Detect Testing Patterns
+
+Examine existing test files in the same package to detect conventions:
+
+- **Test framework**: stdlib `testing` or `testify` (check for `github.com/stretchr/testify` imports)
+- **Table-driven pattern**: look for `tests := []struct` or `tt := []struct` patterns
+- **Naming conventions**: `Test_functionName` vs `TestFunctionName` vs `TestPackage_FunctionName`
+- **Helper patterns**: test fixtures, setup/teardown, `testdata/` directory usage
+
+Match these conventions when writing new tests.
+
+### 4.5d. Write Tests
+
+For each testable fix:
+
+**If an existing table-driven test exists for the affected function:**
+- Add a new test case to the existing table that covers the scenario the review comment flagged
+- Name the case descriptively (e.g., `"returns error when input is nil"`)
+
+**If no existing test exists:**
+- Create a new table-driven test function in the appropriate `_test.go` file
+- Follow the package's detected conventions (4.5c)
+- Include at least:
+  - A test case that exercises the fixed behavior (the "green" case)
+  - A test case for the edge case or incorrect input the review comment identified
+
+### 4.5e. Verify Tests Pass
+
+Run the tests to confirm they pass with the fix applied:
+
+```bash
+go test ./path/to/package/... -run "TestFunctionName" -v
+```
+
+All new tests must pass (green). If any fail, fix the test until green.
+
+**Note on red-green:** The traditional red-green cycle (verify test fails without fix, then passes with fix) is impractical here because fixes are applied in batch during Step 4. The review comment itself serves as the "red" evidence — it identified broken or incorrect behavior. The green confirmation in this step validates the test correctly covers the fixed behavior.

--- a/.agents/skills/address-review/watch-loop.md
+++ b/.agents/skills/address-review/watch-loop.md
@@ -1,0 +1,111 @@
+# Watch Loop: Bot Re-review Monitoring
+
+## Phase Transition
+
+Before entering the watch loop, update the loop state phase so that any stop-hook re-entry resumes at Step 12 instead of restarting the fix cycle:
+
+```bash
+SAFE_LOOP_NAME=$(echo "address-review-${RESOLVED_PR:-auto}" | sed 's/[^a-zA-Z0-9_-]/-/g')
+LOOP_STATE_FILE=".claude/${SAFE_LOOP_NAME}.loop.local.json"
+if [ -f "$LOOP_STATE_FILE" ]; then
+  source "${CLAUDE_PLUGIN_ROOT}/lib/loop-state.sh"
+  set_loop_phase "$LOOP_STATE_FILE" "watching"
+  echo "Phase set to: watching"
+fi
+```
+
+**Note:** `BOT_REVIEW_BASELINE` should already be set from Step 6 (right after the push). If for some reason it wasn't captured earlier (e.g., re-entry after context loss), capture it now as a fallback.
+
+**CRITICAL: Persist the baseline in the state file** so it survives context-loss re-entry:
+
+```bash
+if [ -z "$BOT_REVIEW_BASELINE" ]; then
+  BOT_REVIEW_BASELINE=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+  echo "Bot review baseline captured (fallback): $BOT_REVIEW_BASELINE"
+fi
+
+if [ -f "$LOOP_STATE_FILE" ]; then
+  set_loop_field "$LOOP_STATE_FILE" "bot_review_baseline" "$BOT_REVIEW_BASELINE"
+  echo "Bot review baseline persisted: $BOT_REVIEW_BASELINE"
+fi
+```
+
+---
+
+## Step 12: Watch for Bot Re-review (default, skipped with --no-watch)
+
+**Skip this entire step if `WATCH_MODE` is `false` or no review bots were detected in the Bot Discovery step.**
+
+**NEVER check for, trigger, or mention a bot that was NOT found in the Bot Discovery step. If Bot Discovery found zero bots, you MUST skip this entire step.**
+
+### 12a. Check if all detected bots have approved
+
+**ONLY check bots that were discovered in the Bot Discovery step above. If no bots were discovered, skip Step 12 entirely.**
+
+For each bot from your Bot Discovery results, use the approval detection logic from the Bot Registry (`bot-registry.md`) to determine if it has approved. The detection approaches by bot type:
+
+- Bots with formal review states (e.g., CodeRabbit): Query latest review state
+- Bots with issue comment signals: Check latest issue comment body
+- Bots with status checks (e.g., Greptile): Check `gh pr checks`
+- Bots with timestamp-based detection (e.g., Copilot, Claude): Compare against BOT_REVIEW_BASELINE
+
+**Do NOT run checks for bots that were not in your Bot Discovery results.**
+
+**If ALL detected bots are done → output `<done>COMPLETE</done>` and stop.**
+
+### 12b. Wait for bot re-review (quiet period detection)
+
+If any bot hasn't approved yet:
+
+1. **Record baseline:** Get the current count of reviews + thread comments per pending bot.
+
+2. **Poll every 15 seconds:**
+   ```bash
+   sleep 15
+   ```
+   Then re-query review/comment counts via the same GraphQL queries.
+
+3. **Quiet period detection:**
+   - If counts changed since last poll → reset quiet timer, bot is still posting. Keep polling.
+   - If counts are stable for 2 consecutive polls (30 seconds of no new activity) → bot has finished posting. Proceed to 12c.
+
+4. **Timeout:** If 5 minutes pass with no new activity from any bot AND bots haven't approved:
+   - Use `AskUserQuestion` to ask: "Bots haven't responded after 5 minutes. Would you like to keep waiting, re-trigger bot reviews, or exit?"
+   - If "keep waiting" → reset timeout, continue polling
+   - If "re-trigger" → go to 12d
+   - If "exit" → output `<done>COMPLETE</done>`
+
+### 12c. New comments found — loop back to Step 2
+
+After the quiet period ends and new unresolved comments/threads exist:
+
+**First, clear the `watching` phase** so stop-hook re-entry runs the fix cycle instead of skipping to Step 12:
+
+```bash
+SAFE_LOOP_NAME=$(echo "address-review-${RESOLVED_PR:-auto}" | sed 's/[^a-zA-Z0-9_-]/-/g')
+LOOP_STATE_FILE=".claude/${SAFE_LOOP_NAME}.loop.local.json"
+if [ -f "$LOOP_STATE_FILE" ]; then
+  source "${CLAUDE_PLUGIN_ROOT}/lib/loop-state.sh"
+  set_loop_phase "$LOOP_STATE_FILE" "fixing"
+  echo "Phase reset to: fixing (new bot feedback detected)"
+fi
+```
+
+Then:
+
+1. Re-fetch all review feedback (Step 2) but **only address NEW unresolved comments** from bots. Already-resolved threads stay resolved.
+2. Loop back through Steps 2-11 for the new feedback only.
+3. After completing the fix cycle, return to Step 12a to re-check approval status (the Phase Transition section will set phase back to `watching`).
+
+### 12d. No new comments but bot hasn't approved — re-trigger
+
+If a bot's quiet period ended with no new comments but it still hasn't approved:
+
+1. Look up the bot's re-review trigger command from the Bot Registry (`bot-registry.md`).
+2. If a trigger exists → post it:
+   ```bash
+   gh pr comment "$PR_NUM" --body "<trigger command>"
+   ```
+3. **Max 3 re-trigger attempts per bot.** Track the count.
+4. If 3 attempts exhausted → use `AskUserQuestion`: "Bot <login> hasn't approved after 3 re-trigger attempts. Keep trying, skip this bot, or exit?"
+5. After re-triggering → return to 12b to wait again.

--- a/.agents/skills/gemini-image/SKILL.md
+++ b/.agents/skills/gemini-image/SKILL.md
@@ -1,0 +1,308 @@
+---
+name: gemini-image
+description: |
+  WHEN: User asks to "generate an image", "create an image", "make a picture",
+  "create a graphic", "generate artwork", "make an illustration", "create a visual",
+  "generate a photo", "make a banner", "create a hero image", "generate a thumbnail",
+  "make a logo", "create an icon", "I need an image", or similar image generation
+  requests. Also trigger when user says "use Gemini to make", "AI-generated image",
+  or "image for my blog/site/project".
+  WHEN NOT: User is discussing image formats, image processing code, or asking about
+  image generation conceptually. Do not trigger for screenshots, editing existing
+  images, or when the user explicitly wants DALL-E, Midjourney, or Stable Diffusion.
+---
+
+# Gemini Image Generation
+
+You detected an image generation request. Confirm intent before proceeding.
+
+**Say:** "It sounds like you want to generate an image. I can do that using the Gemini API. Let me walk you through the options."
+
+If the user confirms, proceed. If not, stop.
+
+**Tip:** You can also use `/gemini-image <description>` to generate images directly.
+
+## 1. Check Prerequisites
+
+Verify the environment:
+
+```bash
+echo "GEMINI_API_KEY set: $([ -n "$GEMINI_API_KEY" ] && echo 'yes' || echo 'no')"
+which python3
+```
+
+If `GEMINI_API_KEY` is not set:
+
+> `GEMINI_API_KEY` is not set. Get one free at https://aistudio.google.com/apikey
+> Then export it: `export GEMINI_API_KEY="your-key-here"`
+
+Stop and wait for the user to set the key.
+
+If `python3` is not available, inform the user that Python 3 is required.
+
+> **Note:** The Gemini CLI's Nano Banana extension was investigated as an alternative generation path, but it has a known MCP tool registration bug (Gemini CLI v0.34.0 / Nano Banana v1.0.12) where tools fail to load at runtime. Only the REST API is reliable for image generation at this time.
+
+## 2. Gather Image Details
+
+Extract the image description from the user's request and confirm it.
+
+### Model Selection
+
+Ask the user which model to use:
+
+| Model ID | Best For | Known Issues |
+|----------|----------|--------------|
+| `gemini-3.1-flash-image-preview` | Fast, high-volume, newest **(Recommended)** | `aspectRatio` may be ignored in edit/background operations |
+| `gemini-2.5-flash-image` | Stable, proven, fewest bugs | Most reliable for `imageConfig` params |
+
+Default: `gemini-3.1-flash-image-preview`
+
+### Aspect Ratio
+
+Infer from context when possible, then confirm:
+
+| Context Clue | Suggested Ratio |
+|--------------|-----------------|
+| "hero image", "banner", "header" | `16:9` |
+| "profile pic", "avatar", "icon", "logo" | `1:1` |
+| "story", "mobile", "vertical" | `9:16` |
+| "poster", "book cover" | `3:4` |
+| "presentation", "thumbnail" | `4:3` |
+| "ultrawide", "cinematic" | `21:9` |
+
+If no context clue, default to `1:1`.
+
+**All supported ratios:** `1:1`, `1:4`, `1:8`, `2:3`, `3:2`, `3:4`, `4:1`, `4:3`, `4:5`, `5:4`, `8:1`, `9:16`, `16:9`, `21:9`
+
+> **Note:** On `gemini-3.1-flash-image-preview`, `aspectRatio` may be silently ignored during image editing or background replacement operations. If aspect ratio is critical for an edit operation, consider using `gemini-2.5-flash-image` instead.
+
+### Image Resolution
+
+Ask the user:
+
+| Resolution | Notes |
+|------------|-------|
+| `1K` | Good quality, fast **(default)** |
+| `2K` | Higher detail |
+| `4K` | Maximum detail, slower |
+| `512` | Only available on `gemini-3.1-flash-image-preview` |
+
+Default: `1K`
+
+> **Important:** `imageSize` values are **case-sensitive**. Use `"1K"`, `"2K"`, `"4K"` exactly — lowercase (e.g., `"1k"`) silently falls back to 512px resolution.
+
+If user selects `512` with a model other than `gemini-3.1-flash-image-preview`, warn them and switch to `1K`.
+
+### Reference Image (Optional)
+
+Ask if they want to include a reference image (path to file). Default: no.
+
+### Output Path
+
+Ask or auto-generate a descriptive filename in the current directory (e.g., `hero-banner.png`, `coffee-logo.png`).
+
+## 3. Build Request JSON
+
+**First, export the gathered values as environment variables** so the python3 script can read them:
+
+**Important:** Always single-quote user-provided values to prevent shell injection (quotes, backticks, `$` in prompts):
+
+```bash
+export GEMINI_PROMPT='<the user'"'"'s image description — single-quote wrapped>'
+export GEMINI_MODEL='<selected model, e.g. gemini-3.1-flash-image-preview>'
+export GEMINI_ASPECT_RATIO='<selected ratio, e.g. 1:1>'
+export GEMINI_IMAGE_SIZE='<selected resolution, e.g. 1K>'
+export GEMINI_REF_IMAGE='<path to reference image, or empty>'
+export GEMINI_OUTPUT_PATH='<output file path>'
+```
+
+Then run the builder:
+
+```bash
+python3 << 'PYEOF'
+import json, base64, sys, os
+
+prompt = os.environ.get("GEMINI_PROMPT", "")
+model = os.environ.get("GEMINI_MODEL", "gemini-3.1-flash-image-preview")
+aspect_ratio = os.environ.get("GEMINI_ASPECT_RATIO", "1:1")
+image_size = os.environ.get("GEMINI_IMAGE_SIZE", "1K")
+ref_image_path = os.environ.get("GEMINI_REF_IMAGE", "")
+pid = os.getpid()
+
+parts = []
+
+if ref_image_path and os.path.exists(ref_image_path):
+    ext = ref_image_path.lower().rsplit(".", 1)[-1]
+    mime_map = {"png": "image/png", "jpg": "image/jpeg", "jpeg": "image/jpeg", "webp": "image/webp", "gif": "image/gif"}
+    mime = mime_map.get(ext, "image/png")
+    with open(ref_image_path, "rb") as f:
+        b64 = base64.b64encode(f.read()).decode()
+    parts.append({"inlineData": {"mimeType": mime, "data": b64}})
+
+parts.append({"text": prompt})
+
+payload = {
+    "contents": [{"parts": parts}],
+    "generationConfig": {
+        "responseModalities": ["TEXT", "IMAGE"],
+        "imageConfig": {
+            "aspectRatio": aspect_ratio
+        }
+    }
+}
+
+if image_size != "1K":
+    payload["generationConfig"]["imageConfig"]["imageSize"] = image_size
+
+outfile = f"/tmp/gemini-image-request-{pid}.json"
+with open(outfile, "w") as f:
+    json.dump(payload, f)
+
+print(outfile)
+PYEOF
+```
+
+Capture the printed path as `REQUEST_FILE`.
+
+## 4. API Call
+
+Use the `REQUEST_FILE` path from Step 3 and the `GEMINI_MODEL` env var:
+
+```bash
+RESPONSE_FILE="/tmp/gemini-image-response-$$.json"
+HTTP_STATUS=$(curl -s -o "$RESPONSE_FILE" -w "%{http_code}" -X POST \
+  "https://generativelanguage.googleapis.com/v1beta/models/${GEMINI_MODEL}:generateContent?key=$GEMINI_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d @"${REQUEST_FILE}")
+export GEMINI_RESPONSE_FILE="$RESPONSE_FILE"
+echo "HTTP status: $HTTP_STATUS"
+```
+
+If `HTTP_STATUS` is 429, wait 30s and retry once. If 400/403, show the error and suggest fixes. Only proceed if 200.
+
+## 5. Extract and Save Image
+
+Use python3 to parse the response and save:
+
+```bash
+python3 << 'PYEOF'
+import json, base64, sys, os
+
+response_file = os.environ.get("GEMINI_RESPONSE_FILE", "")
+output_path = os.environ.get("GEMINI_OUTPUT_PATH", "output.png")
+
+with open(response_file) as f:
+    data = json.load(f)
+
+if "error" in data:
+    print(f"API Error: {data['error'].get('message', str(data['error']))}", file=sys.stderr)
+    sys.exit(1)
+
+candidates = data.get("candidates", [])
+if not candidates:
+    print("No candidates in response", file=sys.stderr)
+    sys.exit(1)
+
+parts = candidates[0].get("content", {}).get("parts", [])
+
+text_parts = []
+image_data = None
+image_mime = None
+
+for part in parts:
+    if "text" in part:
+        text_parts.append(part["text"])
+    elif "inlineData" in part:
+        image_data = part["inlineData"]["data"]
+        image_mime = part["inlineData"].get("mimeType", "image/png")
+
+if not image_data:
+    print("No image data in response", file=sys.stderr)
+    if text_parts:
+        print(f"Model response: {' '.join(text_parts)}", file=sys.stderr)
+    sys.exit(1)
+
+raw_bytes = base64.b64decode(image_data)
+
+if output_path.lower().endswith(".png") and image_mime == "image/jpeg":
+    try:
+        from PIL import Image
+        import io
+        img = Image.open(io.BytesIO(raw_bytes))
+        img.save(output_path, "PNG")
+        print(f"Converted JPEG→PNG and saved to {output_path}")
+    except ImportError:
+        import subprocess, shutil
+        if shutil.which("magick"):
+            tmp_jpg = output_path + ".tmp.jpg"
+            with open(tmp_jpg, "wb") as f:
+                f.write(raw_bytes)
+            result = subprocess.run(["magick", tmp_jpg, output_path], capture_output=True)
+            os.remove(tmp_jpg)
+            if result.returncode == 0:
+                print(f"Converted JPEG→PNG (magick) and saved to {output_path}")
+            else:
+                output_path = output_path.rsplit(".", 1)[0] + ".jpg"
+                with open(output_path, "wb") as f:
+                    f.write(raw_bytes)
+                print(f"magick failed, saved as JPEG: {output_path}")
+        else:
+            output_path = output_path.rsplit(".", 1)[0] + ".jpg"
+            with open(output_path, "wb") as f:
+                f.write(raw_bytes)
+            print(f"No PNG converter available (install Pillow or ImageMagick), saved as JPEG: {output_path}")
+else:
+    with open(output_path, "wb") as f:
+        f.write(raw_bytes)
+    print(f"Saved to {output_path}")
+
+size_kb = os.path.getsize(output_path) / 1024
+print(f"Size: {size_kb:.1f} KB")
+
+if text_parts:
+    print(f"Model notes: {' '.join(text_parts)}")
+PYEOF
+```
+
+## 6. Save Prompt File
+
+Write a `{name}_prompt.txt` alongside the image:
+
+```bash
+PROMPT_FILE="${GEMINI_OUTPUT_PATH%.*}_prompt.txt"
+cat > "$PROMPT_FILE" << EOF
+Prompt: ${GEMINI_PROMPT}
+Model: ${GEMINI_MODEL}
+Aspect Ratio: ${GEMINI_ASPECT_RATIO}
+Resolution: ${GEMINI_IMAGE_SIZE}
+Reference Image: ${GEMINI_REF_IMAGE:-none}
+Date: $(date -u +"%Y-%m-%dT%H:%M:%SZ")
+EOF
+```
+
+## 7. Cleanup and Report
+
+```bash
+rm -f "${REQUEST_FILE}" "${RESPONSE_FILE}"
+```
+
+Report:
+- Image saved to: `{output_path}`
+- Prompt saved to: `{prompt_file}`
+- File size
+- Any model notes from text parts
+
+Ask: "Would you like to regenerate with different settings, adjust the prompt, or generate another image?"
+
+## Error Handling
+
+| Error | Action |
+|-------|--------|
+| Missing `GEMINI_API_KEY` | Link to https://aistudio.google.com/apikey |
+| Missing `python3` | Inform user Python 3 is required |
+| API 429 (rate limit) | Wait 30s and retry once |
+| API 400 (bad request) | Show error, suggest simpler prompt |
+| API 403 (forbidden) | Check API key, suggest regenerating |
+| JPEG when PNG requested | Auto-convert: Pillow → magick → .jpg fallback |
+| No image in response | Show model text, suggest rephrasing |
+| `imageSize` lowercase value | Warn about case sensitivity before sending request |

--- a/.agents/skills/go-best-practices/SKILL.md
+++ b/.agents/skills/go-best-practices/SKILL.md
@@ -1,0 +1,154 @@
+---
+name: go-best-practices
+description: |
+  WHEN: User is writing Go code, asking about Go patterns, reviewing Go code, asking
+  "what's the best way to...", "how should I structure...", "is this idiomatic?",
+  or any question about error handling, concurrency, interfaces, packages, testing patterns,
+  or code organization in Go. Also activate when user is debugging Go code, refactoring Go,
+  or working in a Go project (go.mod present) and asks general coding questions.
+  Trigger this skill liberally for ANY Go-related development work.
+  WHEN NOT: Non-Go languages, questions entirely unrelated to programming
+---
+
+# Go Best Practices Skill
+
+Apply idiomatic Go patterns and best practices from Gopher Guides training materials.
+
+## When Helping with Go Code
+
+### Error Handling
+
+- **Wrap errors with context**: Use `fmt.Errorf("operation failed: %w", err)`
+- **Check errors immediately**: Don't defer error checking
+- **Return errors, don't panic**: Panics are for unrecoverable situations only
+- **Create sentinel errors** for expected conditions: `var ErrNotFound = errors.New("not found")`
+- **Use errors.Is() and errors.As()** for error comparison
+
+```go
+// Good
+if err != nil {
+    return fmt.Errorf("failed to process user %s: %w", userID, err)
+}
+
+// Avoid
+if err != nil {
+    log.Fatal(err)  // Don't panic on recoverable errors
+}
+```
+
+### Interface Design
+
+- **Accept interfaces, return structs**: Functions should accept interfaces but return concrete types
+- **Keep interfaces small**: Prefer single-method interfaces
+- **Define interfaces at point of use**: Not where the implementation lives
+- **Don't export interfaces unnecessarily**: Only if users need to mock
+
+```go
+// Good - interface defined by consumer
+type Reader interface {
+    Read(p []byte) (n int, err error)
+}
+
+func ProcessData(r Reader) error { ... }
+
+// Avoid - exporting implementation details
+type Service interface {
+    Method1() error
+    Method2() error
+    Method3() error  // Too many methods
+}
+```
+
+### Concurrency
+
+- **Don't communicate by sharing memory; share memory by communicating**
+- **Use channels for coordination, mutexes for state**
+- **Always pass context.Context as first parameter**
+- **Use errgroup for coordinating goroutines**
+- **Avoid goroutine leaks**: Ensure goroutines can exit
+
+```go
+// Good - using errgroup
+g, ctx := errgroup.WithContext(ctx)
+for _, item := range items {
+    item := item  // capture loop variable
+    g.Go(func() error {
+        return process(ctx, item)
+    })
+}
+if err := g.Wait(); err != nil {
+    return err
+}
+```
+
+### Testing
+
+- **Use table-driven tests** for multiple scenarios
+- **Call t.Parallel()** for independent tests
+- **Use t.Helper()** in test helpers
+- **Test behavior, not implementation**
+- **Use testify for assertions** when it improves readability
+
+```go
+func TestAdd(t *testing.T) {
+    tests := []struct {
+        name string
+        a, b int
+        want int
+    }{
+        {"positive numbers", 2, 3, 5},
+        {"with zero", 5, 0, 5},
+        {"negative numbers", -2, -3, -5},
+    }
+
+    for _, tt := range tests {
+        t.Run(tt.name, func(t *testing.T) {
+            t.Parallel()
+            got := Add(tt.a, tt.b)
+            if got != tt.want {
+                t.Errorf("Add(%d, %d) = %d, want %d", tt.a, tt.b, got, tt.want)
+            }
+        })
+    }
+}
+```
+
+### Package Organization
+
+- **Package names should be short and lowercase**: `user` not `userService`
+- **Avoid package-level state**: Use dependency injection
+- **One package per directory**: No multi-package directories
+- **internal/ for non-public packages**: Prevents external imports
+
+### Naming Conventions
+
+- **Use MixedCaps or mixedCaps**: Not underscores
+- **Acronyms should be consistent**: `URL`, `HTTP`, `ID` (all caps for exported, all lower otherwise)
+- **Short names for short scopes**: `i` for loop index, `err` for errors
+- **Descriptive names for exports**: `ReadConfig` not `RC`
+
+### Code Organization
+
+- **Declare variables close to use**
+- **Use defer for cleanup immediately after resource acquisition**
+- **Group related declarations**
+- **Order: constants, variables, types, functions**
+
+## Anti-Patterns to Avoid
+
+- **Empty interface (`interface{}` or `any`)**: Use specific types when possible
+- **Global state**: Prefer dependency injection
+- **Naked returns**: Always name what you're returning
+- **Stuttering**: `user.UserService` should be `user.Service`
+- **init() functions**: Prefer explicit initialization
+- **Complex constructors**: Use functional options pattern
+
+## When in Doubt
+
+- Refer to [Effective Go](https://go.dev/doc/effective_go)
+- Check the Go standard library for examples
+- Use `go vet` and `staticcheck` for automated guidance
+
+---
+
+*This skill is powered by Gopher Guides training materials. For comprehensive Go training, visit [gopherguides.com](https://gopherguides.com).*

--- a/.agents/skills/go-profiling-optimization/SKILL.md
+++ b/.agents/skills/go-profiling-optimization/SKILL.md
@@ -1,0 +1,368 @@
+---
+name: go-profiling-optimization
+description: |
+  WHEN: User is analyzing Go performance, asking about profiling, optimization, benchmarking
+  strategy, memory allocations, CPU hotspots, pprof, flame graphs, escape analysis, or
+  "why is this slow". Also activate when user mentions PGO, GOGC, GOMEMLIMIT, runtime/trace,
+  net/http/pprof, gcflags, benchstat, sync.Pool, buffer pooling, preallocation, or is
+  interpreting benchmark results, profiling output, or trace data. Trigger when user asks
+  "how do I profile", "where is the bottleneck", "how to reduce allocations", "is this
+  allocation on heap or stack", or any question about Go runtime performance tuning.
+  Trigger this skill liberally for ANY Go performance-related work.
+  WHEN NOT: Non-Go languages, general debugging without performance focus (use
+  systematic-debugging instead), writing new benchmarks from scratch (suggest /bench command),
+  questions entirely unrelated to performance or optimization
+---
+
+<!-- cache:start -->
+
+# Go Profiling & Optimization
+
+For hands-on profiling with automatic bottleneck detection and optimization, use `/profile <target>`.
+
+## The Profiling Workflow
+
+**NEVER optimize without profiling data.** Every optimization must be driven by evidence.
+
+```
+Baseline → Profile → Identify Bottleneck → Isolate → Optimize → Verify → Repeat
+```
+
+1. Establish a benchmark baseline with `go test -bench=. -benchmem -count=6`
+2. Profile (CPU, then memory, then trace if concurrent)
+3. Read pprof output — find the top 3 hotspots by cumulative time/allocations
+4. Create isolation benchmarks for each hotspot
+5. Apply ONE optimization at a time
+6. Re-benchmark and compare with `benchstat old.bench new.bench`
+7. Verify p-value < 0.05 (statistically significant improvement)
+8. Repeat until diminishing returns
+
+## Profile Types — When to Use Each
+
+| Profile | Flag | Use When |
+|---------|------|----------|
+| CPU | `-cpuprofile=cpu.pprof` | Function is slow, high CPU usage |
+| Memory (heap) | `-memprofile=mem.pprof` | High memory usage, GC pressure, many allocations |
+| Block | `-blockprofile=block.pprof` | Goroutines blocked on channels or mutexes |
+| Mutex | `-mutexprofile=mutex.pprof` | Lock contention suspected |
+| Goroutine | `runtime/pprof.Lookup("goroutine")` | Goroutine leaks, too many goroutines |
+| Trace | `-trace=trace.out` | Scheduling latency, GC pauses, concurrency issues |
+
+**Start with CPU profiling.** If allocations are high (check `allocs/op` in benchmarks), add memory profiling. Use trace only for concurrency investigation.
+
+## Reading pprof Output
+
+### Key Metrics
+
+- **flat / flat%**: Time spent ONLY in this function, not in functions it calls
+- **cum / cum%**: Cumulative time — this function AND everything it calls
+- **sum%**: Running total of flat% from top to bottom
+
+**Always sort by cumulative (`-cum`)** to find where time is actually spent. A function with low `flat` but high `cum` is calling expensive children.
+
+### Source Annotations
+
+```bash
+go tool pprof -list=FunctionName cpu.pprof
+```
+
+Shows source code with per-line timing. Time values on the LEFT show how much each line costs. This is your most powerful diagnostic — it tells you the EXACT lines to optimize.
+
+### Callers and Callees
+
+```bash
+go tool pprof -peek=FunctionName cpu.pprof
+```
+
+Shows who calls the hot function and what it calls. Useful for understanding the full hot path.
+
+## Escape Analysis
+
+```bash
+go build -gcflags="-m" ./...
+```
+
+Shows the compiler's allocation decisions:
+- `escapes to heap` — variable allocated on heap (costs GC time)
+- `does not escape` — stays on stack (free, automatic cleanup)
+- `moved to heap` — compiler couldn't prove it stays in scope
+
+### Common Escape Triggers
+
+- Returning a pointer to a local variable
+- Storing a value in an `interface{}` / `any` (interface boxing)
+- Capturing a variable in a closure sent to a goroutine
+- Passing a pointer to a function that the compiler can't inline
+- Slice/map literals that grow beyond known bounds
+
+### Avoiding Unnecessary Escapes
+
+```go
+// Escapes — returns pointer, forces heap allocation
+func newThing() *Thing {
+    t := Thing{Name: "x"}
+    return &t
+}
+
+// Stays on stack — caller owns the memory
+func initThing(t *Thing) {
+    t.Name = "x"
+}
+```
+
+## Common Optimization Techniques
+
+### Preallocation
+
+```go
+// Avoid — grows slice multiple times, each grow allocates
+items := []string{}
+for _, v := range data {
+    items = append(items, v)
+}
+
+// Good — allocate once with known capacity
+items := make([]string, 0, len(data))
+for _, v := range data {
+    items = append(items, v)
+}
+```
+
+### String Building
+
+```go
+// Avoid — each += allocates a new string
+result := ""
+for _, s := range parts {
+    result += s
+}
+
+// Good — single allocation
+var b strings.Builder
+for _, s := range parts {
+    b.WriteString(s)
+}
+result := b.String()
+```
+
+### Buffer Reuse
+
+```go
+// Avoid — allocates buffer every call
+func readByte(r io.Reader) (byte, error) {
+    var buf [1]byte
+    _, err := r.Read(buf[:])
+    return buf[0], err
+}
+
+// Good — caller provides reusable buffer
+func readByte(r io.Reader, buf []byte) (byte, error) {
+    _, err := r.Read(buf)
+    return buf[0], err
+}
+```
+
+### Buffered I/O
+
+```go
+// Avoid — each Read() call hits the OS
+count := process(file)
+
+// Good — bufio batches reads, dramatically fewer syscalls
+br := bufio.NewReader(file)
+count := process(br)
+```
+
+### sync.Pool for Frequent Allocations
+
+```go
+var bufPool = sync.Pool{
+    New: func() any {
+        return new(bytes.Buffer)
+    },
+}
+
+func process() {
+    buf := bufPool.Get().(*bytes.Buffer)
+    buf.Reset()
+    defer bufPool.Put(buf)
+    // use buf...
+}
+```
+
+CRITICAL: `sync.Pool` objects may be collected at any GC cycle. Never rely on pool for correctness — only for performance.
+
+### Struct Field Alignment
+
+```go
+// Wastes memory — padding between fields
+type Bad struct {
+    a bool    // 1 byte + 7 padding
+    b int64   // 8 bytes
+    c bool    // 1 byte + 7 padding
+}             // = 24 bytes
+
+// Compact — fields ordered by size descending
+type Good struct {
+    b int64   // 8 bytes
+    a bool    // 1 byte
+    c bool    // 1 byte + 6 padding
+}             // = 16 bytes
+```
+
+### Hot Path: Avoid Interface Boxing
+
+```go
+// Avoid in hot loops — each call boxes the int into interface{}
+fmt.Sprintf("%d", n)
+
+// Good — no interface boxing
+strconv.Itoa(n)
+```
+
+## Profile-Guided Optimization (PGO)
+
+Available since Go 1.21. Uses production CPU profiles to guide compiler optimizations (inlining, devirtualization). Typical improvement: 7-14% CPU reduction.
+
+### PGO Workflow
+
+1. Build and deploy WITHOUT PGO (baseline)
+2. Collect a CPU profile from production (representative workload)
+3. Save as `default.pgo` in the main package directory
+4. Rebuild — the compiler auto-detects `default.pgo`
+5. Deploy and measure improvement
+
+```bash
+# Collect production profile (30 seconds)
+curl -o default.pgo 'http://localhost:6060/debug/pprof/profile?seconds=30'
+
+# Rebuild with PGO (automatic — compiler finds default.pgo)
+go build -o myapp ./cmd/myapp/
+```
+
+Use production profiles, NOT synthetic benchmarks. PGO optimizes the code paths that actually run in production.
+
+## Runtime Tuning
+
+### GOGC (Garbage Collection Target)
+
+Controls GC frequency. Default: `GOGC=100` (GC runs when heap doubles).
+
+- `GOGC=50` — GC runs more often, lower memory usage, higher CPU for GC
+- `GOGC=200` — GC runs less often, higher memory usage, lower CPU for GC
+- `GOGC=off` — Disable GC entirely (batch jobs that exit quickly)
+
+### GOMEMLIMIT (Go 1.19+)
+
+Soft memory limit. GC becomes more aggressive as heap approaches this limit.
+
+```bash
+GOMEMLIMIT=512MiB ./myapp
+```
+
+CRITICAL: This is a SOFT limit. It does not prevent OOM if live heap exceeds the limit. It tells the GC to work harder to stay under the target.
+
+### Latency vs Throughput Trade-off
+
+- **Latency-sensitive** (APIs): Lower GOGC (more frequent, shorter GC pauses)
+- **Throughput-oriented** (batch): Higher GOGC or `GOGC=off` (minimize GC overhead)
+- **Memory-constrained**: Set GOMEMLIMIT, let GC adapt automatically
+
+## Execution Tracing
+
+### When to Use
+
+Use `runtime/trace` when profiling shows the code isn't CPU-bound but is still slow — indicates goroutine scheduling issues, GC pauses, or contention.
+
+### Generating Traces
+
+```bash
+go test -trace=trace.out -bench=. -run=^$ ./pkg/
+```
+
+### Extracting Profiles from Traces
+
+Traces can be converted to pprof profiles for text-based analysis:
+
+```bash
+go tool trace -pprof=net trace.out > trace-net.pprof      # Network blocking
+go tool trace -pprof=sync trace.out > trace-sync.pprof    # Sync blocking
+go tool trace -pprof=syscall trace.out > trace-syscall.pprof  # Syscall blocking
+go tool trace -pprof=sched trace.out > trace-sched.pprof  # Scheduler latency
+```
+
+### Go 1.22+ Improvements
+
+- 90% reduction in tracing overhead (1-2% vs previous 10-20%)
+- Flight recorder mode — continuous recording with on-demand capture
+- Safe for production use at low overhead
+
+## OpenTelemetry for Go (Distributed Tracing)
+
+When performance problems span multiple services, use OpenTelemetry for distributed tracing.
+
+### Key Concepts
+
+- **TracerProvider**: Creates tracers, manages span export
+- **Span**: Unit of work with name, timing, attributes
+- **Context propagation**: Carries trace IDs across service boundaries (HTTP headers)
+- **OTLP**: Standard export protocol to backends (Jaeger, Tempo, Datadog)
+
+### When to Use
+
+- Request latency varies across services — need to find which service is slow
+- Microservice architectures where a request touches multiple services
+- Production latency investigation where local profiling isn't sufficient
+
+OpenTelemetry complements local profiling: pprof finds hotspots within a service, OTel finds which service is the bottleneck.
+
+## Continuous Profiling
+
+For production systems, consider always-on profiling:
+
+- **Grafana Pyroscope** (open source) — aggregates profiles over time, integrates with Grafana
+- **Google Cloud Profiler** — <0.5% overhead, 30-day retention
+- **Datadog Continuous Profiler** — integrates with PGO for automatic optimization
+
+Continuous profiling catches performance regressions that only appear under production load patterns.
+
+## Anti-Patterns
+
+- Optimizing without profiling data — you WILL optimize the wrong thing
+- Premature micro-optimization (removing interfaces, using `unsafe`) without measurement
+- Ignoring allocations in hot loops — allocations are often the #1 bottleneck
+- Using `interface{}` / `any` in performance-critical paths without benchmarking the cost
+- Forgetting `-count` flag — a single benchmark run has no statistical validity
+- Profiling debug builds instead of release builds
+- Using synthetic workloads for PGO instead of production profiles
+- Calling `runtime.ReadMemStats()` frequently — it triggers a stop-the-world pause
+
+## Benchmarking Reminders
+
+- Use `b.Loop()` (Go 1.24+) instead of `for i := 0; i < b.N; i++` — prevents compiler
+  from optimizing away the benchmark target. For Go < 1.24, use a sink variable with `b.N`
+- Use `b.ReportAllocs()` or `-benchmem` to track allocations per operation
+- Use `-count=6` minimum for benchstat comparisons (more runs = better statistics)
+- Use `b.StopTimer()`/`b.StartTimer()` to exclude setup from timing
+- Use `benchstat old.bench new.bench` — check p-value < 0.05 for significance
+
+## Quick Reference: Latency Numbers
+
+Understanding relative costs helps prioritize optimizations:
+
+| Operation | Latency | Relative |
+|-----------|---------|----------|
+| L1 cache reference | 0.5 ns | 1x |
+| Main memory reference | 100 ns | 200x |
+| SSD random read (NVMe) | 100 µs | 200,000x |
+| HDD disk seek | 10 ms | 20,000,000x |
+| Network round-trip (same datacenter) | 500 µs | 1,000,000x |
+| Network round-trip (cross datacenter) | 150 ms | 300,000,000x |
+
+Focus on I/O and allocation patterns first. Nanosecond-level CPU optimizations rarely matter unless you're in a tight inner loop processing millions of items.
+
+<!-- cache:end -->
+
+---
+
+*Powered by [Gopher Guides](https://gopherguides.com) training materials.*

--- a/.agents/skills/gopher-guides/SKILL.md
+++ b/.agents/skills/gopher-guides/SKILL.md
@@ -1,0 +1,122 @@
+---
+name: gopher-guides
+description: |
+  WHEN: User asks about Go best practices, idiomatic patterns, how to properly implement
+  something in Go, or wants authoritative training material. Trigger when reviewing Go code,
+  asking "what's the right way to...", "is this correct Go?", "how do professionals do this?",
+  or requesting Go training/learning resources. Also activate when user needs Go code review
+  feedback, wants to understand Go conventions, or is learning Go. This skill provides
+  official Gopher Guides training materials via API — use it whenever professional Go
+  guidance would improve the answer.
+  WHEN NOT: Questions entirely unrelated to Go programming
+---
+
+# Gopher Guides Professional Training
+
+Access official Gopher Guides training materials via API for authoritative Go best practices.
+
+## Important: Always Use `--variable`/`--expand-header` Syntax
+
+**Do NOT use `$VAR` or `${VAR}` shell expansion in curl commands.** Environment variable expansion is unreliable in AI coding assistant shell/bash tools (Claude Code, Codex, etc.). Always use curl's built-in `--variable %` and `--expand-header` syntax instead.
+
+> **Requires curl 8.3+.** If you get `unknown option: --variable`, see the fallback note at the bottom.
+
+## Step 1: Verify API Key
+
+```bash
+curl -s --variable %GOPHER_GUIDES_API_KEY \
+  --expand-header "Authorization: Bearer {{GOPHER_GUIDES_API_KEY}}" \
+  https://gopherguides.com/api/gopher-ai/me
+```
+
+**On success**: Display a brief confirmation to the user, then proceed to Step 2:
+- "✓ Gopher Guides API: Authenticated as {email} ({tier_category} tier)"
+
+**On error or missing key**: Help the user configure:
+1. Get API key at [gopherguides.com](https://gopherguides.com)
+2. Add to shell profile (`~/.zshrc` or `~/.bashrc`): `export GOPHER_GUIDES_API_KEY="your-key"`
+3. Restart your terminal/IDE to pick up the new environment variable
+
+**Do NOT provide Go advice without a valid, verified API key.**
+
+## Step 2: Query the API
+
+Use the cache wrapper script for all API calls. It automatically caches responses
+(24h for practices/examples, 1h for audit/review) to avoid redundant API calls.
+
+The cache wrapper is at `${CLAUDE_PLUGIN_ROOT}/scripts/cache-api.sh`.
+
+### For "what's the best way to..." questions
+
+```bash
+"${CLAUDE_PLUGIN_ROOT}/scripts/cache-api.sh" practices '{"topic": "error handling"}'
+```
+
+### For code review/audit
+
+```bash
+"${CLAUDE_PLUGIN_ROOT}/scripts/cache-api.sh" audit '{"code": "<user code here>", "focus": "error-handling"}'
+```
+
+### For "show me an example of..."
+
+```bash
+"${CLAUDE_PLUGIN_ROOT}/scripts/cache-api.sh" examples '{"topic": "table driven tests"}'
+```
+
+### For PR/diff review
+
+```bash
+"${CLAUDE_PLUGIN_ROOT}/scripts/cache-api.sh" review '{"diff": "<diff output>"}'
+```
+
+### Direct API calls (bypassing cache)
+
+If you need to bypass the cache, use curl directly:
+
+```bash
+curl -s -X POST -H "Authorization: Bearer $GOPHER_GUIDES_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{"topic": "error handling"}' \
+  https://gopherguides.com/api/gopher-ai/practices
+```
+
+### Cache Management
+
+- Cache location: `.claude/gopher-guides-cache.json`
+- Clear cache: Use `/clear-cache` command
+- TTL: 24 hours (practices, examples), 1 hour (audit, review)
+
+## Response Handling
+
+The API returns JSON with:
+- `content`: Formatted guidance from training materials
+- `sources`: Module references with similarity scores
+
+Present the content to the user with proper attribution to Gopher Guides.
+
+## Topics Covered
+
+The training materials cover:
+
+- **Fundamentals**: Types, functions, packages, errors
+- **Testing**: Table-driven tests, mocks, benchmarks
+- **Concurrency**: Goroutines, channels, sync, context
+- **Web Development**: HTTP handlers, middleware, APIs
+- **Database**: SQL, ORMs, migrations
+- **Best Practices**: Code organization, error handling, interfaces
+- **Tooling**: go mod, go test, linters, profiling
+
+## Fallback for curl < 8.3
+
+If `--variable` is not supported (curl versions before 8.3), use `printf` to avoid shell expansion issues:
+
+```sh
+KEY=$(printenv GOPHER_GUIDES_API_KEY) && curl -s -H "Authorization: Bearer $KEY" https://gopherguides.com/api/gopher-ai/me
+```
+
+Check your curl version with `curl --version`.
+
+---
+
+*Powered by [Gopher Guides](https://gopherguides.com) - the official Go training partner.*

--- a/.agents/skills/htmx/SKILL.md
+++ b/.agents/skills/htmx/SKILL.md
@@ -1,0 +1,1087 @@
+---
+name: htmx
+description: |
+  WHEN: User is building web apps with htmx, writing hx-* attributes, handling htmx events,
+  using htmx with Go templ templates, debugging htmx requests/swaps, asking about htmx
+  patterns including OOB swaps, SSE, WebSockets, extensions, or JavaScript integration.
+  Also trigger when user mentions "partial page updates", "swap", "boost", "trigger",
+  "hx-get/post/put/delete", server-sent events in web context, or is building hypermedia-driven
+  apps. Activate whenever htmx is in the project dependencies or HTML templates contain hx-* attrs.
+  WHEN NOT: Pure client-side SPA frameworks (React/Vue/Svelte) without htmx
+---
+
+<!-- cache:start -->
+
+# htmx Best Practices & Go/Templ Integration
+
+Apply correct htmx patterns when building hypermedia-driven web applications, especially with Go and templ.
+
+## Core Principles
+
+- **Return HTML fragments, not JSON** — htmx is designed for hypermedia; the server returns rendered HTML
+- **Use HTML attributes, not JavaScript** — prefer `hx-*` attributes over `htmx.ajax()` or `fetch()` calls
+- **Server controls behavior** — use response headers (`HX-Retarget`, `HX-Reswap`, `HX-Redirect`) for control flow
+- **Check `HX-Request` header** — return fragments for htmx requests, full pages for normal requests
+- **Don't mix paradigms** — avoid using `fetch()` alongside htmx in the same page; pick one approach
+
+---
+
+## Templ Interpolation Rules (CRITICAL)
+
+Templ does NOT support string interpolation inside quoted attribute values. This is the #1 source of bugs.
+
+### Dynamic Attributes
+
+```go
+// CORRECT: Go expression in curly braces (no quotes around braces)
+templ ItemLink(id string) {
+    <div hx-get={ fmt.Sprintf("/items/%s", id) }>Load</div>
+}
+
+// CORRECT: String concatenation also works
+templ ItemLink(id string) {
+    <div hx-get={ "/items/" + id }>Load</div>
+}
+
+// CORRECT: Echo named routes for type-safe URLs
+templ ItemLink(c echo.Context, id string) {
+    <div hx-get={ c.Echo().Reverse("items-show", id) }>Load</div>
+}
+
+// WRONG: No interpolation inside quoted strings — emits literal "{ id }"
+templ ItemLink(id string) {
+    <div hx-get="/items/{ id }">Load</div>
+}
+```
+
+### Dynamic JSON in hx-vals — Use json.Marshal, Not fmt.Sprintf
+
+`fmt.Sprintf` with `%s` into JSON is an injection risk if the value contains `"`, `\`, or newlines. Always use `json.Marshal` or `%q` for safety.
+
+```go
+// CORRECT: json.Marshal helper (safest — handles all special characters)
+func hxVals(data map[string]any) string {
+    b, err := json.Marshal(data)
+    if err != nil {
+        return "{}"
+    }
+    return string(b)
+}
+
+templ ItemButton(item Item) {
+    <button hx-post="/api/items" hx-vals={ hxVals(map[string]any{"id": item.ID}) }>
+        Save
+    </button>
+}
+
+// CORRECT: %q for CSRF tokens (Go-safe quoting, handles quotes/backslashes)
+templ Layout(c echo.Context, content templ.Component) {
+    <body hx-headers={ fmt.Sprintf(`{"X-CSRF-Token": %q}`, CSRFToken(c)) }>
+        @content
+    </body>
+}
+
+// CORRECT: Static JSON uses plain quoted attribute
+templ StaticVals() {
+    <button hx-post="/api" hx-vals='{"key": "value"}'>Submit</button>
+}
+
+// DANGEROUS: %s with unescaped strings — breaks if value contains quotes
+// A message like: Missing "alt" attribute → produces broken JSON
+templ BrokenVals(message string) {
+    <button hx-vals={ fmt.Sprintf(`{"message": "%s"}`, message) }>Send</button>
+}
+
+// WRONG: Mixing constant and dynamic syntax — emits literal "{ token }"
+templ BrokenVals(token string) {
+    <button hx-vals='{"csrf": "{ token }"}'>Submit</button>
+}
+```
+
+### URL Construction
+
+```go
+// CORRECT: fmt.Sprintf for server-constructed URLs with multiple params
+templ ItemRow(item Item) {
+    <tr hx-get={ fmt.Sprintf("/items/%d/edit", item.ID) } hx-trigger="click"
+        hx-target="this" hx-swap="outerHTML">
+        <td>{ item.Name }</td>
+    </tr>
+}
+
+// CORRECT: String concatenation for simple paths
+templ JobRow(jobID string) {
+    <tr hx-get={ "/api/jobs/" + jobID + "/row" } hx-trigger="every 2s" hx-swap="outerHTML">
+        // row content
+    </tr>
+}
+
+// CORRECT: Query parameters appended to route
+templ Pagination(c echo.Context, saID string, limit, offset int) {
+    <button hx-get={ c.Echo().Reverse("transactions", saID) +
+        fmt.Sprintf("?limit=%d&offset=%d", limit, offset) }>
+        Next
+    </button>
+}
+
+// CORRECT: templ.URL() for user-influenced URLs
+templ UserLink(userURL string) {
+    <a hx-get={ string(templ.URL(userURL)) }>Profile</a>
+}
+
+// IMPORTANT: URL-encode dynamic query param values
+templ Search(query string) {
+    <button hx-get={ fmt.Sprintf("/search?q=%s", url.QueryEscape(query)) }>Search</button>
+}
+```
+
+### HTML Escaping is Normal
+
+Templ HTML-escapes all attribute values (`"` becomes `&quot;`). This is **correct behavior** — browsers un-escape it before htmx reads the attribute via the DOM API. Never try to work around this.
+
+---
+
+## Templ Component Patterns
+
+### Spread Attributes for Reusable Components
+
+Use `templ.Attributes` with spread syntax to inject htmx attributes into reusable UI components. This keeps components htmx-agnostic while allowing consumers to add any htmx behavior.
+
+```go
+// Component definition — accepts arbitrary attributes via spread
+templ Button(text string, attrs templ.Attributes) {
+    <button class="btn btn-primary" { attrs... }>{ text }</button>
+}
+
+// Consumer injects htmx behavior
+@Button("Save", templ.Attributes{
+    "hx-post":   "/api/items",
+    "hx-target": "#result",
+    "hx-swap":   "innerHTML",
+})
+
+// Works with templUI-style Props pattern too
+@input.Input(input.Props{
+    Type:  input.TypeSearch,
+    Name:  "search",
+    Attributes: templ.Attributes{
+        "hx-get":     "/users?partial=true",
+        "hx-trigger": "input changed delay:300ms",
+        "hx-target":  "#users-table",
+    },
+})
+```
+
+### Conditional Attributes
+
+Use templ `if` blocks inside element tags for conditional htmx behavior:
+
+```go
+// Dual-mode form: create vs edit
+templ TaskForm(c echo.Context, task *Task) {
+    <form
+        if task != nil {
+            hx-put={ fmt.Sprintf("/tasks/%d", task.ID) }
+            hx-target={ fmt.Sprintf("#task-%d", task.ID) }
+            hx-swap="outerHTML"
+        } else {
+            hx-post="/tasks"
+            hx-target="#task-list"
+            hx-swap="afterbegin"
+        }
+    >
+        // form fields
+    </form>
+}
+
+// Self-terminating polling (only poll while job is active)
+templ JobRow(job Job) {
+    if job.Status == "running" || job.Status == "pending" {
+        <tr id={ "job-" + job.ID }
+            hx-get={ "/api/jobs/" + job.ID + "/row" }
+            hx-trigger="every 2s"
+            hx-swap="outerHTML">
+            @jobRowContent(job)
+        </tr>
+    } else {
+        <tr id={ "job-" + job.ID }>
+            @jobRowContent(job)
+        </tr>
+    }
+}
+
+// Boolean attributes
+templ SubmitButton(isDisabled bool) {
+    <button hx-post="/submit" disabled?={ isDisabled }>Submit</button>
+}
+
+// selected?= for option elements (cleaner than if blocks)
+<option value="low" selected?={ task.Priority == "low" }>Low</option>
+```
+
+### Separated Components for Full Page vs Partial
+
+Extract the inner content as a separate component so the same templ renders both as a full page and as an htmx partial:
+
+```go
+// Full page (normal request)
+templ ProductDetail(c echo.Context, product Product) {
+    @layouts.Main(c, product.Name) {
+        <div id="product-detail">
+            @ProductDetailContent(product)
+        </div>
+    }
+}
+
+// Partial (htmx request) — same inner component
+templ ProductDetailContent(product Product) {
+    <h1>{ product.Name }</h1>
+    // ...
+}
+```
+
+---
+
+## JavaScript and hx-on Events in Templ
+
+Templ treats `hx-on:*` attributes as script attributes. They expect `templ.JSFuncCall` or constant strings, NOT plain Go string variables.
+
+### Correct Patterns
+
+```go
+// CORRECT: Simple constant inline JS
+templ SimpleButton() {
+    <button hx-get="/items"
+        hx-on::after-request="document.getElementById('spinner').classList.add('hidden')">
+        Load
+    </button>
+}
+
+// CORRECT: Conditional form reset on success
+templ ContactForm() {
+    <form hx-post="/contact"
+        hx-on::after-request="if(event.detail.successful) this.reset()">
+        // fields
+    </form>
+}
+
+// CORRECT: templ.JSFuncCall for dynamic data
+var confirmHandle = templ.NewOnceHandle()
+
+templ DeleteButton(id string) {
+    @confirmHandle.Once() {
+        <script>
+            function confirmDelete(id, event) {
+                if (!confirm("Delete item " + id + "?")) {
+                    event.preventDefault();
+                }
+            }
+        </script>
+    }
+    <button hx-delete={ fmt.Sprintf("/api/items/%s", id) }
+        hx-on::before-request={ templ.JSFuncCall("confirmDelete", id) }>
+        Delete
+    </button>
+}
+
+// CORRECT: templ.JSFuncCall for onclick with dynamic args (safely escapes values)
+templ CopyButton(text string) {
+    <button onclick={ templ.JSFuncCall("copyToClipboard", text) }>
+        Copy
+    </button>
+}
+
+// WRONG: Plain Go string variable for hx-on
+templ BrokenHandler(handler string) {
+    <button hx-on::click={ handler }>Click</button>
+}
+```
+
+### Event Name Syntax
+
+```html
+<!-- All valid: -->
+<button hx-on::before-request="...">        <!-- shorthand (double colon, omits htmx:) -->
+<button hx-on:htmx:before-request="...">    <!-- long form -->
+<button hx-on--before-request="...">         <!-- dash form (JSX-compatible) -->
+
+<!-- WRONG: camelCase (HTML attributes are case-insensitive) -->
+<button hx-on:htmx:beforeRequest="...">
+```
+
+### Alpine.js Listening to htmx Events
+
+```go
+// Alpine can listen to htmx events with @ syntax
+<form hx-put="/tasks/1" hx-target="closest div" hx-swap="outerHTML"
+    @htmx:after-request="editing = false">
+```
+
+### Embedding Go Data in Script Tags
+
+```go
+// {{ }} syntax inside script tags for string values
+templ PageScript(endpoint string) {
+    <script>
+        const endpoint = "{{ endpoint }}";
+    </script>
+}
+
+// templ.JSONScript for structured data (safest)
+templ ItemPage(items []Item) {
+    @templ.JSONScript("items-data", items)
+    <script>
+        const items = JSON.parse(document.getElementById('items-data').textContent);
+    </script>
+}
+
+// templ.NewOnceHandle() prevents duplicate script tags in repeated components
+```
+
+### Dynamic hx-post via JavaScript (When URL Is Unknown Until Interaction)
+
+When the target URL depends on user interaction (e.g., editing different rows in a shared modal), set it dynamically and re-process:
+
+```javascript
+const form = document.getElementById('edit-form');
+form.setAttribute('hx-post', '/items/' + itemId + '/edit');
+htmx.process(form);  // CRITICAL: htmx must re-scan to pick up the new attribute
+```
+
+---
+
+## Go Handler Patterns
+
+### Fragment vs Full Page
+
+```go
+// Standard pattern with helper function
+func isHTMXRequest(r *http.Request) bool {
+    return r.Header.Get("HX-Request") == "true"
+}
+
+func (h *Handler) ListItems(c echo.Context) error {
+    items, err := h.store.ListItems(c.Request().Context())
+    if err != nil {
+        return err
+    }
+    if isHTMXRequest(c.Request()) {
+        return views.ItemList(items).Render(c.Request().Context(), c.Response().Writer)
+    }
+    return views.ItemsPage(c, items).Render(c.Request().Context(), c.Response().Writer)
+}
+```
+
+### Alternative: Separate Routes for Partials
+
+Instead of checking `HX-Request`, use route structure:
+
+```go
+e.GET("/items", h.ItemsPage)          // Full page
+e.GET("/api/items", h.ItemsPartial)    // htmx partial
+```
+
+### Multi-Target Response with OOB (Writing Multiple Components)
+
+```go
+func (h *Handler) CreateAPIKey(c echo.Context) error {
+    // ... create key ...
+    ctx := c.Request().Context()
+
+    // Render primary response first (goes to hx-target)
+    if err := views.APIKeysList(c, keys).Render(ctx, c.Response().Writer); err != nil {
+        return err
+    }
+    // Then render OOB component (has hx-swap-oob="true", goes to its own target)
+    if err := views.NewKeyModal(c, apiKey).Render(ctx, c.Response().Writer); err != nil {
+        return err
+    }
+    return nil
+}
+```
+
+### htmx-Aware Redirects
+
+Always check `HX-Request` before redirecting — htmx ignores HTTP 302 redirects:
+
+```go
+func Redirect(c echo.Context, url string) error {
+    if c.Request().Header.Get("HX-Request") == "true" {
+        c.Response().Header().Set("HX-Redirect", url)
+        return c.NoContent(http.StatusOK)
+    }
+    return c.Redirect(http.StatusSeeOther, url)
+}
+```
+
+### Event-Driven List Reloads with HX-Trigger
+
+Instead of OOB swaps, trigger a client-side refetch after mutations:
+
+```go
+// Handler: signal that data changed
+func (h *Handler) DeleteItem(c echo.Context) error {
+    // ... delete ...
+    c.Response().Header().Set("HX-Trigger", "reloadList")
+    return c.NoContent(http.StatusOK)
+}
+```
+
+```go
+// Template: list container listens for the event
+<div id="items-list"
+    hx-get={ c.Echo().Reverse("items-list") }
+    hx-trigger="reloadList from:body"
+    hx-swap="innerHTML">
+    // items here
+</div>
+```
+
+### Delete with Empty Response
+
+```go
+// Return empty 200 — htmx removes the element via hx-swap="delete" or hx-swap="outerHTML"
+func (h *Handler) DeleteItem(c echo.Context) error {
+    // ... delete ...
+    return c.NoContent(http.StatusOK)
+}
+```
+
+### Validation Error Re-rendering
+
+Store errors in echo context and re-render the same form component:
+
+```go
+func (h *Handler) UpdateItem(c echo.Context) error {
+    errMap := NewErrMap()
+    if name == "" {
+        errMap.Add("name", "Name is required")
+    }
+    if len(errMap) > 0 {
+        c.Set("errors", errMap)
+        return views.ItemForm(c, item).Render(c.Request().Context(), c.Response().Writer)
+    }
+    // ... save ...
+}
+```
+
+```go
+// In templ: conditional error display
+<input name="name" type="text"
+    class={ "border rounded px-3 py-2",
+        templ.KV("border-red-300", views.HasErrors(c, "name")),
+        templ.KV("border-gray-300", !views.HasErrors(c, "name")) }>
+if views.HasErrors(c, "name") {
+    <p class="text-red-500 text-sm">{ views.FirstError(c, "name") }</p>
+}
+```
+
+---
+
+## Swap Strategies
+
+| Strategy | Behavior | When to Use |
+|----------|----------|-------------|
+| `innerHTML` | Replace inner content (default) | Update container contents |
+| `outerHTML` | Replace entire element | Replace a component entirely, inline edit |
+| `textContent` | Replace text only, no HTML parsing | Display raw text safely |
+| `beforebegin` | Insert before target | Add sibling before element |
+| `afterbegin` | Prepend inside target | Prepend to a list (new items first) |
+| `beforeend` | Append inside target | Append to a list (infinite scroll) |
+| `afterend` | Insert after target | Add sibling after element |
+| `delete` | Remove target element | Delete items from lists |
+| `none` | No swap (OOB still processed) | Side-effect-only requests, HX-Redirect |
+| `morph` | Idiomorph morphing (extension) | Preserve state/focus during updates |
+
+### Swap Modifiers
+
+Append to `hx-swap` value: `hx-swap="innerHTML swap:500ms settle:100ms scroll:top transition:true focus-scroll:true ignoreTitle:true"`
+
+---
+
+## Trigger Patterns
+
+```html
+<!-- Standard events -->
+<button hx-get="/api" hx-trigger="click">Click</button>
+<input hx-get="/search" hx-trigger="input changed delay:500ms" hx-target="#results">
+<form hx-post="/submit" hx-trigger="submit">
+
+<!-- Special triggers -->
+<div hx-get="/content" hx-trigger="load">                  <!-- On page load -->
+<div hx-get="/content" hx-trigger="revealed">               <!-- When scrolled into view -->
+<div hx-get="/content" hx-trigger="intersect threshold:0.5"> <!-- Intersection observer -->
+<div hx-get="/poll" hx-trigger="every 2s">                  <!-- Polling -->
+
+<!-- Modifiers -->
+<button hx-get="/api" hx-trigger="click once">              <!-- Fire once only -->
+<input hx-get="/validate" hx-trigger="input changed delay:300ms"> <!-- Debounce -->
+<input hx-get="/search" hx-trigger="keyup changed delay:500ms, search"> <!-- Debounce + clear button -->
+<input hx-get="/search" hx-trigger="keyup throttle:500ms">  <!-- Throttle -->
+<button hx-get="/api" hx-trigger="click from:body">         <!-- Listen on different element -->
+<button hx-get="/api" hx-trigger="click consume">           <!-- Stop propagation -->
+<button hx-get="/api" hx-trigger="click queue:last">        <!-- Queue strategy -->
+
+<!-- Event filters (JS boolean expressions) -->
+<button hx-get="/api" hx-trigger="click[ctrlKey]">          <!-- Only with Ctrl held -->
+<input hx-get="/api" hx-trigger="keyup[key=='Enter']">      <!-- Only on Enter key -->
+
+<!-- Multiple triggers -->
+<div hx-get="/api" hx-trigger="click, keyup[key=='Enter'] from:body">
+
+<!-- Event-driven trigger (from HX-Trigger response header) -->
+<div hx-get="/items" hx-trigger="reloadList from:body" hx-swap="innerHTML">
+```
+
+### Self-Terminating Polling
+
+The best polling pattern: include `hx-trigger="every Ns"` only when the condition is active. When the server returns a response without the polling attributes, polling stops automatically.
+
+```go
+templ JobRow(job Job) {
+    if job.Status == "running" || job.Status == "pending" {
+        <tr id={ "job-" + job.ID }
+            hx-get={ "/api/jobs/" + job.ID + "/row" }
+            hx-trigger="every 2s"
+            hx-swap="outerHTML">
+            @jobRowContent(job)
+        </tr>
+    } else {
+        <tr id={ "job-" + job.ID }>
+            @jobRowContent(job)
+        </tr>
+    }
+}
+```
+
+---
+
+## Request/Response Headers
+
+### Request Headers (sent by htmx automatically)
+
+| Header | Value |
+|--------|-------|
+| `HX-Request` | Always `"true"` — do NOT set this manually via `hx-headers`, it's redundant |
+| `HX-Trigger` | ID of triggering element |
+| `HX-Trigger-Name` | Name of triggering element |
+| `HX-Target` | ID of target element |
+| `HX-Current-URL` | Browser's current URL |
+| `HX-Boosted` | `"true"` if boosted |
+
+### Response Headers (server sends to control htmx)
+
+| Header | Effect |
+|--------|--------|
+| `HX-Location` | Client-side redirect without full page reload |
+| `HX-Push-Url` | Push URL into browser history |
+| `HX-Redirect` | Full page redirect (use instead of HTTP 302 for htmx) |
+| `HX-Refresh` | Full page refresh if `"true"` |
+| `HX-Replace-Url` | Replace current URL in history |
+| `HX-Reswap` | Override swap strategy |
+| `HX-Retarget` | Override target element (CSS selector) |
+| `HX-Trigger` | Trigger client-side events (JSON for multiple) |
+| `HX-Trigger-After-Swap` | Trigger events after swap |
+| `HX-Trigger-After-Settle` | Trigger events after settle |
+
+---
+
+## Out-of-Band (OOB) Swaps
+
+Update multiple parts of the page from a single response:
+
+```go
+// Go handler writes multiple components — primary first, then OOB
+templ PrimaryResponse(task Task) {
+    @TaskItem(task)
+}
+
+templ StatsOOB(stats Stats) {
+    <div id="task-count" hx-swap-oob="true">
+        { fmt.Sprint(stats.Total) } tasks
+    </div>
+}
+
+// Tab state OOB update (update active tab styling alongside content)
+templ FilterTabsOOB(activeFilter string) {
+    <div id="filter-tabs" hx-swap-oob="outerHTML:#filter-tabs">
+        // tabs with active styling
+    </div>
+}
+
+// Style card OOB (two-panel sync — update sidebar card when detail panel changes)
+templ StyleCardOOB(data StyleCardData) {
+    <div id={ fmt.Sprintf("style-card-%s", data.StyleID) } hx-swap-oob="true"
+        class="border-emerald-500 bg-emerald-500/10">
+        // card content
+    </div>
+}
+```
+
+### OOB Gotchas
+
+- OOB elements **must have matching IDs** on the page
+- Primary content must come first in the response
+- Table elements (`<tr>`, `<td>`) need `<template>` wrappers for OOB
+- If OOB target is inside the primary swap area, it may not exist when OOB runs
+- Sending only OOB content with no primary response replaces the target with nothing
+- Nested OOB is processed by default; disable with `htmx.config.allowNestedOobSwaps = false`
+
+---
+
+## Error Handling
+
+### 4xx/5xx Responses Don't Swap by Default
+
+This is a major gotcha. Form validation returning 422 won't display errors unless configured.
+
+**Option 1: Re-render form at 200 with error state** (most common in Go/templ)
+
+The server returns HTTP 200 with the form re-rendered showing inline errors. This avoids the 4xx swap problem entirely.
+
+**Option 2: response-targets extension**
+
+```html
+<script src="https://cdn.jsdelivr.net/npm/htmx-ext-response-targets@2.0.4"></script>
+<div hx-ext="response-targets">
+    <form hx-post="/register"
+        hx-target="#success"
+        hx-target-422="#validation-errors"
+        hx-target-5*="#server-error">
+    </form>
+</div>
+```
+
+**Option 3: HX-Retarget response header**
+
+```go
+if c.Request().Header.Get("HX-Request") == "true" {
+    c.Response().Header().Set("HX-Retarget", "#error-container")
+    return views.ErrorAlert(message).Render(c.Request().Context(), c.Response().Writer)
+}
+```
+
+**Option 4: beforeSwap event**
+
+```javascript
+document.body.addEventListener('htmx:beforeSwap', function(event) {
+    if (event.detail.xhr.status === 422) {
+        event.detail.shouldSwap = true;
+        event.detail.isError = false;
+    }
+});
+```
+
+---
+
+## Filter State Preservation
+
+When building filter/search UIs, use `hx-include` to carry all filter values and `hx-push-url` for bookmarkable URLs:
+
+```go
+templ ProductFilters(sortBy, sortDir, brand, category string) {
+    // Hidden inputs carry state across filter changes
+    <input type="hidden" name="sort" value={ sortBy }/>
+    <input type="hidden" name="dir" value={ sortDir }/>
+    <input type="hidden" name="category" value={ category }/>
+
+    <select name="brand"
+        hx-get="/products"
+        hx-trigger="change"
+        hx-target="#products-table"
+        hx-include="[name='q'],[name='sort'],[name='dir'],[name='category']"
+        hx-push-url="true">
+        // options
+    </select>
+
+    <input type="search" name="q"
+        hx-get="/products"
+        hx-trigger="input changed delay:300ms, search"
+        hx-target="#products-table"
+        hx-include="[name='brand'],[name='sort'],[name='dir'],[name='category']"
+        hx-push-url="true">
+}
+```
+
+---
+
+## Forms and File Uploads
+
+### File Upload with Auto-Submit on Selection
+
+```go
+// Hidden file input triggered by a styled button — uploads immediately on selection
+<input type="file" accept="image/*" multiple
+    class="hidden"
+    x-ref="fileInput"
+    hx-post={ fmt.Sprintf("/items/%s/images", item.ID) }
+    hx-trigger="change"
+    hx-target="#images-section"
+    hx-swap="innerHTML"
+    hx-encoding="multipart/form-data"
+    name="images"/>
+<button @click="$refs.fileInput.click()">Upload Images</button>
+```
+
+### File Upload with Progress and Disabled Submit
+
+```html
+<form hx-post="/upload" hx-encoding="multipart/form-data"
+    hx-indicator="#upload-spinner" hx-disabled-elt="button[type=submit]">
+    <input type="file" name="document">
+    <button type="submit">
+        <span>Upload</span>
+        <span id="upload-spinner" class="htmx-indicator">Uploading...</span>
+    </button>
+</form>
+```
+
+### Include External Values
+
+```html
+<!-- Pull in values from outside the form -->
+<input id="global-filter" name="filter" value="active">
+<form hx-post="/search" hx-include="#global-filter">
+    <input name="query" type="text">
+    <button type="submit">Search</button>
+</form>
+
+<!-- Include a subset of a larger form -->
+<button hx-post="/items/add-color" hx-encoding="multipart/form-data"
+    hx-include="#add-color-form">Add Color</button>
+```
+
+### Radio/Checkbox Auto-Submit
+
+```go
+// Radio buttons that auto-submit on change (default trigger for inputs)
+<input type="radio" name={ fmt.Sprintf("primary-image-%s", productID) }
+    value={ img.ID }
+    checked?={ img.IsPrimary }
+    hx-put={ fmt.Sprintf("/images/%s/set-primary", img.ID) }
+    hx-target="#images-grid"
+    hx-swap="outerHTML"
+    hx-indicator="none">
+```
+
+---
+
+## Inline Editing Pattern
+
+The most common htmx pattern in Go/templ apps:
+
+```go
+// Read-only row
+templ EntryRow(entry Entry) {
+    <tr id={ fmt.Sprintf("entry-%d", entry.ID) }>
+        <td>{ entry.Name }</td>
+        <td>
+            <button hx-get={ fmt.Sprintf("/entries/%d/edit", entry.ID) }
+                hx-target={ fmt.Sprintf("#entry-%d", entry.ID) }
+                hx-swap="outerHTML">Edit</button>
+            <button hx-delete={ fmt.Sprintf("/entries/%d", entry.ID) }
+                hx-target={ fmt.Sprintf("#entry-%d", entry.ID) }
+                hx-swap="delete"
+                hx-confirm="Are you sure?">Delete</button>
+        </td>
+    </tr>
+}
+
+// Edit form (replaces the row)
+templ EntryEditForm(entry Entry) {
+    <tr id={ fmt.Sprintf("entry-%d", entry.ID) }>
+        <td><input name="name" value={ entry.Name } form={ fmt.Sprintf("edit-form-%d", entry.ID) }></td>
+        <td>
+            <form id={ fmt.Sprintf("edit-form-%d", entry.ID) }
+                hx-put={ fmt.Sprintf("/entries/%d", entry.ID) }
+                hx-target={ fmt.Sprintf("#entry-%d", entry.ID) }
+                hx-swap="outerHTML">
+                <button type="submit">Save</button>
+            </form>
+            <button hx-get={ fmt.Sprintf("/entries/%d", entry.ID) }
+                hx-target={ fmt.Sprintf("#entry-%d", entry.ID) }
+                hx-swap="outerHTML">Cancel</button>
+        </td>
+    </tr>
+}
+```
+
+---
+
+## Alpine.js + htmx Integration
+
+### Separation of Concerns
+
+Use htmx for server communication, Alpine for client-side UI state:
+
+```go
+// Alpine dropdown + htmx server action
+<div x-data="{ open: false }">
+    <button @click="open = !open">Actions</button>
+    <div x-show="open" @click.away="open = false" x-transition>
+        <button hx-post={ "/api/scrape/" + brand }
+            hx-swap="none"
+            @click="open = false">
+            Full Scrape
+        </button>
+    </div>
+</div>
+```
+
+### Alpine Reacting to htmx Events
+
+```go
+// Alpine state updates based on htmx lifecycle
+<div x-data="{ loading: false }"
+    @htmx:before-request.window="loading = true"
+    @htmx:after-request.window="loading = false">
+    <div x-show="loading">Loading...</div>
+</div>
+```
+
+### Dynamic Alpine-bound htmx Attributes
+
+When Alpine dynamically sets `hx-*` attributes, htmx doesn't see them because it scanned at page load. Call `htmx.process()` to re-scan:
+
+```html
+<button :hx-post="'/api/favorites/' + productId"
+    hx-swap="outerHTML"
+    x-init="htmx.process($el)">
+```
+
+---
+
+## Loading Indicators
+
+```html
+<!-- Built-in indicator pattern -->
+<button hx-get="/api" hx-indicator="#spinner">Load</button>
+<span id="spinner" class="htmx-indicator">Loading...</span>
+
+<!-- CSS for show/hide indicators -->
+<style>
+.htmx-indicator { display: none; }
+.htmx-request .htmx-indicator { display: inline-flex; }
+.htmx-request.htmx-indicator { display: inline-flex; }
+.htmx-indicator-hide { }
+.htmx-request .htmx-indicator-hide { display: none; }
+</style>
+
+<!-- Toggle text during request -->
+<button hx-post="/save" hx-indicator="this">
+    <span class="htmx-indicator-hide">Save</span>
+    <span class="htmx-indicator">Saving...</span>
+</button>
+
+<!-- Disable button during request -->
+<button hx-post="/save" hx-disabled-elt="this">Save</button>
+
+<!-- Disable all form controls -->
+<form hx-post="/submit" hx-disabled-elt="find input, find button">
+```
+
+---
+
+## htmx Sync Strategies
+
+Prevent request conflicts with `hx-sync`:
+
+```html
+<!-- Replace in-flight request with new one (best for search inputs) -->
+<input hx-get="/search" hx-trigger="input changed delay:300ms" hx-sync="this:replace">
+
+<!-- Abort in-flight request, send new one -->
+<button hx-get="/api" hx-sync="this:abort">Load</button>
+
+<!-- Queue requests, keep only the last -->
+<button hx-get="/api" hx-sync="this:queue last">Load</button>
+
+<!-- Sync with a different element (abort validation on form submit) -->
+<form hx-post="/submit">
+    <input hx-get="/validate" hx-sync="closest form:abort">
+    <button type="submit">Submit</button>
+</form>
+```
+
+---
+
+## Target Selectors
+
+Extended CSS selectors for `hx-target`:
+
+```html
+<button hx-get="/api" hx-target="this">                  <!-- The element itself -->
+<button hx-get="/api" hx-target="closest div">            <!-- Nearest ancestor div -->
+<button hx-get="/api" hx-target="closest tr">             <!-- Nearest table row -->
+<button hx-get="/api" hx-target="next .result">           <!-- Next sibling matching -->
+<button hx-get="/api" hx-target="previous .result">       <!-- Previous sibling matching -->
+<button hx-get="/api" hx-target="find .child">            <!-- Descendant matching -->
+<button hx-get="/api" hx-target="#specific-id">            <!-- Standard CSS selector -->
+```
+
+---
+
+## Common Extensions
+
+### json-enc — Send JSON Bodies
+
+```html
+<script src="https://cdn.jsdelivr.net/npm/htmx-ext-json-enc@2.0.1"></script>
+<form hx-post="/api/users" hx-ext="json-enc">
+    <input name="name" value="John">
+    <button type="submit">Create</button>
+</form>
+```
+
+### SSE — Server-Sent Events
+
+```html
+<script src="https://cdn.jsdelivr.net/npm/htmx-ext-sse@2.2.4"></script>
+<div hx-ext="sse" sse-connect="/events" sse-swap="message">Waiting...</div>
+
+<!-- SSE triggers a separate HTTP request -->
+<div hx-ext="sse" sse-connect="/events">
+    <div hx-get="/latest" hx-trigger="sse:data-changed">Loads on SSE event</div>
+</div>
+```
+
+### WebSockets
+
+```html
+<script src="https://cdn.jsdelivr.net/npm/htmx-ext-ws@2.0.4"></script>
+<div hx-ext="ws" ws-connect="/chat">
+    <div id="messages"></div>
+    <form ws-send>
+        <input name="message" type="text">
+        <button type="submit">Send</button>
+    </form>
+</div>
+```
+
+### head-support, preload, loading-states
+
+```html
+<script src="https://cdn.jsdelivr.net/npm/htmx-ext-head-support@2.0.3"></script>
+<script src="https://cdn.jsdelivr.net/npm/htmx-ext-preload@2.1.0"></script>
+<script src="https://cdn.jsdelivr.net/npm/htmx-ext-loading-states@2.0.0"></script>
+```
+
+---
+
+## JavaScript Event Patterns
+
+### Event Delegation (Required for Swapped Content)
+
+```javascript
+// CORRECT: Listen on body or a stable parent — catches events from dynamically swapped content
+document.body.addEventListener('htmx:afterSwap', function(event) {
+    if (event.detail.elt.id === 'my-form') { /* ... */ }
+});
+
+// CORRECT: htmx helper
+htmx.on('htmx:afterSwap', function(event) { /* ... */ });
+
+// WRONG: Direct listener on element that may be swapped out
+document.querySelector('#my-button').addEventListener('htmx:afterSwap', fn);
+```
+
+### afterSwap vs afterSettle Timing
+
+```javascript
+// afterSwap: Content in DOM but transitions NOT started — don't init JS libraries here
+// afterSettle: DOM fully settled, transitions started — safe for initialization
+
+// BEST: Use htmx.onLoad for initializing JS on new content
+htmx.onLoad(function(content) {
+    initializeTooltips(content);
+    initializeCharts(content);
+});
+```
+
+### Programmatic Search Clear
+
+```javascript
+// Clear search and re-trigger htmx request
+document.getElementById('search').value = '';
+htmx.trigger(document.getElementById('search'), 'keyup');
+```
+
+---
+
+## Common Anti-Patterns
+
+| Anti-Pattern | Why It's Wrong | Correct Approach |
+|---|---|---|
+| `hx-vals={ fmt.Sprintf(\`{"msg": "%s"}\`, userInput) }` | JSON injection if value has `"` or `\` | Use `json.Marshal` helper or `%q` |
+| `hx-swap="none"` + `window.location.reload()` | Defeats htmx purpose entirely | Return HTML fragment and swap, or use `HX-Redirect` |
+| `hx-swap="none"` with no feedback | User clicks, nothing visible happens | Add `hx-indicator`, return content, or use `HX-Trigger` for list reload |
+| `hx-target="body"` for navigation-like actions | Loses all client state, scroll position | Use `<a href>` links or `HX-Redirect` |
+| `hx-headers='{"HX-Request": "true"}'` on body | htmx already sets this header automatically | Remove — it's redundant |
+| `hx-post` on both `<form>` AND `<button>` | Button's attributes override form's target/swap | Put `hx-post` on the form OR the button, not both |
+| Duplicate IDs (e.g., wrapper and loader both `id="items"`) | `hx-target` matches the first one, undefined behavior | Use unique IDs |
+| Loading htmx as async/defer/module | Unreliable initialization | Use standard blocking `<script>` tag |
+| Loading different htmx versions on the same page | Undefined behavior, version conflicts | Use one version in the base layout only |
+| Expecting 4xx/5xx to swap content | They don't by default | Re-render at 200 with errors, or use response-targets |
+| Not checking `HX-Request` for redirects | HTTP 302 is ignored by htmx | Use `HX-Redirect` header for htmx requests |
+| GET requests expecting form values | GET doesn't include enclosing form data | Use `hx-include="closest form"` for GET |
+| Using `fetch()` alongside htmx in the same page | Inconsistent patterns, harder to maintain | Pick one approach per page/feature |
+| Mixing `htmx.ajax()` and `hx-*` attributes | Confusing dual paradigms | Prefer attributes; use `htmx.ajax()` only when attributes can't work |
+| Not URL-encoding dynamic query params | `search=foo&bar=baz` breaks URLs | Use `url.QueryEscape()` for user-supplied values |
+
+---
+
+## CSRF Protection Pattern (Go + Templ)
+
+```go
+// Set CSRF token on body so ALL htmx requests include it via attribute inheritance
+// Use %q (not %s) to safely handle special characters in the token
+templ Layout(c echo.Context, content templ.Component) {
+    <html>
+    <body hx-headers={ fmt.Sprintf(`{"X-CSRF-Token": %q}`, CSRFToken(c)) }>
+        @content
+    </body>
+    </html>
+}
+```
+
+---
+
+## Configuration
+
+```html
+<!-- Via meta tag (before htmx script) -->
+<meta name="htmx-config" content='{
+    "defaultSwapStyle": "outerHTML",
+    "selfRequestsOnly": true,
+    "historyCacheSize": 10,
+    "timeout": 5000,
+    "globalViewTransitions": false,
+    "scrollBehavior": "instant"
+}'>
+```
+
+Key settings:
+- `defaultSwapStyle` (default: `innerHTML`) — change if you prefer `outerHTML`
+- `selfRequestsOnly` (default: `true`) — only allow requests to same domain
+- `historyCacheSize` (default: `10`) — pages cached for history
+- `allowScriptTags` (default: `true`) — execute scripts in swapped content
+- `disableInheritance` (default: `false`) — disable attribute inheritance from parents
+- `timeout` (default: `0`) — request timeout in ms
+
+### Debug Logging (Conditional)
+
+```go
+if config.GetHtmxLogging(c) {
+    <script>htmx.logAll();</script>
+}
+```
+
+---
+
+## Useful Go Libraries
+
+- **`github.com/angelofallars/htmx-go`** — Type-safe htmx response headers and request detection
+- **`github.com/donseba/go-htmx`** — Seamless htmx integration with partial render support
+- **`github.com/will-wow/typed-htmx-go`** — Type-safe htmx attributes for templ with autocomplete
+
+<!-- cache:end -->

--- a/.agents/skills/second-opinion/SKILL.md
+++ b/.agents/skills/second-opinion/SKILL.md
@@ -1,0 +1,141 @@
+---
+name: second-opinion
+description: |
+  WHEN: User faces complex architectural decisions, asks for "another perspective", "second opinion",
+  "sanity check", "what do you think", or "am I overthinking this". Also trigger when multiple
+  valid approaches exist and user seems uncertain, when reviewing critical/security-sensitive code,
+  evaluating design trade-offs, choosing between libraries/frameworks, debating patterns like
+  microservices vs monolith, or when the user asks "should I..." about a significant technical
+  decision. Proactively suggest getting a second opinion on complex changes even if not asked.
+  WHEN NOT: User has expressed a clear strong preference, explicitly declines other opinions,
+  or is making simple/routine changes
+---
+
+# Second Opinion Skill
+
+Proactively suggest getting another LLM's perspective when the situation warrants it.
+
+## Trigger Conditions
+
+Suggest a second opinion when you detect:
+
+### 1. Architectural Decisions
+- Choosing between design patterns (e.g., repository vs service layer)
+- Database schema design decisions
+- API design choices (REST vs GraphQL, versioning strategy)
+- Service decomposition (monolith vs microservices)
+- State management approaches
+
+### 2. Complex Trade-offs
+- Performance vs. readability
+- Flexibility vs. simplicity
+- DRY vs. explicit code
+- Build vs. buy decisions
+- Consistency vs. availability trade-offs
+
+### 3. Critical Code Reviews
+- Security-sensitive code (authentication, authorization, crypto)
+- Performance-critical paths
+- Complex algorithms or data structures
+- Code handling financial transactions or PII
+- Concurrency and threading logic
+
+### 4. Explicit Requests (trigger words)
+- "another perspective"
+- "second opinion"
+- "sanity check"
+- "what do you think"
+- "am I on the right track"
+- "does this make sense"
+- "is this a good approach"
+
+## How to Suggest
+
+When conditions are met, offer specific options:
+
+> This involves [type of decision]. Would you like a second opinion from another LLM?
+>
+> - `/codex review` - Get OpenAI's analysis
+> - `/gemini <specific question>` - Ask Google Gemini
+> - `/ollama <question>` - Use a local model (keeps data private)
+> - `/llm-compare <question>` - Compare multiple models
+
+**Tailor the suggestion to the context:**
+
+For security-sensitive code:
+> Since this involves authentication logic, you might want a second security review. Try `/codex review` or `/ollama` (keeps code local) for another perspective.
+
+For architectural decisions:
+> This is a significant architectural choice. Different models sometimes weigh trade-offs differently. Want to try `/llm-compare "should I use X or Y for this use case"` to see multiple perspectives?
+
+For complex algorithms:
+> This algorithm has some complexity. A second set of eyes might catch edge cases. Try `/codex explain the edge cases in this algorithm`.
+
+## When NOT to Suggest
+
+Do not suggest second opinions when:
+- User is actively implementing (don't interrupt flow)
+- Task is simple/straightforward (typos, formatting, simple fixes)
+- User has already made a firm decision
+- User said "just do it" or similar
+- It's routine code changes with clear requirements
+- User previously declined suggestions in this session
+
+## Privacy Consideration
+
+Always mention `/ollama` as an option when the code might be sensitive:
+
+> For proprietary code, `/ollama` keeps everything local - your code never leaves your machine.
+
+## Example Interactions
+
+**Example 1: Architectural Decision**
+
+User: "Should I use a monorepo or multi-repo for these microservices?"
+
+Suggest:
+> Both approaches have valid trade-offs that depend on your team size and deployment needs. For a decision this impactful, would you like another perspective?
+>
+> - `/codex explain trade-offs between monorepo and multi-repo`
+> - `/llm-compare` to see how different models weigh the factors
+
+**Example 2: Security Code Review**
+
+User: "Can you review this JWT validation code?"
+
+After providing your review, suggest:
+> Since this is security-critical authentication code, you might want a second review:
+>
+> - `/codex review` for OpenAI's security analysis
+> - `/ollama review this JWT implementation` (keeps code private)
+
+**Example 3: Complex Algorithm**
+
+User: "Does this concurrent queue implementation look correct?"
+
+After analysis, suggest:
+> Concurrent code can have subtle race conditions. Want a second opinion?
+>
+> - `/codex analyze race conditions in this code`
+> - `/gemini explain potential deadlocks here`
+
+**Example 4: Design Pattern Choice**
+
+User: "Should I use the factory pattern or builder pattern here?"
+
+Suggest:
+> Both patterns could work here with different trade-offs. Want to see how other models approach this?
+>
+> - `/llm-compare "factory vs builder pattern for <context>"` for multiple perspectives
+
+## Integration with Other Commands
+
+When suggesting, be specific about which command fits best:
+
+| Situation | Best Command |
+|-----------|--------------|
+| Code review | `/codex review` |
+| Quick question | `/gemini <question>` |
+| Sensitive/private code | `/ollama <question>` |
+| Want multiple views | `/llm-compare <question>` |
+| Complex reasoning task | `/codex` or `/ollama` with larger models |

--- a/.agents/skills/systematic-debugging/SKILL.md
+++ b/.agents/skills/systematic-debugging/SKILL.md
@@ -1,0 +1,118 @@
+---
+name: systematic-debugging
+description: |
+  WHEN: User is debugging Go code, investigating bugs, analyzing test failures, encountering
+  unexpected behavior, reading stack traces, diagnosing race conditions, fixing flaky tests,
+  or saying "why is this broken", "this doesn't work", "test is failing", "getting an error".
+  Also activate when investigating panics, goroutine deadlocks, data corruption, or any
+  situation where the root cause is not immediately obvious.
+  Trigger this skill liberally for ANY debugging or bug investigation work in Go.
+  WHEN NOT: Writing new features from scratch, code review without a specific bug,
+  questions entirely unrelated to debugging or troubleshooting
+---
+
+# Systematic Debugging
+
+**IRON LAW: NO FIXES WITHOUT ROOT CAUSE INVESTIGATION FIRST.**
+
+Do not guess. Do not "just try changing X." Do not apply quick fixes. Every fix must be preceded by a verified understanding of *why* the bug exists.
+
+## Phase 1: Root Cause Investigation
+
+Before touching any code:
+
+1. **Read the error completely** — full error message, full stack trace, full log output. Do not skim.
+2. **Reproduce consistently** — write a failing test or find a reliable reproduction command:
+   ```bash
+   go test ./path/to/package/... -run TestName -v -count=1
+   ```
+   For race conditions, use the race detector:
+   ```bash
+   go test ./path/to/package/... -race -count=5
+   ```
+3. **Check recent changes** — use `git log --oneline -20` and `git blame` on the affected code. What changed last?
+4. **Trace data flow backward** — start at the error site and trace backward through the call chain. At each step ask: "What called this? What value did it pass? Where did that value come from?"
+5. **Gather evidence at boundaries** — in multi-layer systems (handler → service → repository → database), add temporary diagnostic logging at each layer boundary to narrow the fault location.
+
+**Go-specific investigation tools:**
+- `go vet ./...` — catches common mistakes (printf format mismatches, unreachable code, mutex misuse)
+- `go test -race` — detects data races that cause intermittent failures
+- `dlv test ./path/to/package -- -test.run TestName` — step through with delve when logic flow is unclear
+- Stack trace reading: goroutine state (`running`, `chan receive`, `select`, `semacquire`) reveals deadlocks and blocking
+
+**HARD GATE: Do NOT proceed to Phase 2 until you can state the reproduction steps AND have a failing test or command that demonstrates the bug.**
+
+## Phase 2: Pattern Analysis
+
+1. **Find similar working code** — grep the codebase for similar patterns that work correctly
+2. **Read the working implementation completely** — do not skim
+3. **Identify ALL differences** between the working and broken code — not just the obvious ones
+4. **Understand dependencies and assumptions** — what does the broken code assume about its inputs, environment, or ordering that the working code does not?
+
+## Phase 3: Hypothesis Testing
+
+1. **Form ONE specific hypothesis** — write it down: "The bug occurs because X passes Y to Z, but Z expects W"
+2. **Design a minimal test** — change ONE variable to test the hypothesis. Do not make multiple changes.
+3. **Run the test and evaluate** — did the result confirm or refute the hypothesis?
+4. **If refuted** — return to Phase 1 with new information. Do not stack more hypotheses.
+
+**HARD GATE: If 3 fix attempts fail, STOP.** Do not attempt a 4th fix. Instead:
+- Present findings to the user: what you know, what you tried, what failed
+- Discuss whether the issue is architectural (wrong design) rather than a bug (wrong implementation)
+- Ask for guidance before proceeding
+
+**Red flags that you're violating the process:**
+- "Quick fix for now" — there are no quick fixes, only root causes
+- "Just try changing X" — hypothesize first, then test
+- "One more attempt" after 3 failures — stop and discuss
+- Skipping the reproduction step — you cannot fix what you cannot reproduce
+
+## Phase 4: Implementation
+
+1. **The failing test already exists** from Phase 1 — confirm it still fails
+2. **Implement a single fix** addressing the root cause, not the symptom
+3. **Run the full test suite** — the fix must not break other tests:
+   ```bash
+   go test ./... -count=1
+   ```
+4. **Run with race detector** if concurrency is involved:
+   ```bash
+   go test ./... -race -count=1
+   ```
+5. **Add defense-in-depth validation** where appropriate:
+   - **Entry point**: validate inputs at the public API boundary
+   - **Business logic**: assert preconditions at the start of critical functions
+   - **Environment**: guard against dangerous operations in wrong contexts (e.g., destructive DB calls outside transactions)
+
+## Condition-Based Waiting (For Flaky Tests)
+
+**Never use `time.Sleep` to wait for conditions in tests.** Sleep-based waits are the #1 cause of flaky tests.
+
+Instead, use condition-based waiting:
+
+```go
+// Use testify's Eventually for polling conditions
+assert.Eventually(t, func() bool {
+    return getResult() != nil
+}, 5*time.Second, 10*time.Millisecond, "expected result to be available")
+
+// Or use channels for event-based waiting
+select {
+case result := <-resultCh:
+    assert.Equal(t, expected, result)
+case <-time.After(5 * time.Second):
+    t.Fatal("timed out waiting for result")
+}
+```
+
+**When `time.Sleep` IS acceptable:**
+- After a condition-based wait, to allow a documented settling period
+- Based on documented system timing (e.g., known cache TTL)
+- Always with an explanatory comment stating *why* this specific duration
+
+## Testing Anti-Patterns to Watch For
+
+- **Testing mock behavior instead of real behavior** — if your assertion checks that a mock was called, you're testing the mock, not the code
+- **Test-only methods in production code** — cleanup/destroy methods that only tests use belong in test helpers
+- **Mocking without understanding** — before mocking, document all side effects of the real method and which ones your test needs
+- **Tests that pass immediately** — a test written after a fix that passes on first run proves nothing; it should have failed before the fix

--- a/.agents/skills/tailwind-best-practices/SKILL.md
+++ b/.agents/skills/tailwind-best-practices/SKILL.md
@@ -1,0 +1,452 @@
+---
+name: tailwind-best-practices
+description: |
+  WHEN: User is writing HTML/templates with Tailwind CSS classes, styling components,
+  configuring Tailwind themes, asking about utilities or patterns, or working with any
+  project that uses Tailwind CSS. Also trigger when user mentions "responsive design",
+  "dark mode", "custom colors", "spacing", "flex/grid layout" in a Tailwind project,
+  asks about v4 migration, @theme vs @apply, or is editing CSS/HTML files in a project
+  with tailwind in its dependencies. Activate whenever tailwind.config.* or @tailwind
+  directives are present.
+  WHEN NOT: Projects not using Tailwind, questions about Bootstrap/Bulma/other CSS frameworks
+---
+
+<!-- cache:start -->
+
+# Tailwind CSS v4 Best Practices
+
+You have access to up-to-date Tailwind CSS documentation via MCP tools. Use these tools to provide accurate, current information.
+
+## Available MCP Tools
+
+Use these tools for dynamic, up-to-date Tailwind information:
+
+### `mcp__tailwindcss__search_tailwind_docs`
+
+Use when user asks about any Tailwind feature, utility, or concept.
+
+**Examples:**
+- "How do I use dark mode in Tailwind?"
+- "What are container queries?"
+- "How do responsive breakpoints work?"
+
+### `mcp__tailwindcss__get_tailwind_utilities`
+
+Use when user needs utility classes for a specific CSS property.
+
+**Examples:**
+- "What utilities are available for flexbox?"
+- "Show me spacing utilities"
+- "What text alignment classes exist?"
+
+### `mcp__tailwindcss__get_tailwind_colors`
+
+Use when user asks about colors, palettes, or color-related utilities.
+
+**Examples:**
+- "What colors are available?"
+- "Show me the blue palette shades"
+- "How do I use custom colors?"
+
+### `mcp__tailwindcss__convert_css_to_tailwind`
+
+Use when user has CSS they want to convert to Tailwind utility classes.
+
+**Examples:**
+- "Convert this CSS to Tailwind: display: flex; justify-content: center;"
+- "What's the Tailwind equivalent of margin: 0 auto?"
+
+### `mcp__tailwindcss__generate_component_template`
+
+Use when user needs a component template with Tailwind styling.
+
+**Examples:**
+- "Generate a button component"
+- "Create a card template"
+- "Show me a navbar example"
+
+---
+
+## Official Documentation URLs
+
+When MCP tools are unavailable, use WebFetch with these URLs to get current documentation:
+
+### Getting Started
+| Topic | URL |
+|-------|-----|
+| Installation | https://tailwindcss.com/docs/installation |
+| Using Vite | https://tailwindcss.com/docs/installation/using-vite |
+| Using PostCSS | https://tailwindcss.com/docs/installation/using-postcss |
+| Tailwind CLI | https://tailwindcss.com/docs/installation/tailwind-cli |
+| Editor Setup | https://tailwindcss.com/docs/editor-setup |
+| Upgrade Guide | https://tailwindcss.com/docs/upgrade-guide |
+
+### Core Concepts
+| Topic | URL |
+|-------|-----|
+| Utility Classes | https://tailwindcss.com/docs/styling-with-utility-classes |
+| Hover, Focus, States | https://tailwindcss.com/docs/hover-focus-and-other-states |
+| Responsive Design | https://tailwindcss.com/docs/responsive-design |
+| Dark Mode | https://tailwindcss.com/docs/dark-mode |
+| Theme Variables | https://tailwindcss.com/docs/theme |
+| Colors | https://tailwindcss.com/docs/colors |
+| Custom Styles | https://tailwindcss.com/docs/adding-custom-styles |
+| Functions & Directives | https://tailwindcss.com/docs/functions-and-directives |
+
+### Layout
+| Topic | URL |
+|-------|-----|
+| Display | https://tailwindcss.com/docs/display |
+| Flexbox | https://tailwindcss.com/docs/flex |
+| Grid | https://tailwindcss.com/docs/grid-template-columns |
+| Gap | https://tailwindcss.com/docs/gap |
+| Container | https://tailwindcss.com/docs/container |
+| Position | https://tailwindcss.com/docs/position |
+| Z-Index | https://tailwindcss.com/docs/z-index |
+
+### Spacing
+| Topic | URL |
+|-------|-----|
+| Padding | https://tailwindcss.com/docs/padding |
+| Margin | https://tailwindcss.com/docs/margin |
+| Space Between | https://tailwindcss.com/docs/space |
+
+### Sizing
+| Topic | URL |
+|-------|-----|
+| Width | https://tailwindcss.com/docs/width |
+| Height | https://tailwindcss.com/docs/height |
+| Min/Max Width | https://tailwindcss.com/docs/min-width |
+| Min/Max Height | https://tailwindcss.com/docs/min-height |
+
+### Typography
+| Topic | URL |
+|-------|-----|
+| Font Family | https://tailwindcss.com/docs/font-family |
+| Font Size | https://tailwindcss.com/docs/font-size |
+| Font Weight | https://tailwindcss.com/docs/font-weight |
+| Line Height | https://tailwindcss.com/docs/line-height |
+| Text Color | https://tailwindcss.com/docs/text-color |
+| Text Align | https://tailwindcss.com/docs/text-align |
+
+### Backgrounds & Borders
+| Topic | URL |
+|-------|-----|
+| Background Color | https://tailwindcss.com/docs/background-color |
+| Background Image | https://tailwindcss.com/docs/background-image |
+| Border Radius | https://tailwindcss.com/docs/border-radius |
+| Border Width | https://tailwindcss.com/docs/border-width |
+| Border Color | https://tailwindcss.com/docs/border-color |
+| Box Shadow | https://tailwindcss.com/docs/box-shadow |
+
+### Effects
+| Topic | URL |
+|-------|-----|
+| Opacity | https://tailwindcss.com/docs/opacity |
+| Shadow | https://tailwindcss.com/docs/box-shadow |
+| Blur | https://tailwindcss.com/docs/blur |
+
+### Transforms & Animation
+| Topic | URL |
+|-------|-----|
+| Transform | https://tailwindcss.com/docs/transform |
+| Scale | https://tailwindcss.com/docs/scale |
+| Rotate | https://tailwindcss.com/docs/rotate |
+| Translate | https://tailwindcss.com/docs/translate |
+| Transition | https://tailwindcss.com/docs/transition-property |
+| Animation | https://tailwindcss.com/docs/animation |
+
+### Interactivity
+| Topic | URL |
+|-------|-----|
+| Cursor | https://tailwindcss.com/docs/cursor |
+| User Select | https://tailwindcss.com/docs/user-select |
+| Scroll Behavior | https://tailwindcss.com/docs/scroll-behavior |
+
+---
+
+## Tailwind CSS v4 Core Syntax
+
+**CRITICAL**: Tailwind v4 changed significantly from v3. Always use v4 syntax.
+
+### CSS Entry Point
+
+```css
+@import "tailwindcss";
+```
+
+This single import replaces the old `@tailwind base; @tailwind components; @tailwind utilities;` directives.
+
+### Theme Configuration (@theme directive)
+
+All theme customization is done in CSS, not JavaScript:
+
+```css
+@theme {
+  /* Colors - use oklch for better color manipulation */
+  --color-primary: oklch(0.6 0.2 250);
+  --color-primary-foreground: oklch(1 0 0);
+  --color-secondary: oklch(0.5 0.02 250);
+  --color-secondary-foreground: oklch(1 0 0);
+
+  /* Semantic colors */
+  --color-background: oklch(1 0 0);
+  --color-foreground: oklch(0.145 0 0);
+  --color-muted: oklch(0.95 0 0);
+  --color-muted-foreground: oklch(0.4 0 0);
+  --color-border: oklch(0.9 0 0);
+  --color-destructive: oklch(0.55 0.25 25);
+
+  /* Font families */
+  --font-sans: "Inter", ui-sans-serif, system-ui, sans-serif;
+  --font-mono: "Fira Code", ui-monospace, monospace;
+
+  /* Custom spacing (extends default scale) */
+  --spacing-18: 4.5rem;
+  --spacing-22: 5.5rem;
+
+  /* Custom border radius */
+  --radius-4xl: 2rem;
+}
+```
+
+### Source Detection (@source directive)
+
+Tailwind auto-detects most template files. Use `@source` for custom paths:
+
+```css
+@source "./templates/**/*.templ";
+@source "./components/**/*.html";
+@source "./src/**/*.{js,jsx,ts,tsx,vue,svelte}";
+```
+
+### Dark Mode (@variant directive)
+
+```css
+@variant dark {
+  --color-background: oklch(0.145 0 0);
+  --color-foreground: oklch(0.985 0 0);
+  --color-muted: oklch(0.25 0 0);
+  --color-muted-foreground: oklch(0.6 0 0);
+  --color-border: oklch(0.3 0 0);
+  --color-card: oklch(0.205 0 0);
+}
+```
+
+### Component Layer (@layer components)
+
+Extract repeated patterns:
+
+```css
+@layer components {
+  .btn {
+    @apply px-4 py-2 rounded-lg font-medium transition-colors;
+  }
+  .btn-primary {
+    @apply btn bg-primary text-primary-foreground hover:bg-primary/90;
+  }
+  .btn-secondary {
+    @apply btn bg-secondary text-secondary-foreground hover:bg-secondary/90;
+  }
+  .card {
+    @apply p-6 bg-card rounded-xl border border-border shadow-sm;
+  }
+}
+```
+
+### Plugins (@plugin directive)
+
+```css
+@plugin "@tailwindcss/typography";
+```
+
+---
+
+## Best Practices
+
+### Class Ordering Convention
+
+Order utilities consistently for readability:
+
+**Order:** layout → spacing → sizing → typography → colors → effects → interactive
+
+```html
+<!-- Good: Logical order -->
+<div class="flex items-center gap-4 p-4 w-full text-sm text-gray-700 bg-white shadow-sm hover:bg-gray-50 transition-colors">
+
+<!-- Bad: Random order -->
+<div class="hover:bg-gray-50 flex bg-white p-4 text-sm shadow-sm w-full gap-4 items-center text-gray-700 transition-colors">
+```
+
+### Responsive Design
+
+Mobile-first: base styles for mobile, add breakpoints for larger screens.
+
+```html
+<!-- Mobile first -->
+<div class="w-full md:w-1/2 lg:w-1/3">
+
+<!-- Breakpoints -->
+sm: 640px   <!-- Small devices -->
+md: 768px   <!-- Medium devices -->
+lg: 1024px  <!-- Large devices -->
+xl: 1280px  <!-- Extra large -->
+2xl: 1536px <!-- 2X large -->
+```
+
+### Component Extraction Rule
+
+Extract when a class combination appears **3+ times**:
+
+```css
+/* Instead of repeating in HTML */
+@layer components {
+  .flex-center {
+    @apply flex items-center justify-center;
+  }
+  .text-muted {
+    @apply text-sm text-muted-foreground;
+  }
+}
+```
+
+### Use Theme Variables
+
+Always prefer theme variables over hardcoded values:
+
+```html
+<!-- Good: Uses theme variable -->
+<div class="bg-primary text-primary-foreground">
+
+<!-- Bad: Hardcoded color -->
+<div class="bg-[#3b82f6] text-white">
+```
+
+### Accessibility
+
+```html
+<!-- Focus states -->
+<button class="focus-visible:ring-2 focus-visible:ring-primary focus-visible:outline-none">
+
+<!-- Screen reader only -->
+<span class="sr-only">Close menu</span>
+
+<!-- Ensure contrast -->
+<!-- Use oklch colors with sufficient lightness difference -->
+```
+
+---
+
+## v4 Anti-Patterns to Avoid
+
+### DO NOT USE (v3 patterns):
+
+| Wrong (v3) | Correct (v4) |
+|------------|--------------|
+| `tailwind.config.js` | CSS `@theme { }` directive |
+| `@tailwind base;` | `@import "tailwindcss";` |
+| `@tailwind components;` | (included in import) |
+| `@tailwind utilities;` | (included in import) |
+| `darkMode: 'class'` in config | `@variant dark { }` in CSS |
+| `theme.extend.colors` in JS | `--color-*` in @theme |
+| `content: [...]` in JS | `@source "..."` in CSS |
+
+### Common Mistakes
+
+```html
+<!-- Wrong: Inline styles when utility exists -->
+<div style="display: flex; gap: 1rem;">
+<!-- Correct -->
+<div class="flex gap-4">
+
+<!-- Wrong: px values when scale exists -->
+<div class="p-[16px]">
+<!-- Correct -->
+<div class="p-4">
+
+<!-- Wrong: Duplicate utilities -->
+<div class="p-4 p-6">
+<!-- Correct -->
+<div class="p-6">
+
+<!-- Wrong: Conflicting utilities -->
+<div class="flex block">
+<!-- Correct: Choose one -->
+<div class="flex">
+```
+
+---
+
+## Response Guidelines
+
+When helping with Tailwind CSS:
+
+1. **Always use v4 syntax** - No tailwind.config.js, use @theme in CSS
+2. **Use MCP tools first** - Get current documentation before answering
+3. **Prefer theme variables** - `bg-primary` not `bg-blue-500`
+4. **Include accessibility** - Add focus-visible, sr-only where appropriate
+5. **Show complete examples** - Include all necessary classes
+6. **Explain class choices** - Help users understand why
+
+### Example Response Flow
+
+**User:** "How do I create a button with hover effect?"
+
+**Response:**
+1. Use `mcp__tailwindcss__get_tailwind_utilities` for button-related utilities
+2. Provide example with proper class ordering:
+
+```html
+<button class="px-4 py-2 rounded-lg font-medium bg-primary text-primary-foreground hover:bg-primary/90 focus-visible:ring-2 focus-visible:ring-primary focus-visible:outline-none transition-colors">
+  Click me
+</button>
+```
+
+3. Explain the classes used
+4. Suggest extracting to component if used multiple times
+
+---
+
+## Quick Reference
+
+### Spacing Scale
+| Class | Size |
+|-------|------|
+| 1 | 0.25rem (4px) |
+| 2 | 0.5rem (8px) |
+| 3 | 0.75rem (12px) |
+| 4 | 1rem (16px) |
+| 5 | 1.25rem (20px) |
+| 6 | 1.5rem (24px) |
+| 8 | 2rem (32px) |
+| 10 | 2.5rem (40px) |
+| 12 | 3rem (48px) |
+| 16 | 4rem (64px) |
+
+### Common Patterns
+
+```html
+<!-- Centered content -->
+<div class="flex items-center justify-center">
+
+<!-- Card -->
+<div class="p-6 bg-card rounded-xl border border-border shadow-sm">
+
+<!-- Responsive grid -->
+<div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+
+<!-- Truncated text -->
+<p class="truncate">Long text that will be truncated...</p>
+
+<!-- Gradient background -->
+<div class="bg-gradient-to-r from-primary to-secondary">
+
+<!-- Fixed header -->
+<header class="fixed top-0 left-0 right-0 z-50 bg-background/80 backdrop-blur-sm">
+```
+
+---
+
+*For the latest documentation, always refer to https://tailwindcss.com/docs*
+
+<!-- cache:end -->

--- a/.agents/skills/templui/SKILL.md
+++ b/.agents/skills/templui/SKILL.md
@@ -1,0 +1,415 @@
+---
+name: templui
+description: |
+  WHEN: User is building Go/Templ web apps, using templUI components, converting sites to Templ,
+  asking about templ syntax, Script() templates, HTMX/Alpine integration, JavaScript in templ,
+  or working with .templ files. Also trigger when user mentions "component library", "UI components",
+  "buttons/cards/modals/tables" in a Go web project, "templ generate", Alpine.js with Go,
+  or asks how to build interactive UIs in Go without React/Vue. Activate whenever .templ files
+  are present in the project or templUI is in dependencies.
+  WHEN NOT: Non-Go projects, pure JavaScript/TypeScript frontend frameworks
+---
+
+
+<!-- cache:start -->
+
+# templUI & HTMX/Alpine Best Practices
+Apply templUI patterns and HTMX/Alpine.js best practices when building Go/Templ web applications.
+
+## The Frontend Stack
+
+The Go/Templ stack uses three complementary tools for interactivity:
+
+| Tool | Purpose | Use For |
+|------|---------|---------|
+| **HTMX** | Server-driven interactions | AJAX requests, form submissions, partial page updates, live search |
+| **Alpine.js** | Client-side state & reactivity | Toggles, animations, client-side filtering, transitions, local state |
+| **templUI** | Pre-built UI components | Dropdowns, dialogs, tabs, sidebars (uses vanilla JS via Script() templates) |
+
+**Note:** templUI components use vanilla JavaScript (not Alpine.js) via Script() templates. This is fine - Alpine.js is still part of the stack for your custom client-side needs.
+
+---
+
+## HTMX + Alpine.js Integration
+
+HTMX and Alpine.js work great together. Use HTMX for server communication, Alpine for client-side enhancements.
+
+### When to Use Each
+
+```html
+<!-- HTMX: Server-driven (fetches HTML from server) -->
+<button hx-get="/api/users" hx-target="#user-list">Load Users</button>
+
+<!-- Alpine: Client-side state (no server call) -->
+<div x-data="{ open: false }">
+  <button @click="open = !open">Toggle</button>
+  <div x-show="open">Content</div>
+</div>
+
+<!-- Combined: HTMX loads data, Alpine filters it -->
+<div x-data="{ filter: '' }">
+  <input x-model="filter" placeholder="Filter...">
+  <div hx-get="/users" hx-trigger="load">
+    <template x-for="user in users.filter(u => u.name.includes(filter))">
+      <div x-text="user.name"></div>
+    </template>
+  </div>
+</div>
+```
+
+### Key Integration Patterns
+
+**Alpine-Morph Extension**: Preserves Alpine state across HTMX swaps:
+```html
+<script src="https://unpkg.com/htmx.org/dist/ext/alpine-morph.js"></script>
+<div hx-ext="alpine-morph" hx-swap="morph">...</div>
+```
+
+**htmx.process() for Alpine Conditionals**: When Alpine's `x-if` renders HTMX content:
+```html
+<template x-if="showForm">
+  <form hx-post="/submit" x-init="htmx.process($el)">...</form>
+</template>
+```
+
+**Triggering HTMX from Alpine**:
+```html
+<button @click="htmx.trigger($refs.form, 'submit')">Submit</button>
+```
+
+---
+
+## templUI Components (Vanilla JS)
+
+templUI components handle their own interactivity via Script() templates using vanilla JavaScript and Floating UI for positioning.
+
+---
+
+## CRITICAL: Templ Interpolation in JavaScript
+
+**Go expressions `{ value }` do NOT interpolate inside `<script>` tags or inline event handlers.** They are treated as literal text, causing errors like:
+
+```
+GET http://localhost:8008/app/quotes/%7B%20id.String()%20%7D 400 (Bad Request)
+```
+
+The `%7B` and `%7D` are URL-encoded `{` and `}` - proof the expression wasn't evaluated.
+
+### Pattern 1: Data Attributes (Recommended)
+
+Use `data-*` attributes to pass Go values, then access via JavaScript:
+
+```templ
+<button
+  data-quote-id={ quote.ID.String() }
+  onclick="openPublishModal(this.dataset.quoteId)">
+  Publish
+</button>
+```
+
+For multiple values:
+```templ
+<div
+  data-id={ item.ID.String() }
+  data-name={ item.Name }
+  data-status={ item.Status }
+  onclick="handleClick(this.dataset)">
+```
+
+### Pattern 2: templ.JSFuncCall (for onclick handlers)
+
+Automatically JSON-encodes arguments and prevents XSS:
+
+```templ
+<button onclick={ templ.JSFuncCall("openPublishModal", quote.ID.String()) }>
+  Publish
+</button>
+```
+
+With multiple arguments:
+```templ
+<button onclick={ templ.JSFuncCall("updateItem", item.ID.String(), item.Name, item.Active) }>
+```
+
+To pass the event object, use `templ.JSExpression`:
+```templ
+<button onclick={ templ.JSFuncCall("handleClick", templ.JSExpression("event"), quote.ID.String()) }>
+```
+
+### Pattern 3: Double-Braces Inside Script Strings
+
+Inside `<script>` tags, use `{{ value }}` (double braces) for interpolation:
+
+```templ
+<script>
+  const quoteId = "{{ quote.ID.String() }}";
+  const itemName = "{{ item.Name }}";
+  openPublishModal(quoteId);
+</script>
+```
+
+Outside strings (bare expressions), values are JSON-encoded:
+```templ
+<script>
+  const config = {{ templ.JSONString(config) }};
+  const isActive = {{ item.Active }};  // outputs: true or false
+</script>
+```
+
+### Pattern 4: templ.JSONString for Complex Data
+
+Pass complex structs/maps to JavaScript via attributes:
+
+```templ
+<div data-config={ templ.JSONString(config) }>
+
+<script>
+  const el = document.querySelector('[data-config]');
+  const config = JSON.parse(el.dataset.config);
+</script>
+```
+
+Or use `templ.JSONScript`:
+```templ
+@templ.JSONScript("config-data", config)
+
+<script>
+  const config = JSON.parse(document.getElementById('config-data').textContent);
+</script>
+```
+
+### Pattern 5: templ.OnceHandle for Reusable Scripts
+
+Ensures scripts are only rendered once, even when component is used multiple times:
+
+```templ
+var publishHandle = templ.NewOnceHandle()
+
+templ QuoteRow(quote Quote) {
+  @publishHandle.Once() {
+    <script>
+      function openPublishModal(id) {
+        fetch(`/api/quotes/${id}/publish`, { method: 'POST' });
+      }
+    </script>
+  }
+  <button
+    data-id={ quote.ID.String() }
+    onclick="openPublishModal(this.dataset.id)">
+    Publish
+  </button>
+}
+```
+
+### When to Use Each Pattern
+
+| Scenario | Use |
+|----------|-----|
+| Simple onclick with one value | Data attribute or `templ.JSFuncCall` |
+| Multiple values needed in JS | Data attributes |
+| Need event object | `templ.JSFuncCall` with `templ.JSExpression("event")` |
+| Inline script with Go values | `{{ value }}` double braces |
+| Complex object/struct | `templ.JSONString` or `templ.JSONScript` |
+| Reusable script in loop | `templ.OnceHandle` |
+
+### Common Mistakes
+
+```templ
+// WRONG - won't interpolate, becomes literal text
+onclick="doThing({ id })"
+
+// WRONG - single braces don't work in scripts
+<script>const x = { value };</script>
+
+// WRONG - Go expression in URL string inside script
+<script>
+  fetch(`/api/quotes/{ id }/publish`)  // BROKEN
+</script>
+
+// CORRECT alternatives:
+onclick={ templ.JSFuncCall("doThing", id) }
+
+<script>const x = "{{ value }}";</script>
+
+<button data-id={ id } onclick="doFetch(this.dataset.id)">
+```
+
+---
+
+## templUI CLI Tool
+
+**Install CLI:**
+```bash
+go install github.com/templui/templui/cmd/templui@latest
+```
+
+**Key Commands:**
+```bash
+templui init                    # Initialize project, creates .templui.json
+templui add button card         # Add specific components
+templui add "*"                 # Add ALL components
+templui add -f dropdown         # Force update existing component
+templui list                    # List available components
+templui new my-app              # Create new project
+templui upgrade                 # Update CLI to latest version
+```
+
+**ALWAYS use the CLI to add/update components** - it fetches the complete component including Script() templates that may be missing if copied manually.
+
+---
+
+## Script() Templates - REQUIRED for Interactive Components
+
+Components with JavaScript include a `Script()` template function. **You MUST add these to your base layout's `<head>`:**
+
+```templ
+// In your base layout <head>:
+@popover.Script()      // Required for: popover, dropdown, tooltip, combobox
+@dropdown.Script()     // Required for: dropdown
+@dialog.Script()       // Required for: dialog, sheet, alertdialog
+@accordion.Script()    // Required for: accordion, collapsible
+@tabs.Script()         // Required for: tabs
+@carousel.Script()     // Required for: carousel
+@toast.Script()        // Required for: toast/sonner
+@clipboard.Script()    // Required for: copybutton
+```
+
+**Component Dependencies:**
+| Component | Requires Script() from |
+|-----------|----------------------|
+| dropdown | dropdown, popover |
+| tooltip | popover |
+| combobox | popover |
+| sheet | dialog |
+| alertdialog | dialog |
+| collapsible | accordion |
+
+**If a component doesn't work (no click events, no positioning), check that:**
+1. The Script() template is called in the layout
+2. The component was installed via CLI (not manually copied)
+3. All dependency scripts are included
+
+---
+
+## Converting Sites to Templ/templUI
+
+When converting HTML/React/Vue to Go/Templ:
+
+**Conversion Process:**
+1. Analyze existing UI patterns
+2. Map to templUI base components
+3. Convert syntax:
+   - `class` stays as `class` in templ
+   - `className` (React) → `class`
+   - React/Vue event handlers → vanilla JS via Script() or HTMX
+   - Dynamic content → templ expressions `{ variable }` or `@component()`
+4. **Add required Script() templates to layout**
+5. Set up proper Go package structure
+
+**Templ Syntax Quick Reference:**
+```templ
+package components
+
+type ButtonProps struct {
+    Text    string
+    Variant string
+}
+
+templ Button(props ButtonProps) {
+    <button class={ "btn", props.Variant }>
+        { props.Text }
+    </button>
+}
+
+// Conditional
+if condition {
+    <span>Shown</span>
+}
+
+// Loops
+for _, item := range items {
+    <li>{ item.Name }</li>
+}
+
+// Composition
+@Header()
+@Content() {
+    // Children
+}
+```
+
+---
+
+## Auditing for Better Component Usage
+
+**Audit Checklist:**
+1. **Script() Templates**: Are all required Script() calls in the base layout?
+2. **CLI Installation**: Were components added via `templui add` or manually copied?
+3. **Component Consistency**: Same patterns using same components?
+4. **Base Component Usage**: Custom code that could use templUI?
+5. **Dark Mode**: Tailwind dark: variants used?
+6. **Responsive**: Mobile breakpoints applied?
+
+**Common Issues to Check:**
+- Missing `@popover.Script()` → dropdowns/tooltips don't open
+- Missing `@dialog.Script()` → dialogs/sheets don't work
+- Manually copied components missing Script() template files
+
+---
+
+## Import Pattern
+
+```go
+import "github.com/templui/templui/components/button"
+import "github.com/templui/templui/components/dropdown"
+import "github.com/templui/templui/components/dialog"
+```
+
+---
+
+## Troubleshooting
+
+**JavaScript URL contains literal `{` or `%7B` (URL-encoded brace):**
+Go expressions don't interpolate in `<script>` tags. Use data attributes:
+```templ
+// WRONG: <script>fetch(`/api/{ id }`)</script>
+// RIGHT:
+<button data-id={ id } onclick="doFetch(this.dataset.id)">
+```
+See "CRITICAL: Templ Interpolation in JavaScript" section above.
+
+**Component not responding to clicks:**
+1. Check Script() is in layout: `@dropdown.Script()`, `@popover.Script()`
+2. Reinstall: `templui add -f dropdown popover`
+3. Check browser console for JS errors
+
+**Dropdown/Tooltip not positioning correctly:**
+1. Ensure `@popover.Script()` is in layout (uses Floating UI)
+2. Reinstall popover: `templui add -f popover`
+
+**Dialog/Sheet not opening:**
+1. Add `@dialog.Script()` to layout
+2. Reinstall: `templui add -f dialog`
+
+---
+
+## Resources
+
+**templUI:**
+- Documentation: https://templui.io/docs
+- GitHub: https://github.com/templui/templui
+
+**HTMX + Alpine.js:**
+- [HTMX and Alpine.js: How to combine two great, lean front ends](https://www.infoworld.com/article/3856520/htmx-and-alpine-js-how-to-combine-two-great-lean-front-ends.html)
+- [Full-Stack Go App with HTMX and Alpine.js](https://ntorga.com/full-stack-go-app-with-htmx-and-alpinejs/)
+- [When to Add Alpine.js to htmx](https://dev.to/alex_aslam/when-to-add-alpinejs-to-htmx-9bj)
+- [HTMX Alpine-Morph Extension](https://htmx.org/extensions/alpine-morph/)
+
+**Templ:**
+- Templ Docs: https://templ.guide
+
+---
+
+*This skill provides templUI and HTMX/Alpine.js best practices for Go/Templ web development.*
+
+<!-- cache:end -->

--- a/.agents/skills/validate-skills/SKILL.md
+++ b/.agents/skills/validate-skills/SKILL.md
@@ -1,0 +1,52 @@
+---
+name: validate-skills
+description: |
+  WHEN: User is editing .md files in commands/ or skills/ directories, creating new slash commands
+  or skills, modifying fenced bash/shell code blocks in markdown plugin files, asking about
+  validating command files, or discussing shell code correctness in plugin markdown.
+  Also activate when user mentions "shellcheck", "bash -n", "code block validation",
+  "portability check", or has just finished writing/editing a command or skill markdown file.
+  WHEN NOT: Editing Go source code, working with non-markdown files, writing general
+  documentation or README files, questions unrelated to plugin command/skill development
+---
+
+# Validate Skills
+
+When working on `.md` command or skill files that contain fenced bash/shell code blocks, suggest running `/validate-skills` to catch issues before they ship.
+
+## What It Catches
+
+- **Syntax errors**: Unclosed quotes, mismatched if/fi, invalid redirections (`bash -n`)
+- **Shell pitfalls**: Unquoted variables, deprecated syntax, SC2015 `A && B || C` (`shellcheck`)
+- **Portability issues**: macOS vs Linux differences (`mktemp` templates, `sed -i`, `grep -P`, `readlink -f`, `date` flags)
+- **Unsafe commands**: RED-tier commands (`rm`, `sudo`, `eval`, pipe-to-shell) flagged as warnings
+- **Template variable handling**: Blocks with unresolvable plugin variables (`$CLAUDE_PLUGIN_ROOT`, `$ARGUMENTS`, `$MODEL`) are skipped for execution but still syntax-checked
+- **Execution failures**: GREEN-tier read-only commands that fail at runtime (broken `jq` filters, invalid `grep` patterns, `mktemp` template errors)
+
+## Common Pitfalls in Plugin Markdown
+
+### macOS vs Linux
+- `mktemp /tmp/foo.XXXXXX.md` — template characters must be at end on macOS, use `mktemp /tmp/foo-XXXXXX` + rename
+- `sed -i '' 's/old/new/' file` (macOS) vs `sed -i 's/old/new/' file` (Linux) — use `sed -i.bak` for portability
+- `grep -P` not available on macOS — use `grep -E` instead
+- `readlink -f` not available on macOS — use `realpath` or `cd ... && pwd`
+- `date -d` (Linux) vs `date -j -f` (macOS)
+
+### Shell Safety
+- `A && B || C` is NOT if/else — if B fails, C still runs (ShellCheck SC2015)
+- Unquoted `$VAR` splits on whitespace and expands globs — always quote: `"$VAR"`
+- `[ -z $VAR ]` fails if VAR is empty — use `[ -z "$VAR" ]`
+
+### External Tool Output
+- Never assume tool output is pure JSON — check for banners, headers, progress bars
+- `curl` may return HTML error pages on failure — check HTTP status codes
+- `gh` CLI output format changes between versions — prefer `--json` + `--jq`
+
+## Usage
+
+```
+/validate-skills                              # Validate all plugin .md files
+/validate-skills plugins/go-dev/commands/     # Validate a directory
+/validate-skills path/to/command.md           # Validate a specific file
+/validate-skills --json                       # Output structured JSON
+```

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,93 +2,102 @@
 
 Project instructions for OpenAI Codex CLI.
 
-## Project Overview
-
-gopher-ai is a Claude Code plugin marketplace providing Go-focused development tools. It contains seven plugins:
-
-- **go-workflow**: Issue-to-PR workflow automation with git worktree management
-- **go-dev**: Go-specific development tools (test generation, linting, code explanation)
-- **productivity**: Git activity reports (standup, weekly summaries, changelogs, releases)
-- **gopher-guides**: MCP integration with Gopher Guides training materials
-- **llm-tools**: Multi-LLM utilities (Ollama, Gemini, Codex delegation, comparisons)
-- **go-web**: Go web project scaffolding and templUI integration
-- **tailwind**: Tailwind CSS v4 migration and optimization tools
-
 ## Available Skills
 
-Skills are auto-invoked based on context. Install from `dist/codex/skills/`:
+Skills auto-activate based on context, or invoke directly with `$skill-name`.
+
+### Go Development
 
 | Skill | Triggers |
 |-------|----------|
 | `go-best-practices` | Go code, patterns, reviews, "best way to..." |
-| `second-opinion` | Architecture decisions, security code, "sanity check" |
-| `tailwind-best-practices` | Tailwind CSS classes, themes, utilities |
-| `templui` | Go/Templ web apps, HTMX, Alpine.js |
-| `go-profiling-optimization` | Profiling, pprof, optimization, PGO, "why is this slow" |
+| `go-profiling-optimization` | Performance, profiling, benchmarks, "why is this slow" |
+| `systematic-debugging` | Debugging, test failures, stack traces, "why is this broken" |
 | `gopher-guides` | Go training materials, idiomatic patterns |
+
+### Code Quality
+
+| Skill | Triggers |
+|-------|----------|
+| `validate-skills` | Editing command/skill .md files, shell code validation |
+| `address-review` | PR review comments, reviewer feedback, unresolved threads |
+
+### Web Development
+
+| Skill | Triggers |
+|-------|----------|
+| `tailwind-best-practices` | Tailwind CSS classes, themes, v4 config |
+| `templui` | Go/Templ web apps, templUI components, HTMX/Alpine.js |
+| `htmx` | htmx attributes, partial page updates, SSE, swaps |
+
+### Multi-LLM
+
+| Skill | Triggers |
+|-------|----------|
+| `second-opinion` | Architecture decisions, security code, "sanity check" |
+| `gemini-image` | Image generation requests |
 
 ## Installation
 
-### Via Skills Installer
+### Via Codex skill installer (recommended)
 
-```bash
+```
 codex> $skill-installer gopherguides/gopher-ai
 ```
 
-### Manual Installation
+### One-liner install
 
 ```bash
-# Clone the repository
+# User-level (available across all projects)
+bash <(curl -fsSL https://raw.githubusercontent.com/gopherguides/gopher-ai/main/scripts/install-codex.sh) --user
+
+# Repo-level (available to all contributors)
+bash <(curl -fsSL https://raw.githubusercontent.com/gopherguides/gopher-ai/main/scripts/install-codex.sh) --repo .
+```
+
+### Manual install
+
+```bash
 git clone https://github.com/gopherguides/gopher-ai
 cd gopher-ai
-
-# Build universal distribution
 ./scripts/build-universal.sh
-
-# Copy skills to Codex
-cp -r dist/codex/skills/* ~/.codex/skills/
+cp -r dist/codex/skills/* ~/.agents/skills/
 ```
 
-## Usage
+### Skill locations
 
-Skills activate automatically based on context. You can also invoke directly:
+| Scope | Path | Use case |
+|-------|------|----------|
+| Repo-level | `.agents/skills/` | Shared team standards (committed to repo) |
+| User-level | `$HOME/.agents/skills/` | Personal toolkit across all projects |
+| Legacy | `~/.codex/skills/` | Still loaded for backward compatibility |
 
+> **Migrating from `~/.codex/skills/`?** Move your skills to `~/.agents/skills/` — Codex scans both paths, but `.agents/skills/` is the current convention.
+
+## Updating
+
+Re-run the installer to replace existing skills:
+
+```bash
+bash <(curl -fsSL https://raw.githubusercontent.com/gopherguides/gopher-ai/main/scripts/install-codex.sh) --user
 ```
-$go-best-practices
-$second-opinion
-$tailwind-best-practices
-$templui
-$go-profiling-optimization
-$gopher-guides
-```
 
-## Architecture
+Or update manually:
 
-```
-plugins/
-  <plugin-name>/
-    .claude-plugin/
-      plugin.json      # Plugin metadata
-    commands/          # Slash command definitions (*.md)
-    skills/            # Auto-invoked skills (SKILL.md)
-    agents/            # Agent definitions
+```bash
+rm -rf ~/.agents/skills/{go-best-practices,second-opinion,tailwind-best-practices,templui,gopher-guides,go-profiling-optimization,systematic-debugging,validate-skills,htmx,address-review,gemini-image}
+cp -r dist/codex/skills/* ~/.agents/skills/
 ```
 
 ## Development
 
 ```bash
-# Install git hooks
-./scripts/install-hooks.sh
-
-# Build universal distribution
-./scripts/build-universal.sh
-
-# Sync shared files
-./scripts/sync-shared.sh
+./scripts/install-hooks.sh       # Install git hooks
+./scripts/build-universal.sh     # Build universal distribution
+./scripts/sync-shared.sh         # Sync shared files
 ```
 
 ## Links
 
 - [Gopher Guides](https://gopherguides.com) - Official Go training
 - [GitHub Repository](https://github.com/gopherguides/gopher-ai)
-- [Claude Code Plugin Docs](https://docs.anthropic.com/claude-code/plugins)

--- a/README.md
+++ b/README.md
@@ -9,12 +9,12 @@ Gopher AI provides skills and commands for the three major AI coding assistants:
 | Platform | Status | Install Method |
 |----------|--------|----------------|
 | **Claude Code** | Full support | Plugin marketplace |
-| **OpenAI Codex CLI** | Skills only | Manual or skills installer |
+| **OpenAI Codex CLI** | Skills only | Skills installer, one-liner, or manual |
 | **Google Gemini CLI** | Extensions | Manual install |
 
 **What's included:**
 - 7 modules (go-workflow, go-dev, productivity, gopher-guides, llm-tools, go-web, tailwind)
-- 5 auto-invoked skills for Go best practices, second opinions, and more
+- 11 auto-invoked skills for Go best practices, debugging, profiling, and more
 - 20+ slash commands for development workflows
 
 ## Quick Start
@@ -38,14 +38,17 @@ Gopher AI provides skills and commands for the three major AI coding assistants:
 ### OpenAI Codex CLI
 
 ```bash
-# Via skills installer
+# Via skills installer (recommended)
 codex> $skill-installer gopherguides/gopher-ai
+
+# Or one-liner install (user-level)
+bash <(curl -fsSL https://raw.githubusercontent.com/gopherguides/gopher-ai/main/scripts/install-codex.sh) --user
 
 # Or manual installation
 git clone https://github.com/gopherguides/gopher-ai
 cd gopher-ai
 ./scripts/build-universal.sh
-cp -r dist/codex/skills/* ~/.codex/skills/
+cp -r dist/codex/skills/* ~/.agents/skills/
 ```
 
 ### Google Gemini CLI
@@ -192,14 +195,22 @@ Skills are auto-invoked behaviors that activate based on context. Available acro
 | Skill | Triggers When |
 |-------|---------------|
 | `go-best-practices` | Writing Go code, asking about patterns, code reviews |
-| `second-opinion` | Architecture decisions, security code, "sanity check" requests |
+| `go-profiling-optimization` | Performance, profiling, benchmarks, "why is this slow" |
+| `systematic-debugging` | Debugging, test failures, stack traces, "why is this broken" |
+| `gopher-guides` | Asking about Go idioms, "what's the right way to..." |
+| `validate-skills` | Editing command/skill .md files, shell code validation |
+| `address-review` | PR review comments, reviewer feedback, unresolved threads |
 | `tailwind-best-practices` | Working with Tailwind CSS classes, themes, utilities |
 | `templui` | Building Go/Templ web apps, HTMX/Alpine.js integration |
-| `gopher-guides` | Asking about Go idioms, "what's the right way to..." |
+| `htmx` | htmx attributes, partial page updates, SSE, swaps |
+| `second-opinion` | Architecture decisions, security code, "sanity check" requests |
+| `gemini-image` | Image generation requests |
 
 ## Agent Skills (GitHub Copilot)
 
-Distributable [Agent Skills](https://agentskills.io) for Go code quality auditing. Install to your repo:
+> **Not to be confused with Codex skills.** These Agent Skills follow the [agentskills.io](https://agentskills.io) specification and install to `.github/skills/` for GitHub Copilot. For Codex CLI skills (which use `.agents/skills/`), see [OpenAI Codex CLI](#openai-codex-cli) above.
+
+Distributable Agent Skills for Go code quality auditing. Install to your repo:
 
 ```bash
 bash <(curl -fsSL https://raw.githubusercontent.com/gopherguides/gopher-ai/main/agent-skills/scripts/install.sh) --repo .
@@ -248,7 +259,34 @@ SHELL=/bin/bash claude
 
 ### OpenAI Codex CLI
 
-Skills are installed to `~/.codex/skills/`. After installation, skills activate automatically based on context. You can also invoke directly with `$skill-name`.
+**Skill locations** (Codex scans in this order):
+
+| Scope | Path | Use case |
+|-------|------|----------|
+| Repo-level | `.agents/skills/` | Shared team standards, committed to repo |
+| User-level | `$HOME/.agents/skills/` | Personal toolkit across all projects |
+| Legacy | `~/.codex/skills/` | Still loaded for backward compatibility |
+
+After installation, skills activate automatically based on context. You can also invoke directly with `$skill-name`.
+
+**Updating skills:**
+
+Re-run the installer to replace existing skills with the latest version:
+
+```bash
+bash <(curl -fsSL https://raw.githubusercontent.com/gopherguides/gopher-ai/main/scripts/install-codex.sh) --user
+```
+
+**Migrating from `~/.codex/skills/`:**
+
+The `~/.codex/skills/` path is legacy. Move to the current convention:
+
+```bash
+# Install to the new location
+bash <(curl -fsSL https://raw.githubusercontent.com/gopherguides/gopher-ai/main/scripts/install-codex.sh) --user
+# Remove legacy copy
+rm -rf ~/.codex/skills/
+```
 
 ### Google Gemini CLI
 
@@ -363,6 +401,7 @@ This generates:
 - `dist/codex/` - Codex-compatible skills
 - `dist/gemini/` - Gemini extensions
 - `dist/*.tar.gz` - Release archives
+- `.agents/skills/` - Repo-local Codex skills (for working inside this repo)
 
 ## License
 

--- a/scripts/build-universal.sh
+++ b/scripts/build-universal.sh
@@ -19,7 +19,11 @@ build_codex() {
     echo "------------------------"
 
     local codex_dir="$DIST_DIR/codex"
+    local repo_agents_dir="$ROOT_DIR/.agents/skills"
     mkdir -p "$codex_dir/skills"
+
+    rm -rf "$repo_agents_dir"
+    mkdir -p "$repo_agents_dir"
 
     for skill_dir in "$ROOT_DIR"/plugins/*/skills/*/; do
         if [[ -f "${skill_dir}SKILL.md" ]]; then
@@ -27,12 +31,15 @@ build_codex() {
             echo "  - Copying skill: $skill_name"
             mkdir -p "$codex_dir/skills/$skill_name"
             cp "${skill_dir}"*.md "$codex_dir/skills/$skill_name/"
+            mkdir -p "$repo_agents_dir/$skill_name"
+            cp "${skill_dir}"*.md "$repo_agents_dir/$skill_name/"
         fi
     done
 
     echo "  - Generating AGENTS.md"
     generate_agents_md > "$codex_dir/AGENTS.md"
 
+    echo "  - Populated repo-level .agents/skills/ ($(find "$repo_agents_dir" -maxdepth 1 -mindepth 1 -type d | wc -l | tr -d ' ') skills)"
     echo "  Done: $codex_dir"
 }
 
@@ -42,38 +49,91 @@ generate_agents_md() {
 
 Project instructions for OpenAI Codex CLI.
 
-## Project Overview
-
-gopher-ai is a Go-focused development toolkit providing skills for:
-
-- **Go Best Practices**: Idiomatic Go patterns and error handling
-- **Second Opinion**: Get alternative perspectives on complex decisions
-- **Tailwind CSS**: v4 best practices and utilities
-- **templUI**: Go/Templ web development with HTMX/Alpine.js
-- **Gopher Guides**: Training materials integration
-
 ## Available Skills
 
-Skills are auto-invoked based on context. Available skills:
+Skills auto-activate based on context, or invoke directly with `$skill-name`.
+
+### Go Development
 
 | Skill | Triggers |
 |-------|----------|
 | `go-best-practices` | Go code, patterns, reviews, "best way to..." |
-| `second-opinion` | Architecture decisions, security code, "sanity check" |
-| `tailwind-best-practices` | Tailwind CSS classes, themes, utilities |
-| `templui` | Go/Templ web apps, HTMX, Alpine.js |
+| `go-profiling-optimization` | Performance, profiling, benchmarks, "why is this slow" |
+| `systematic-debugging` | Debugging, test failures, stack traces, "why is this broken" |
 | `gopher-guides` | Go training materials, idiomatic patterns |
 
-## Usage with Codex
+### Code Quality
 
-Skills activate automatically. You can also invoke directly:
+| Skill | Triggers |
+|-------|----------|
+| `validate-skills` | Editing command/skill .md files, shell code validation |
+| `address-review` | PR review comments, reviewer feedback, unresolved threads |
+
+### Web Development
+
+| Skill | Triggers |
+|-------|----------|
+| `tailwind-best-practices` | Tailwind CSS classes, themes, v4 config |
+| `templui` | Go/Templ web apps, templUI components, HTMX/Alpine.js |
+| `htmx` | htmx attributes, partial page updates, SSE, swaps |
+
+### Multi-LLM
+
+| Skill | Triggers |
+|-------|----------|
+| `second-opinion` | Architecture decisions, security code, "sanity check" |
+| `gemini-image` | Image generation requests |
+
+## Installation
+
+### Via Codex skill installer (recommended)
 
 ```
-$go-best-practices
-$second-opinion
-$tailwind-best-practices
-$templui
-$gopher-guides
+codex> $skill-installer gopherguides/gopher-ai
+```
+
+### One-liner install
+
+```bash
+# User-level (available across all projects)
+bash <(curl -fsSL https://raw.githubusercontent.com/gopherguides/gopher-ai/main/scripts/install-codex.sh) --user
+
+# Repo-level (available to all contributors)
+bash <(curl -fsSL https://raw.githubusercontent.com/gopherguides/gopher-ai/main/scripts/install-codex.sh) --repo .
+```
+
+### Manual install
+
+```bash
+git clone https://github.com/gopherguides/gopher-ai
+cd gopher-ai
+./scripts/build-universal.sh
+cp -r dist/codex/skills/* ~/.agents/skills/
+```
+
+### Skill locations
+
+| Scope | Path | Use case |
+|-------|------|----------|
+| Repo-level | `.agents/skills/` | Shared team standards (committed to repo) |
+| User-level | `$HOME/.agents/skills/` | Personal toolkit across all projects |
+| Legacy | `~/.codex/skills/` | Still loaded for backward compatibility |
+
+> **Migrating from `~/.codex/skills/`?** Move your skills to `~/.agents/skills/` — Codex scans both paths, but `.agents/skills/` is the current convention.
+
+## Updating
+
+Re-run the installer to replace existing skills:
+
+```bash
+bash <(curl -fsSL https://raw.githubusercontent.com/gopherguides/gopher-ai/main/scripts/install-codex.sh) --user
+```
+
+Or update manually:
+
+```bash
+rm -rf ~/.agents/skills/{go-best-practices,second-opinion,tailwind-best-practices,templui,gopher-guides,go-profiling-optimization,systematic-debugging,validate-skills,htmx,address-review,gemini-image}
+cp -r dist/codex/skills/* ~/.agents/skills/
 ```
 
 ## Links
@@ -292,9 +352,12 @@ print_summary() {
     echo ""
     echo "Installation instructions:"
     echo ""
-    echo "  Codex CLI:"
-    echo "    cp -r dist/codex/skills/* ~/.codex/skills/"
+    echo "  Codex CLI (user-level):"
+    echo "    cp -r dist/codex/skills/* ~/.agents/skills/"
     echo "    cp dist/codex/AGENTS.md ./AGENTS.md"
+    echo ""
+    echo "  Codex CLI (legacy path, still supported):"
+    echo "    cp -r dist/codex/skills/* ~/.codex/skills/"
     echo ""
     echo "  Gemini CLI:"
     echo "    gemini extensions install ./dist/gemini/gopher-ai-<plugin>"

--- a/scripts/install-codex.sh
+++ b/scripts/install-codex.sh
@@ -1,0 +1,151 @@
+#!/usr/bin/env bash
+# install-codex.sh — Install or update gopher-ai Codex skills
+# Usage:
+#   bash install-codex.sh --user              # Install to $HOME/.agents/skills/
+#   bash install-codex.sh --repo .            # Install to ./.agents/skills/
+#   bash install-codex.sh --repo /path/to     # Install to /path/to/.agents/skills/
+#   bash install-codex.sh --legacy            # Install to ~/.codex/skills/ (deprecated)
+#   bash install-codex.sh                     # Default: --user
+#
+# This script clones the gopher-ai repo, builds the Codex skill distribution,
+# and copies skills to the target location. Existing skills are replaced cleanly.
+
+set -euo pipefail
+
+REPO_URL="https://github.com/gopherguides/gopher-ai"
+BRANCH="main"
+CLONE_DIR=""
+
+usage() {
+    echo "Usage: $0 [--user] [--repo <path>] [--legacy] [--branch <branch>]"
+    echo ""
+    echo "Install or update gopher-ai skills for OpenAI Codex CLI."
+    echo ""
+    echo "Options:"
+    echo "  --user             Install to \$HOME/.agents/skills/ (default)"
+    echo "  --repo <path>      Install to <path>/.agents/skills/ (repo-level)"
+    echo "  --legacy           Install to ~/.codex/skills/ (deprecated, use --user)"
+    echo "  --branch <name>    Use a specific branch (default: main)"
+    echo "  --help             Show this help"
+    echo ""
+    echo "Skill locations (Codex scans in this order):"
+    echo "  Repo-level:   .agents/skills/          Committed to repo, shared with team"
+    echo "  User-level:   \$HOME/.agents/skills/    Personal toolkit, all projects"
+    echo "  Legacy:       ~/.codex/skills/          Still loaded for backward compat"
+    exit 0
+}
+
+cleanup() {
+    [[ -n "$CLONE_DIR" && -d "$CLONE_DIR" ]] && rm -rf "$CLONE_DIR"
+}
+trap cleanup EXIT
+
+MODE=""
+TARGET=""
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --user)
+            MODE="user"
+            shift
+            ;;
+        --repo)
+            MODE="repo"
+            TARGET="${2:-.}"
+            shift 2
+            ;;
+        --legacy)
+            MODE="legacy"
+            shift
+            ;;
+        --branch)
+            BRANCH="$2"
+            shift 2
+            ;;
+        --help|-h)
+            usage
+            ;;
+        *)
+            echo "Unknown option: $1"
+            usage
+            ;;
+    esac
+done
+
+if [[ -z "$MODE" ]]; then
+    MODE="user"
+fi
+
+# ── Determine destination ────────────────────────────────────────────
+case "$MODE" in
+    user)
+        DEST="$HOME/.agents/skills"
+        ;;
+    repo)
+        TARGET=$(cd "$TARGET" && pwd)
+        DEST="$TARGET/.agents/skills"
+        ;;
+    legacy)
+        DEST="$HOME/.codex/skills"
+        echo "Warning: ~/.codex/skills/ is a legacy path."
+        echo "Consider using --user (\$HOME/.agents/skills/) instead."
+        echo ""
+        ;;
+esac
+
+# ── Check for legacy skills and suggest migration ────────────────────
+if [[ "$MODE" != "legacy" && -d "$HOME/.codex/skills" ]]; then
+    legacy_count=$(find "$HOME/.codex/skills" -maxdepth 1 -mindepth 1 -type d 2>/dev/null | wc -l | tr -d ' ')
+    if [[ "$legacy_count" -gt 0 ]]; then
+        echo "Note: Found $legacy_count skill(s) at legacy path ~/.codex/skills/"
+        echo "After installing to the new location, you can remove the legacy copy:"
+        echo "  rm -rf ~/.codex/skills/"
+        echo ""
+    fi
+fi
+
+# ── Clone and build ──────────────────────────────────────────────────
+echo "Fetching gopher-ai skills..."
+CLONE_DIR=$(mktemp -d)
+git clone --depth 1 --branch "$BRANCH" "$REPO_URL" "$CLONE_DIR" 2>/dev/null
+
+if [[ ! -f "$CLONE_DIR/scripts/build-universal.sh" ]]; then
+    echo "Error: build script not found in repository"
+    exit 1
+fi
+
+echo "Building skill distribution..."
+(cd "$CLONE_DIR" && bash scripts/build-universal.sh) > /dev/null 2>&1
+
+if [[ ! -d "$CLONE_DIR/dist/codex/skills" ]]; then
+    echo "Error: build did not produce Codex skills"
+    exit 1
+fi
+
+# ── Install skills ───────────────────────────────────────────────────
+mkdir -p "$DEST"
+
+installed=0
+for skill_dir in "$CLONE_DIR/dist/codex/skills"/*/; do
+    if [[ -f "$skill_dir/SKILL.md" ]]; then
+        skill_name=$(basename "$skill_dir")
+        rm -rf "${DEST:?}/$skill_name"
+        cp -r "$skill_dir" "$DEST/$skill_name"
+        echo "  Installed: $skill_name"
+        installed=$((installed + 1))
+    fi
+done
+
+echo ""
+echo "Done! $installed skills installed to $DEST/"
+
+if [[ "$MODE" == "repo" ]]; then
+    echo ""
+    echo "Next steps:"
+    echo "  1. git add .agents/skills/"
+    echo "  2. git commit -m 'feat: add gopher-ai Codex skills'"
+fi
+
+echo ""
+echo "Skills activate automatically in Codex based on context."
+echo "You can also invoke directly: \$go-best-practices, \$second-opinion, etc."


### PR DESCRIPTION
## Summary

- Add repo-local `.agents/skills/` directory with all 11 skills so Codex users working in the repo get skills immediately
- Create `scripts/install-codex.sh` — standalone installer with `--user`, `--repo`, and `--legacy` modes
- Update `scripts/build-universal.sh` to populate `.agents/skills/` alongside `dist/codex/` and list all 11 skills (was 5)
- Rewrite `AGENTS.md` with full skill inventory, new install paths, and update workflow
- Update `README.md`: Quick Start, Skills Reference (5→11), Platform Notes (migration guide), Agent Skills disambiguation, Building section

Fixes #115

## What changed

### New files
- `.agents/skills/` — 11 skill directories copied from `plugins/*/skills/*/`, giving Codex repo-level skill discovery
- `scripts/install-codex.sh` — one-liner installer: `bash <(curl ...) --user` (or `--repo .` for repo-level)

### Updated files
- `AGENTS.md` — full rewrite: all 11 skills listed, `$HOME/.agents/skills/` as primary, `~/.codex/skills/` as legacy only
- `README.md` — 6 targeted edits: skill count (5→11), Quick Start adds one-liner, Skills Reference expanded, Agent Skills vs Codex disambiguation, Platform Notes adds scope table + migration + update workflow, Building notes `.agents/skills/` output
- `scripts/build-universal.sh` — `build_codex()` also populates `.agents/skills/`, `generate_agents_md()` lists all 11 skills with new paths, `print_summary()` uses new primary path

### Path convention
| Context | Old | New |
|---------|-----|-----|
| Primary install | `~/.codex/skills/` | `$HOME/.agents/skills/` |
| Repo-level | (none) | `.agents/skills/` |
| Legacy compat | — | `~/.codex/skills/` (still loaded) |

## Test Plan

- [x] `./scripts/build-universal.sh` succeeds and populates both `dist/codex/skills/` (11 skills) and `.agents/skills/` (11 skills)
- [x] `shellcheck scripts/install-codex.sh` passes clean
- [x] All remaining `~/.codex/skills/` references are in legacy/compatibility context only
- [x] All primary install paths reference `~/.agents/skills/` or `.agents/skills/`
- [ ] Manual: run `bash scripts/install-codex.sh --user` against a fresh `$HOME/.agents/skills/`