### PR TITLE
docs(codex): add plugin install/update flow

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -56,26 +56,25 @@ Browse available plugins with the `/plugins` command in Codex CLI.
 To add these plugins to **your own repo**:
 
 ```bash
-mkdir -p /path/to/your-repo/.agents/plugins
-cp .agents/plugins/marketplace.json /path/to/your-repo/.agents/plugins/
-cp -r plugins/ /path/to/your-repo/plugins/
+./scripts/install-codex.sh --repo /path/to/your-repo
 ```
 
-### Global (Personal) Installation
+### Global (Personal) Installation and Update
 
 To make plugins available across all your repos:
 
 ```bash
-git clone https://github.com/gopherguides/gopher-ai
-cd gopher-ai
 ./scripts/build-universal.sh
-
-mkdir -p ~/.codex/plugins ~/.agents/plugins
-cp -r dist/codex/plugins/* ~/.codex/plugins/
-cp dist/codex/plugins/marketplace.json ~/.agents/plugins/marketplace.json
+./scripts/install-codex.sh --user
 ```
 
-Restart Codex after installation. Use `/plugins` to verify they appear.
+Or as a one-liner from GitHub:
+
+```bash
+bash <(curl -fsSL https://raw.githubusercontent.com/gopherguides/gopher-ai/main/scripts/install-codex.sh) --user
+```
+
+Restart Codex after installation or update. Use `/plugins` to verify they appear.
 
 ### Flat Skills (Legacy)
 
@@ -112,6 +111,7 @@ plugins/
 - GitHub CLI (`gh`) installed and authenticated
 - Git with worktree support
 - `golangci-lint` (optional, for lint checks)
+- `jq` for `./scripts/install-codex.sh`
 
 ## Links
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Gopher AI provides skills and commands for the three major AI coding assistants:
 | Platform | Status | Install Method |
 |----------|--------|----------------|
 | **Claude Code** | Full support | Plugin marketplace |
-| **OpenAI Codex CLI** | Full plugin support | Plugin install or manual |
+| **OpenAI Codex CLI** | Full plugin support | Repo-local, installer script, or manual |
 | **Google Gemini CLI** | Extensions | Manual install |
 
 **What's included:**
@@ -45,12 +45,13 @@ cd gopher-ai
 codex   # Plugins load automatically from .agents/plugins/marketplace.json
 # Use /plugins to browse, $start-issue 42 to invoke workflow skills
 
-# Global install (all repos)
+# Global install or update (all repos)
 ./scripts/build-universal.sh
