### PR TITLE
fix(codex): use supported marketplace auth policy

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -12,7 +12,7 @@
       },
       "policy": {
         "installation": "AVAILABLE",
-        "authentication": "ON_FIRST_USE"
+        "authentication": "ON_USE"
       },
       "category": "Development"
     },
@@ -24,7 +24,7 @@
       },
       "policy": {
         "installation": "AVAILABLE",
-        "authentication": "ON_FIRST_USE"
+        "authentication": "ON_USE"
       },
       "category": "Development"
     },
@@ -36,7 +36,7 @@
       },
       "policy": {
         "installation": "AVAILABLE",
-        "authentication": "ON_FIRST_USE"
+        "authentication": "ON_USE"
       },
       "category": "Development"
     },
@@ -48,7 +48,7 @@
       },
       "policy": {
         "installation": "AVAILABLE",
-        "authentication": "ON_FIRST_USE"
+        "authentication": "ON_USE"
       },
       "category": "Productivity"
     },
@@ -60,7 +60,7 @@
       },
       "policy": {
         "installation": "AVAILABLE",
-        "authentication": "ON_FIRST_USE"
+        "authentication": "ON_USE"
       },
       "category": "Development"
     },
@@ -72,7 +72,7 @@
       },
       "policy": {
         "installation": "AVAILABLE",
-        "authentication": "ON_FIRST_USE"
+        "authentication": "ON_USE"
       },
       "category": "Development"
     }

--- a/scripts/build-universal.sh
+++ b/scripts/build-universal.sh
@@ -70,7 +70,7 @@ generate_codex_marketplace() {
             if [[ "$plugin_name" == "llm-tools" ]]; then
                 category="Productivity"
             fi
-            printf '    {\n      "name": "%s",\n      "source": { "source": "local", "path": "./.codex/plugins/%s" },\n      "policy": { "installation": "AVAILABLE", "authentication": "ON_FIRST_USE" },\n      "category": "%s"\n    }' "$plugin_name" "$plugin_name" "$category"
+            printf '    {\n      "name": "%s",\n      "source": { "source": "local", "path": "./.codex/plugins/%s" },\n      "policy": { "installation": "AVAILABLE", "authentication": "ON_USE" },\n      "category": "%s"\n    }' "$plugin_name" "$plugin_name" "$category"
         fi
     done
     echo ''


### PR DESCRIPTION
## Summary

- update the Codex marketplace generator to use the supported `ON_USE` authentication policy
- update the checked-in repo-local marketplace manifest to match the current Codex CLI schema
- restore personal marketplace loading in Codex CLI v0.117.0 so Gopher AI plugins can be discovered and installed

## Test Plan

- [x] `bash -n scripts/build-universal.sh`
- [x] `jq . .agents/plugins/marketplace.json`
- [x] rebuild and reinstall the personal marketplace
- [x] verify Codex no longer rejects the marketplace schema and Gopher AI plugins appear in `/plugins`
