### PR TITLE
fix: bootstrap Codex standalone install

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,6 +6,8 @@ Project instructions for OpenAI Codex CLI.
 
 gopher-ai is a Go-focused development toolkit distributed as both Claude Code plugins and Codex plugins. Each plugin bundles related skills that activate automatically or can be invoked explicitly.
 
+The Codex plugin set currently includes `go-workflow`, `go-dev`, `gopher-guides`, `llm-tools`, `go-web`, and `tailwind`. The repo's `productivity` module is currently Claude-only.
+
 ## Plugins
 
 | Plugin | Description | Skills |
@@ -74,6 +76,8 @@ Or as a one-liner from GitHub:
 bash <(curl -fsSL https://raw.githubusercontent.com/gopherguides/gopher-ai/main/scripts/install-codex.sh) --user
 ```
 
+The one-liner bootstraps a temporary checkout of the latest `main` branch, builds the Codex distribution, and installs it into your user-space Codex directories.
+
 Restart Codex after installation or update. Use `/plugins` to verify they appear.
 
 ### Flat Skills (Legacy)
@@ -100,7 +104,7 @@ plugins/
     .claude-plugin/
       plugin.json        # Claude Code manifest
     .codex-plugin/
-      plugin.json        # Codex manifest
+      plugin.json        # Codex manifest when the plugin is packaged for Codex
     commands/            # Claude Code slash commands
     skills/              # Skills (shared by both platforms)
     agents/              # Claude Code agent definitions

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ codex   # Plugins load automatically from .agents/plugins/marketplace.json
 ./scripts/install-codex.sh --user
 # Restart Codex — use /plugins to verify
 
-# Or one-liner install from GitHub
+# Or one-liner install from GitHub (bootstraps latest main, then installs)
 bash <(curl -fsSL https://raw.githubusercontent.com/gopherguides/gopher-ai/main/scripts/install-codex.sh) --user
 ```
 
@@ -256,9 +256,11 @@ SHELL=/bin/bash claude
 
 Plugins are distributed via the [Codex plugin system](https://developers.openai.com/codex/plugins). Each plugin contains skills that activate automatically or can be invoked explicitly.
 
-**Repo-local discovery:** Codex reads `.agents/plugins/marketplace.json` on startup and syncs plugins automatically. Use `/plugins` to browse and manage installed plugins. Each plugin has both `.claude-plugin/plugin.json` and `.codex-plugin/plugin.json` — the same plugin directory serves both platforms.
+**Repo-local discovery:** Codex reads `.agents/plugins/marketplace.json` on startup and syncs plugins automatically. Use `/plugins` to browse and manage installed plugins. Plugins with `.codex-plugin/plugin.json` are packaged for Codex. Today that set is `go-workflow`, `go-dev`, `gopher-guides`, `llm-tools`, `go-web`, and `tailwind`. The repo's `productivity` module remains Claude-only.
 
 **Global install or update:** Build the distribution and run `./scripts/install-codex.sh --user`. The installer replaces the current gopher-ai plugins in `~/.codex/plugins/` and merges the marketplace entries into `~/.agents/plugins/marketplace.json` without removing unrelated plugin entries.
+
+**GitHub one-liner:** `bash <(curl -fsSL https://raw.githubusercontent.com/gopherguides/gopher-ai/main/scripts/install-codex.sh) --user` bootstraps a temporary checkout of the latest `main` branch, builds the Codex distribution, and installs it into your user-space Codex directories.
 
 **Install into another repo:** Use `./scripts/install-codex.sh --repo /path/to/your-repo` to copy the current plugin set into another repository and update that repo's `.agents/plugins/marketplace.json`.
 

--- a/scripts/build-universal.sh
+++ b/scripts/build-universal.sh
@@ -22,12 +22,14 @@ build_codex() {
     mkdir -p "$codex_dir/plugins" "$codex_dir/skills"
 
     # Build Codex plugin packages for plugins with .codex-plugin/plugin.json
-    for plugin_dir in "$ROOT_DIR"/plugins/*/; do
+    for plugin_dir in "$ROOT_DIR"/plugins/*; do
+        [[ -d "$plugin_dir" ]] || continue
         plugin_name=$(basename "$plugin_dir")
-        if [[ -f "${plugin_dir}.codex-plugin/plugin.json" ]]; then
+        if [[ -f "$plugin_dir/.codex-plugin/plugin.json" ]]; then
             echo "  - Building plugin: $plugin_name"
             local dest="$codex_dir/plugins/$plugin_name"
-            cp -R "$plugin_dir" "$codex_dir/plugins/"
+            mkdir -p "$dest"
+            cp -R "$plugin_dir"/. "$dest/"
             rm -rf "$dest/.claude-plugin"
         fi
     done
@@ -81,7 +83,10 @@ generate_codex_marketplace() {
 }
 
 generate_agents_md() {
-    cat << 'EOF'
+    if [[ -f "$ROOT_DIR/AGENTS.md" ]]; then
+        cat "$ROOT_DIR/AGENTS.md"
+    else
+        cat << 'EOF'
 # AGENTS.md
 
 Project instructions for OpenAI Codex CLI.
@@ -202,6 +207,7 @@ plugins/
 - [Gopher Guides](https://gopherguides.com) - Official Go training
 - [GitHub Repository](https://github.com/gopherguides/gopher-ai)
 EOF
+    fi
 }
 
 build_gemini() {

--- a/scripts/install-codex.sh
+++ b/scripts/install-codex.sh
@@ -4,6 +4,10 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
 DIST_DIR="$ROOT_DIR/dist/codex"
+REPO_SLUG="${GOPHER_AI_REPO:-gopherguides/gopher-ai}"
+REPO_REF="${GOPHER_AI_REF:-main}"
+ARCHIVE_URL="${GOPHER_AI_ARCHIVE_URL:-https://codeload.github.com/${REPO_SLUG}/tar.gz/refs/heads/${REPO_REF}}"
+BOOTSTRAP_DIR=""
 
 usage() {
     cat <<'EOF'
@@ -20,6 +24,14 @@ Options:
 EOF
 }
 
+cleanup() {
+    if [[ -n "$BOOTSTRAP_DIR" && -d "$BOOTSTRAP_DIR" ]]; then
+        rm -rf "$BOOTSTRAP_DIR"
+    fi
+}
+
+trap cleanup EXIT
+
 require_cmd() {
     local cmd="$1"
     if ! command -v "$cmd" >/dev/null 2>&1; then
@@ -28,7 +40,31 @@ require_cmd() {
     fi
 }
 
+bootstrap_repo() {
+    if [[ -f "$ROOT_DIR/scripts/build-universal.sh" ]]; then
+        return
+    fi
+
+    require_cmd curl
+    require_cmd tar
+
+    BOOTSTRAP_DIR="$(mktemp -d)"
+    curl -fsSL "$ARCHIVE_URL" | tar -xz -C "$BOOTSTRAP_DIR"
+
+    local extracted_root
+    extracted_root="$(find "$BOOTSTRAP_DIR" -mindepth 1 -maxdepth 1 -type d | head -n 1)"
+    if [[ -z "$extracted_root" || ! -f "$extracted_root/scripts/build-universal.sh" ]]; then
+        echo "error: failed to bootstrap gopher-ai from $ARCHIVE_URL" >&2
+        exit 1
+    fi
+
+    ROOT_DIR="$extracted_root"
+    DIST_DIR="$ROOT_DIR/dist/codex"
+}
+
 ensure_dist() {
+    bootstrap_repo
+
     if [[ ! -f "$DIST_DIR/plugins/marketplace.json" ]]; then
         "$ROOT_DIR/scripts/build-universal.sh"
     fi
@@ -87,50 +123,11 @@ write_user_marketplace() {
 build_repo_marketplace() {
     local output_file="$1"
 
-    jq -n '
-        {
-          name: "gopher-ai",
-          interface: { displayName: "Gopher AI" },
-          plugins: [
-            {
-              name: "go-workflow",
-              source: { source: "local", path: "./plugins/go-workflow" },
-              policy: { installation: "AVAILABLE", authentication: "ON_USE" },
-              category: "Development"
-            },
-            {
-              name: "go-dev",
-              source: { source: "local", path: "./plugins/go-dev" },
-              policy: { installation: "AVAILABLE", authentication: "ON_USE" },
-              category: "Development"
-            },
-            {
-              name: "gopher-guides",
-              source: { source: "local", path: "./plugins/gopher-guides" },
-              policy: { installation: "AVAILABLE", authentication: "ON_USE" },
-              category: "Development"
-            },
-            {
-              name: "llm-tools",
-              source: { source: "local", path: "./plugins/llm-tools" },
-              policy: { installation: "AVAILABLE", authentication: "ON_USE" },
-              category: "Productivity"
-            },
-            {
-              name: "go-web",
-              source: { source: "local", path: "./plugins/go-web" },
-              policy: { installation: "AVAILABLE", authentication: "ON_USE" },
-              category: "Development"
-            },
-            {
-              name: "tailwind",
-              source: { source: "local", path: "./plugins/tailwind" },
-              policy: { installation: "AVAILABLE", authentication: "ON_USE" },
-              category: "Development"
-            }
-          ]
-        }
-    ' >"$output_file"
+    jq '
+        .plugins |= map(
+            .source.path |= sub("^\\./\\.codex/plugins/"; "./plugins/")
+        )
+    ' "$DIST_DIR/plugins/marketplace.json" >"$output_file"
 }
 
 copy_repo_plugins() {

--- a/scripts/test-installation.sh
+++ b/scripts/test-installation.sh
@@ -112,6 +112,86 @@ else
   echo "OK"
 fi
 
+echo -n "Codex distribution builds... "
+if ! "$ROOT_DIR/scripts/build-universal.sh" >/tmp/gopher-ai-build.log 2>&1; then
+  echo "FAIL"
+  sed -n '1,120p' /tmp/gopher-ai-build.log
+  ERRORS=$((ERRORS + 1))
+else
+  echo "OK"
+fi
+
+CODEX_MARKETPLACE="$ROOT_DIR/dist/codex/plugins/marketplace.json"
+echo -n "Codex marketplace is valid JSON... "
+if ! jq . "$CODEX_MARKETPLACE" >/dev/null 2>&1; then
+  echo "FAIL"
+  ERRORS=$((ERRORS + 1))
+else
+  echo "OK"
+fi
+
+CODEX_PLUGIN_COUNT=$(jq '.plugins | length' "$CODEX_MARKETPLACE")
+echo -n "Codex repo install writes matching marketplace entries... "
+TMP_REPO=$(mktemp -d)
+if ! "$ROOT_DIR/scripts/install-codex.sh" --repo "$TMP_REPO" >/tmp/gopher-ai-install-repo.log 2>&1; then
+  echo "FAIL"
+  sed -n '1,120p' /tmp/gopher-ai-install-repo.log
+  ERRORS=$((ERRORS + 1))
+else
+  REPO_MARKETPLACE="$TMP_REPO/.agents/plugins/marketplace.json"
+  ACTUAL_COUNT=$(jq '.plugins | length' "$REPO_MARKETPLACE")
+  BAD_PATHS=$(jq -r '.plugins[] | select(.source.path | startswith("./plugins/") | not) | .source.path' "$REPO_MARKETPLACE")
+  MISSING_DIRS=""
+  for i in $(seq 0 $((ACTUAL_COUNT - 1))); do
+    PLUGIN_PATH=$(jq -r ".plugins[$i].source.path" "$REPO_MARKETPLACE")
+    if [ ! -d "$TMP_REPO/${PLUGIN_PATH#./}" ]; then
+      MISSING_DIRS="$MISSING_DIRS $PLUGIN_PATH"
+    fi
+  done
+  if [ "$ACTUAL_COUNT" -ne "$CODEX_PLUGIN_COUNT" ] || [ -n "$BAD_PATHS" ] || [ -n "$MISSING_DIRS" ]; then
+    echo "FAIL"
+    [ "$ACTUAL_COUNT" -ne "$CODEX_PLUGIN_COUNT" ] && echo "expected $CODEX_PLUGIN_COUNT plugins, got $ACTUAL_COUNT"
+    [ -n "$BAD_PATHS" ] && echo "bad plugin paths:$BAD_PATHS"
+    [ -n "$MISSING_DIRS" ] && echo "missing plugin dirs:$MISSING_DIRS"
+    ERRORS=$((ERRORS + 1))
+  else
+    echo "OK"
+  fi
+fi
+rm -rf "$TMP_REPO"
+
+echo -n "Standalone Codex installer bootstraps correctly... "
+TMP_HOME=$(mktemp -d)
+TMP_SCRIPT_DIR=$(mktemp -d)
+TMP_ARCHIVE_DIR=$(mktemp -d)
+cp "$ROOT_DIR/scripts/install-codex.sh" "$TMP_SCRIPT_DIR/install-codex.sh"
+cp -R "$ROOT_DIR" "$TMP_ARCHIVE_DIR/gopher-ai-main"
+tar -czf "$TMP_ARCHIVE_DIR/gopher-ai-main.tar.gz" -C "$TMP_ARCHIVE_DIR" gopher-ai-main
+if ! HOME="$TMP_HOME" GOPHER_AI_ARCHIVE_URL="file://$TMP_ARCHIVE_DIR/gopher-ai-main.tar.gz" bash "$TMP_SCRIPT_DIR/install-codex.sh" --user >/tmp/gopher-ai-install-user.log 2>&1; then
+  echo "FAIL"
+  sed -n '1,120p' /tmp/gopher-ai-install-user.log
+  ERRORS=$((ERRORS + 1))
+else
+  USER_MARKETPLACE="$TMP_HOME/.agents/plugins/marketplace.json"
+  ACTUAL_COUNT=$(jq '.plugins | length' "$USER_MARKETPLACE")
+  MISSING_DIRS=""
+  for i in $(seq 0 $((ACTUAL_COUNT - 1))); do
+    PLUGIN_PATH=$(jq -r ".plugins[$i].source.path" "$USER_MARKETPLACE")
+    if [ ! -d "$TMP_HOME/${PLUGIN_PATH#./}" ]; then
+      MISSING_DIRS="$MISSING_DIRS $PLUGIN_PATH"
+    fi
+  done
+  if [ "$ACTUAL_COUNT" -ne "$CODEX_PLUGIN_COUNT" ] || [ -n "$MISSING_DIRS" ]; then
+    echo "FAIL"
+    [ "$ACTUAL_COUNT" -ne "$CODEX_PLUGIN_COUNT" ] && echo "expected $CODEX_PLUGIN_COUNT plugins, got $ACTUAL_COUNT"
+    [ -n "$MISSING_DIRS" ] && echo "missing plugin dirs:$MISSING_DIRS"
+    ERRORS=$((ERRORS + 1))
+  else
+    echo "OK"
+  fi
+fi
+rm -rf "$TMP_HOME" "$TMP_SCRIPT_DIR" "$TMP_ARCHIVE_DIR"
+
 echo ""
 if [ $ERRORS -gt 0 ]; then
   echo "FAILED: $ERRORS test(s) failed"


### PR DESCRIPTION
## Summary
- bootstrap `scripts/install-codex.sh` from a GitHub archive when it is run outside a repo checkout
- fix Codex build packaging on macOS so plugin directories are copied into `dist/codex/plugins/<plugin>`
- clarify Codex docs about the actual Codex plugin set and add installation coverage for standalone bootstrap

## Testing
- `shellcheck scripts/install-codex.sh scripts/test-installation.sh scripts/build-universal.sh`
- `./scripts/test-installation.sh`
- `./scripts/test-commands.sh`
- `./scripts/test-hooks.sh`
- `./scripts/check-shared-sync.sh`