-mkdir -p ~/.codex/plugins ~/.agents/plugins
-cp -r dist/codex/plugins/* ~/.codex/plugins/
-cp dist/codex/plugins/marketplace.json ~/.agents/plugins/marketplace.json
+./scripts/install-codex.sh --user
 # Restart Codex — use /plugins to verify
+
+# Or one-liner install from GitHub
+bash <(curl -fsSL https://raw.githubusercontent.com/gopherguides/gopher-ai/main/scripts/install-codex.sh) --user
 ```
 
 ### Google Gemini CLI
@@ -257,7 +258,11 @@ Plugins are distributed via the [Codex plugin system](https://developers.openai.
 
 **Repo-local discovery:** Codex reads `.agents/plugins/marketplace.json` on startup and syncs plugins automatically. Use `/plugins` to browse and manage installed plugins. Each plugin has both `.claude-plugin/plugin.json` and `.codex-plugin/plugin.json` — the same plugin directory serves both platforms.
 
-**Global install:** Copy `dist/codex/plugins/` to `~/.codex/plugins/` and `marketplace.json` to `~/.agents/plugins/`. The built marketplace points at `~/.codex/plugins/` using Codex's personal marketplace path rules. See Quick Start above.
+**Global install or update:** Build the distribution and run `./scripts/install-codex.sh --user`. The installer replaces the current gopher-ai plugins in `~/.codex/plugins/` and merges the marketplace entries into `~/.agents/plugins/marketplace.json` without removing unrelated plugin entries.
+
+**Install into another repo:** Use `./scripts/install-codex.sh --repo /path/to/your-repo` to copy the current plugin set into another repository and update that repo's `.agents/plugins/marketplace.json`.
+
+**Manual install:** Copy `dist/codex/plugins/` to `~/.codex/plugins/` and `marketplace.json` to `~/.agents/plugins/` if you prefer manual steps.
 
 **Workflow skills** (from `go-workflow` plugin):
 

--- a/scripts/build-universal.sh
+++ b/scripts/build-universal.sh
@@ -27,8 +27,7 @@ build_codex() {
         if [[ -f "${plugin_dir}.codex-plugin/plugin.json" ]]; then
             echo "  - Building plugin: $plugin_name"
             local dest="$codex_dir/plugins/$plugin_name"
-            mkdir -p "$dest"
-            cp -R "${plugin_dir}." "$dest/"
+            cp -R "$plugin_dir" "$codex_dir/plugins/"
             rm -rf "$dest/.claude-plugin"
         fi
     done
@@ -86,13 +85,13 @@ Project instructions for OpenAI Codex CLI.
 
 ## Project Overview
 
-gopher-ai is a Go-focused development toolkit distributed as Codex plugins. Each plugin bundles related skills that activate automatically or can be invoked explicitly.
+gopher-ai is a Go-focused development toolkit distributed as both Claude Code plugins and Codex plugins. Each plugin bundles related skills that activate automatically or can be invoked explicitly.
 
 ## Plugins
 
 | Plugin | Description | Skills |
 |--------|-------------|--------|
-| `go-workflow` | Issue-to-PR workflow automation | start-issue, create-worktree, commit, create-pr, ship, remove-worktree, prune-worktree, address-review, coverage |
+| `go-workflow` | Issue-to-PR workflow automation | start-issue, create-worktree, commit, create-pr, ship, remove-worktree, prune-worktree, address-review |
 | `go-dev` | Go development tools and best practices | go-best-practices, go-profiling-optimization, systematic-debugging, validate-skills |
 | `gopher-guides` | Gopher Guides training materials | gopher-guides |
 | `llm-tools` | Multi-LLM second opinions and delegation | second-opinion, gemini-image |
@@ -131,22 +130,61 @@ $prune-worktree
 
 ### Repo-Local (Recommended)
 
-Codex reads `.agents/plugins/marketplace.json` on startup and syncs plugins automatically. Use `/plugins` to browse available plugins.
+This repo includes `.agents/plugins/marketplace.json` which Codex reads on startup. When you clone this repo and run Codex inside it, all plugins are discovered automatically.
 
-### Global (Personal) Installation
+Use `/plugins` to browse available plugins.
+
+To add these plugins to another repo:
 
 ```bash
-mkdir -p ~/.codex/plugins ~/.agents/plugins
-cp -r dist/codex/plugins/* ~/.codex/plugins/
-cp dist/codex/plugins/marketplace.json ~/.agents/plugins/marketplace.json
+./scripts/install-codex.sh --repo /path/to/your-repo
 ```
 
-Restart Codex after installation. Use `/plugins` to verify.
+### Global (Personal) Installation and Update
+
+To install or replace the current gopher-ai plugins in your personal Codex setup:
+
+```bash
+./scripts/build-universal.sh
+./scripts/install-codex.sh --user
+```
+
+Or as a one-liner from GitHub:
+
+```bash
+bash <(curl -fsSL https://raw.githubusercontent.com/gopherguides/gopher-ai/main/scripts/install-codex.sh) --user
+```
+
+Restart Codex after installation or update. Use `/plugins` to verify.
 
 ### Flat Skills (Legacy)
 
+Individual skills can also be installed without the plugin system:
+
 ```bash
 cp -r dist/codex/skills/* ~/.codex/skills/
+```
+
+Or use the built-in `$skill-installer` for curated skills.
+
+## Architecture
+
+```
+.agents/plugins/
+  marketplace.json       # Codex plugin discovery
+
+.claude-plugin/
+  marketplace.json       # Claude Code plugin discovery
+
+plugins/
+  <plugin-name>/
+    .claude-plugin/
+      plugin.json        # Claude Code manifest
+    .codex-plugin/
+      plugin.json        # Codex manifest
+    commands/            # Claude Code slash commands
+    skills/              # Skills shared by both platforms
+    agents/              # Claude Code agent definitions
 ```
 
 ## Requirements
@@ -154,6 +192,7 @@ cp -r dist/codex/skills/* ~/.codex/skills/
 - GitHub CLI (`gh`) installed and authenticated
 - Git with worktree support
 - `golangci-lint` (optional, for lint checks)
+- `jq` for `./scripts/install-codex.sh`
 
 ## Links
 
@@ -326,8 +365,6 @@ EOF
 convert_allowlist_to_denylist() {
     local allowlist="$1"
 
-    local all_tools='["Bash", "Read", "Write", "Edit", "Glob", "Grep", "WebFetch", "WebSearch", "Task", "TodoWrite", "AskUserQuestion", "NotebookEdit"]'
-
     if [[ "$allowlist" == *"Bash"* && "$allowlist" != *"Bash("* ]]; then
         echo "[]"
         return
@@ -344,8 +381,8 @@ create_archives() {
     cd "$DIST_DIR"
 
     if [[ -d "codex" ]]; then
-        tar -czf "gopher-ai-codex-skills-v${VERSION}.tar.gz" codex/
-        echo "  - Created: gopher-ai-codex-skills-v${VERSION}.tar.gz"
+        tar -czf "gopher-ai-codex-plugins-v${VERSION}.tar.gz" codex/
+        echo "  - Created: gopher-ai-codex-plugins-v${VERSION}.tar.gz"
     fi
 
     if [[ -d "gemini" ]]; then
@@ -371,10 +408,11 @@ print_summary() {
     echo ""
     echo "Installation instructions:"
     echo ""
-    echo "  Codex CLI (plugins):"
-    echo "    mkdir -p ~/.codex/plugins ~/.agents/plugins"
-    echo "    cp -r dist/codex/plugins/* ~/.codex/plugins/"
-    echo "    cp dist/codex/plugins/marketplace.json ~/.agents/plugins/marketplace.json"
+    echo "  Codex CLI (user-level plugins):"
+    echo "    ./scripts/install-codex.sh --user"
+    echo ""
+    echo "  Codex CLI (repo-level plugins):"
+    echo "    ./scripts/install-codex.sh --repo /path/to/your-repo"
     echo ""
     echo "  Codex CLI (flat skills, legacy):"
     echo "    cp -r dist/codex/skills/* ~/.codex/skills/"

--- a/scripts/install-codex.sh
+++ b/scripts/install-codex.sh
@@ -1,0 +1,201 @@
+#!/bin/bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+DIST_DIR="$ROOT_DIR/dist/codex"
+
+usage() {
+    cat <<'EOF'
+Usage:
+  scripts/install-codex.sh --user
+  scripts/install-codex.sh --repo /path/to/repo
+
+Installs or updates gopher-ai Codex plugins using the current plugin-based layout.
+
+Options:
+  --user        Install into ~/.codex/plugins and merge entries into ~/.agents/plugins/marketplace.json
+  --repo PATH   Install into PATH/plugins and merge entries into PATH/.agents/plugins/marketplace.json
+  --help        Show this help text
+EOF
+}
+
+require_cmd() {
+    local cmd="$1"
+    if ! command -v "$cmd" >/dev/null 2>&1; then
+        echo "error: required command not found: $cmd" >&2
+        exit 1
+    fi
+}
+
+ensure_dist() {
+    if [[ ! -f "$DIST_DIR/plugins/marketplace.json" ]]; then
+        "$ROOT_DIR/scripts/build-universal.sh"
+    fi
+}
+
+merge_marketplace() {
+    local existing="$1"
+    local incoming="$2"
+    local merged="$3"
+
+    if [[ -f "$existing" ]]; then
+        jq -s '
+            .[0] as $old | .[1] as $new |
+            {
+              name: ($old.name // $new.name // "local-plugins"),
+              interface: ($old.interface // $new.interface // {"displayName":"Local Plugins"}),
+              plugins: (
+                (($old.plugins // [])
+                  | map(select(.name as $name | (($new.plugins // []) | map(.name) | index($name) | not))))
+                + ($new.plugins // [])
+              )
+            }
+        ' "$existing" "$incoming" >"$merged"
+    else
+        cp "$incoming" "$merged"
+    fi
+}
+
+copy_user_plugins() {
+    local plugins_home="$HOME/.codex/plugins"
+    mkdir -p "$plugins_home"
+
+    local plugin_path
+    for plugin_path in "$DIST_DIR"/plugins/*; do
+        [[ -d "$plugin_path" ]] || continue
+        local plugin_name
+        plugin_name="$(basename "$plugin_path")"
+        rm -rf "${plugins_home:?}/$plugin_name"
+        cp -R "$plugin_path" "$plugins_home/"
+        echo "installed plugin: $plugins_home/$plugin_name"
+    done
+}
+
+write_user_marketplace() {
+    local marketplace_dir="$HOME/.agents/plugins"
+    local marketplace_file="$marketplace_dir/marketplace.json"
+    local tmp_file
+    tmp_file="$(mktemp)"
+
+    mkdir -p "$marketplace_dir"
+    merge_marketplace "$marketplace_file" "$DIST_DIR/plugins/marketplace.json" "$tmp_file"
+    mv "$tmp_file" "$marketplace_file"
+    echo "updated marketplace: $marketplace_file"
+}
+
+build_repo_marketplace() {
+    local output_file="$1"
+
+    jq -n '
+        {
+          name: "gopher-ai",
+          interface: { displayName: "Gopher AI" },
+          plugins: [
+            {
+              name: "go-workflow",
+              source: { source: "local", path: "./plugins/go-workflow" },
+              policy: { installation: "AVAILABLE", authentication: "ON_USE" },
+              category: "Development"
+            },
+            {
+              name: "go-dev",
+              source: { source: "local", path: "./plugins/go-dev" },
+              policy: { installation: "AVAILABLE", authentication: "ON_USE" },
+              category: "Development"
+            },
+            {
+              name: "gopher-guides",
+              source: { source: "local", path: "./plugins/gopher-guides" },
+              policy: { installation: "AVAILABLE", authentication: "ON_USE" },
+              category: "Development"
+            },
+            {
+              name: "llm-tools",
+              source: { source: "local", path: "./plugins/llm-tools" },
+              policy: { installation: "AVAILABLE", authentication: "ON_USE" },
+              category: "Productivity"
+            },
+            {
+              name: "go-web",
+              source: { source: "local", path: "./plugins/go-web" },
+              policy: { installation: "AVAILABLE", authentication: "ON_USE" },
+              category: "Development"
+            },
+            {
+              name: "tailwind",
+              source: { source: "local", path: "./plugins/tailwind" },
+              policy: { installation: "AVAILABLE", authentication: "ON_USE" },
+              category: "Development"
+            }
+          ]
+        }
+    ' >"$output_file"
+}
+
+copy_repo_plugins() {
+    local target_repo="$1"
+    mkdir -p "$target_repo/plugins"
+
+    local plugin_dir
+    for plugin_dir in "$ROOT_DIR"/plugins/*; do
+        [[ -d "$plugin_dir" ]] || continue
+        local plugin_name
+        plugin_name="$(basename "$plugin_dir")"
+        if [[ -f "$plugin_dir/.codex-plugin/plugin.json" ]]; then
+            rm -rf "${target_repo:?}/plugins/$plugin_name"
+            cp -R "$plugin_dir" "$target_repo/plugins/"
+            echo "installed plugin: $target_repo/plugins/$plugin_name"
+        fi
+    done
+}
+
+write_repo_marketplace() {
+    local target_repo="$1"
+    local marketplace_dir="$target_repo/.agents/plugins"
+    local marketplace_file="$marketplace_dir/marketplace.json"
+    local incoming_file
+    local merged_file
+
+    incoming_file="$(mktemp)"
+    merged_file="$(mktemp)"
+
+    mkdir -p "$marketplace_dir"
+    build_repo_marketplace "$incoming_file"
+    merge_marketplace "$marketplace_file" "$incoming_file" "$merged_file"
+    mv "$merged_file" "$marketplace_file"
+    rm -f "$incoming_file"
+    echo "updated marketplace: $marketplace_file"
+}
+
+main() {
+    require_cmd jq
+
+    case "${1:-}" in
+        --help|-h)
+            usage
+            ;;
+        --user)
+            ensure_dist
+            copy_user_plugins
+            write_user_marketplace
+            ;;
+        --repo)
+            if [[ $# -lt 2 ]]; then
+                echo "error: --repo requires a target path" >&2
+                exit 1
+            fi
+            ensure_dist
+            local target_repo
+            target_repo="$(cd "$2" && pwd)"
+            copy_repo_plugins "$target_repo"
+            write_repo_marketplace "$target_repo"
+            ;;
+        *)
+            usage >&2
+            exit 1
+            ;;
+    esac
+}
+
+main "$@"


### PR DESCRIPTION
## Summary

- add `scripts/install-codex.sh` for Codex plugin install/update at user and repo scope
- update README and AGENTS to make the plugin workflow the primary Codex path
- update `scripts/build-universal.sh` generated docs, archive naming, and install summary to match the current plugin architecture
- fix Codex plugin packaging copy logic in `build-universal.sh`

Fixes #115

Replaces the stale direction in #118, which was based on the older flat-skills workflow.

## Verification

- [x] `shellcheck scripts/install-codex.sh scripts/build-universal.sh`
- [x] `./scripts/build-universal.sh`
- [x] `./scripts/install-codex.sh --help`
- [x] `./scripts/install-codex.sh --repo <tmpdir>`
