### PR TITLE
fix(e2e): require visual verification of screenshots against spec

### DIFF
--- a/plugins/go-workflow/commands/complete-issue.md
+++ b/plugins/go-workflow/commands/complete-issue.md
@@ -1,7 +1,7 @@
 ---
 argument-hint: "<issue-number> [--skip-coverage] [--coverage-threshold <n>] [--no-agents]"
 description: "Complete a GitHub issue end-to-end: implement, review, E2E verify, ship"
-allowed-tools: ["Bash", "Read", "Glob", "Grep", "Edit", "Write", "AskUserQuestion", "Agent", "EnterPlanMode", "mcp__chrome-devtools-mcp__navigate_page", "mcp__chrome-devtools-mcp__take_screenshot", "mcp__chrome-devtools-mcp__list_console_messages", "mcp__chrome-devtools-mcp__list_network_requests", "mcp__chrome-devtools-mcp__fill", "mcp__chrome-devtools-mcp__click", "mcp__chrome-devtools-mcp__new_page", "mcp__chrome-devtools-mcp__fill_form", "mcp__chrome-devtools-mcp__wait_for"]
+allowed-tools: ["Bash", "Read", "Glob", "Grep", "Edit", "Write", "AskUserQuestion", "Agent", "EnterPlanMode", "mcp__chrome-devtools-mcp__navigate_page", "mcp__chrome-devtools-mcp__take_screenshot", "mcp__chrome-devtools-mcp__list_console_messages", "mcp__chrome-devtools-mcp__list_network_requests", "mcp__chrome-devtools-mcp__fill", "mcp__chrome-devtools-mcp__click", "mcp__chrome-devtools-mcp__new_page", "mcp__chrome-devtools-mcp__fill_form", "mcp__chrome-devtools-mcp__wait_for", "mcp__chrome-devtools-mcp__evaluate_script"]
 ---
 
 # Complete Issue

--- a/plugins/go-workflow/commands/e2e-verify.md
+++ b/plugins/go-workflow/commands/e2e-verify.md
@@ -1,7 +1,7 @@
 ---
 argument-hint: "[PR-number] [verify|fix-and-verify|investigate|ship-prep|ship|fix-and-ship]"
 description: "Run E2E verification on a PR: rebase, build, browser test, post results"
-allowed-tools: ["Bash", "Read", "Glob", "Grep", "Edit", "Write", "AskUserQuestion", "Agent", "mcp__chrome-devtools-mcp__navigate_page", "mcp__chrome-devtools-mcp__take_screenshot", "mcp__chrome-devtools-mcp__list_console_messages", "mcp__chrome-devtools-mcp__list_network_requests", "mcp__chrome-devtools-mcp__fill", "mcp__chrome-devtools-mcp__click", "mcp__chrome-devtools-mcp__new_page", "mcp__chrome-devtools-mcp__fill_form", "mcp__chrome-devtools-mcp__wait_for"]
+allowed-tools: ["Bash", "Read", "Glob", "Grep", "Edit", "Write", "AskUserQuestion", "Agent", "mcp__chrome-devtools-mcp__navigate_page", "mcp__chrome-devtools-mcp__take_screenshot", "mcp__chrome-devtools-mcp__list_console_messages", "mcp__chrome-devtools-mcp__list_network_requests", "mcp__chrome-devtools-mcp__fill", "mcp__chrome-devtools-mcp__click", "mcp__chrome-devtools-mcp__new_page", "mcp__chrome-devtools-mcp__fill_form", "mcp__chrome-devtools-mcp__wait_for", "mcp__chrome-devtools-mcp__evaluate_script"]
 ---
 
 # E2E Verify

--- a/plugins/go-workflow/skills/complete-issue/SKILL.md
+++ b/plugins/go-workflow/skills/complete-issue/SKILL.md
@@ -7,7 +7,7 @@ description: |
   WHEN NOT: User wants to start an issue without shipping ($start-issue), only ship ($ship),
   only verify ($e2e-verify), or only address review comments ($address-review).
 argument-hint: "<issue-number> [--skip-coverage] [--coverage-threshold <n>] [--no-agents]"
-allowed-tools: ["Bash", "Read", "Glob", "Grep", "Edit", "Write", "AskUserQuestion", "Agent", "EnterPlanMode", "mcp__chrome-devtools-mcp__navigate_page", "mcp__chrome-devtools-mcp__take_screenshot", "mcp__chrome-devtools-mcp__list_console_messages", "mcp__chrome-devtools-mcp__list_network_requests", "mcp__chrome-devtools-mcp__fill", "mcp__chrome-devtools-mcp__click", "mcp__chrome-devtools-mcp__new_page", "mcp__chrome-devtools-mcp__fill_form", "mcp__chrome-devtools-mcp__wait_for"]
+allowed-tools: ["Bash", "Read", "Glob", "Grep", "Edit", "Write", "AskUserQuestion", "Agent", "EnterPlanMode", "mcp__chrome-devtools-mcp__navigate_page", "mcp__chrome-devtools-mcp__take_screenshot", "mcp__chrome-devtools-mcp__list_console_messages", "mcp__chrome-devtools-mcp__list_network_requests", "mcp__chrome-devtools-mcp__fill", "mcp__chrome-devtools-mcp__click", "mcp__chrome-devtools-mcp__new_page", "mcp__chrome-devtools-mcp__fill_form", "mcp__chrome-devtools-mcp__wait_for", "mcp__chrome-devtools-mcp__evaluate_script"]
 ---
 
 # Complete Issue

--- a/plugins/go-workflow/skills/e2e-verify/SKILL.md
+++ b/plugins/go-workflow/skills/e2e-verify/SKILL.md
@@ -7,10 +7,25 @@ description: |
   WHEN NOT: User only wants to run unit tests ($verify), only ship without verification ($ship),
   only address review comments ($address-review), or only run coverage ($coverage).
 argument-hint: "[PR-number] [verify|fix-and-verify|investigate|ship-prep|ship|fix-and-ship]"
-allowed-tools: ["Bash", "Read", "Glob", "Grep", "Edit", "Write", "AskUserQuestion", "Agent", "mcp__chrome-devtools-mcp__navigate_page", "mcp__chrome-devtools-mcp__take_screenshot", "mcp__chrome-devtools-mcp__list_console_messages", "mcp__chrome-devtools-mcp__list_network_requests", "mcp__chrome-devtools-mcp__fill", "mcp__chrome-devtools-mcp__click", "mcp__chrome-devtools-mcp__new_page", "mcp__chrome-devtools-mcp__fill_form", "mcp__chrome-devtools-mcp__wait_for"]
+allowed-tools: ["Bash", "Read", "Glob", "Grep", "Edit", "Write", "AskUserQuestion", "Agent", "mcp__chrome-devtools-mcp__navigate_page", "mcp__chrome-devtools-mcp__take_screenshot", "mcp__chrome-devtools-mcp__list_console_messages", "mcp__chrome-devtools-mcp__list_network_requests", "mcp__chrome-devtools-mcp__fill", "mcp__chrome-devtools-mcp__click", "mcp__chrome-devtools-mcp__new_page", "mcp__chrome-devtools-mcp__fill_form", "mcp__chrome-devtools-mcp__wait_for", "mcp__chrome-devtools-mcp__evaluate_script"]
 ---
 
 # E2E Verify
+
+## Core Principle: Visual Verification is Non-Negotiable
+
+**Every screenshot you take MUST be read and visually inspected.** Taking a screenshot without reading it is useless. The entire point of E2E testing is to verify what the USER sees, not just what the DOM contains.
+
+After every `mcp__chrome-devtools-mcp__take_screenshot`, you MUST:
+
+1. **Read the screenshot** using your multimodal vision capabilities
+2. **Compare it to the spec** — read the issue/PR description and verify the screenshot matches what was requested
+3. **Describe what you see** — document the visual state in your results (layout, content, styling, errors)
+4. **Flag discrepancies** — if what you see doesn't match the spec, report it as a finding
+
+DOM checks (console errors, network requests) supplement visual verification — they do NOT replace it. A page can have zero console errors and zero network failures but still look completely wrong.
+
+---
 
 ## Parse Arguments
 
@@ -212,13 +227,21 @@ Set phase to `e2e-testing`:
 set_loop_phase "$STATE_FILE" "e2e-testing"
 ```
 
+Read the PR/issue description first to understand what the change is supposed to look like:
+
+```bash
+gh pr view "$PR_NUM" --json body,title --jq '"\(.title)\n\n\(.body)"'
+```
+
 Read `e2e-test-execution.md` for the full E2E test procedure:
 - Check MCP availability and web component indicators
 - Detect and start dev server (reuse if already running)
 - Run database migrations if applicable
 - Perform login flow if authentication is required
-- Test each changed route: navigate, screenshot, console check, network check
+- **For each route: navigate → stabilize → screenshot → READ screenshot → compare to spec → document findings**
 - Clean up and collect results
+
+**CRITICAL:** Every screenshot MUST be read and visually compared against the PR/issue spec. If you take a screenshot but don't read it, you have not tested anything.
 
 After E2E testing, persist results:
 

--- a/plugins/go-workflow/skills/e2e-verify/e2e-test-execution.md
+++ b/plugins/go-workflow/skills/e2e-verify/e2e-test-execution.md
@@ -149,18 +149,28 @@ Detect if the app requires authentication:
 
 **Before every screenshot**, execute this stabilization sequence to ensure deterministic, accurate captures. Use `mcp__chrome-devtools-mcp__evaluate_script` to run the JavaScript snippets below. If `evaluate_script` is not available, at minimum use `wait_for` with a reasonable timeout before capturing.
 
-1. **Wait for network idle and DOM stability** — inject and execute:
+1. **Wait for network idle** — inject and execute:
    ```javascript
-   // Wait for no in-flight fetch/XHR requests for 500ms
+   // Poll-based: wait until no new resource entries appear for 500ms
+   // This catches both existing in-flight and new requests
    await new Promise(resolve => {
-     let timer = setTimeout(resolve, 500);
-     const observer = new PerformanceObserver(() => {
-       clearTimeout(timer);
-       timer = setTimeout(resolve, 500);
-     });
-     observer.observe({ entryTypes: ['resource'] });
+     let lastCount = performance.getEntriesByType('resource').length;
+     let stableChecks = 0;
+     const interval = setInterval(() => {
+       const currentCount = performance.getEntriesByType('resource').length;
+       if (currentCount === lastCount) {
+         stableChecks++;
+         if (stableChecks >= 5) { // 5 × 100ms = 500ms stable
+           clearInterval(interval);
+           resolve();
+         }
+       } else {
+         lastCount = currentCount;
+         stableChecks = 0;
+       }
+     }, 100);
      // Fallback: resolve after 5s regardless
-     setTimeout(resolve, 5000);
+     setTimeout(() => { clearInterval(interval); resolve(); }, 5000);
    });
    ```
 
@@ -170,7 +180,11 @@ Detect if the app requires authentication:
    await Promise.all(
      Array.from(document.images)
        .filter(img => !img.complete)
-       .map(img => new Promise(resolve => { img.onload = img.onerror = resolve; }))
+       .map(img => new Promise(resolve => {
+         // Use addEventListener to avoid clobbering app handlers
+         img.addEventListener('load', resolve, { once: true });
+         img.addEventListener('error', resolve, { once: true });
+       }))
    );
    ```
 

--- a/plugins/go-workflow/skills/e2e-verify/e2e-test-execution.md
+++ b/plugins/go-workflow/skills/e2e-verify/e2e-test-execution.md
@@ -2,6 +2,8 @@
 
 This step performs browser-based E2E testing of web-facing changes. It is optional and silently skips when conditions are not met.
 
+**CRITICAL PRINCIPLE: Screenshots must be READ, not just captured.** A screenshot you don't look at is worthless. After every `take_screenshot`, you MUST read the image with your vision capabilities, describe what you see, and compare it against the spec/issue requirements. DOM-only checks (console errors, network requests) are supplementary — they do NOT substitute for visual verification.
+
 ## 5a. Skip Conditions
 
 Skip this entire step (set `E2E_RESULT="skipped"`) if ANY of these are true:
@@ -29,7 +31,33 @@ done || true)
 
 If both `WEB_CHANGES` and `HANDLER_CHANGES` are empty → skip E2E testing.
 
-## 5b. Detect Dev Server
+## 5b. Load the Spec (REQUIRED — do this BEFORE any browser testing)
+
+Before touching the browser, understand what you're verifying against. Read the PR description and linked issue to build a mental model of expected visual state:
+
+```bash
+gh pr view "$PR_NUM" --json body,title --jq '"\(.title)\n\n\(.body)"'
+```
+
+If the PR links to an issue, read that too:
+
+```bash
+ISSUE_NUM=$(gh pr view "$PR_NUM" --json body --jq '.body' | grep -oE '(closes|fixes|resolves) #[0-9]+' | grep -oE '[0-9]+' | head -1)
+if [ -n "$ISSUE_NUM" ]; then
+  gh issue view "$ISSUE_NUM" --json body,title --jq '"\(.title)\n\n\(.body)"'
+fi
+```
+
+**Build a checklist** of what the spec says should be visible:
+- What pages/routes were added or changed?
+- What should they look like? (layout, components, text, styling)
+- What user flows were added? (forms, buttons, navigation)
+- What acceptance criteria are listed?
+- Are there mockups, wireframes, or design descriptions?
+
+This checklist is what you verify screenshots against. If you can't articulate what you expect to see, you can't verify it.
+
+## 5c. Detect Dev Server
 
 1. Check for Air config: `.air.toml` or `air.toml` → command: `air`
 2. Check `Makefile` for targets: `run`, `serve`, `dev` → command: `make <target>`
@@ -42,7 +70,7 @@ Detect the server port:
 - Check `.env` or `.envrc` for PORT
 - Default: `8080` for Go, `3000` for Node, `5173` for Vite
 
-## 5c. Run Database Migrations (if applicable)
+## 5d. Run Database Migrations (if applicable)
 
 **Run migrations BEFORE starting the dev server.** Many apps require up-to-date schema to boot successfully.
 
@@ -58,7 +86,7 @@ else
 fi
 ```
 
-## 5d. Start Dev Server (if not already running)
+## 5e. Start Dev Server (if not already running)
 
 Check if the port is already in use before starting:
 
@@ -84,7 +112,7 @@ done
 
 If server fails to start within 30 seconds → warn ("Dev server failed to start, skipping E2E tests"), set `E2E_RESULT="skipped-server-failed"`, and skip remaining steps. Do NOT block the workflow.
 
-## 5e. Login Flow (if applicable)
+## 5f. Login Flow (if applicable)
 
 Detect if the app requires authentication:
 
@@ -107,9 +135,48 @@ Detect if the app requires authentication:
    - Use `mcp__chrome-devtools-mcp__click` on the submit/login button
    - Use `mcp__chrome-devtools-mcp__wait_for` to confirm navigation after login
    - Use `mcp__chrome-devtools-mcp__take_screenshot` to capture post-login state
+   - **READ the screenshot** — verify you're logged in and see the expected post-login page
 3. If no credentials found: skip login, test only public routes
 
-## 5f. Route Testing
+## 5g. Visual Stabilization Protocol
+
+**Before every screenshot**, execute this stabilization sequence to ensure deterministic, accurate captures:
+
+1. **Wait for network idle** — no pending requests:
+   ```
+   mcp__chrome-devtools-mcp__wait_for selector="body" timeout=5000
+   ```
+
+2. **Wait for fonts and images** — inject and execute:
+   ```javascript
+   await document.fonts.ready;
+   await Promise.all(
+     Array.from(document.images)
+       .filter(img => !img.complete)
+       .map(img => new Promise(resolve => { img.onload = img.onerror = resolve; }))
+   );
+   ```
+
+3. **Disable animations** — inject CSS to freeze all motion:
+   ```javascript
+   const style = document.createElement('style');
+   style.textContent = '*, *::before, *::after { animation-duration: 0s !important; transition-duration: 0s !important; caret-color: transparent !important; scroll-behavior: auto !important; }';
+   document.head.appendChild(style);
+   ```
+
+4. **Blur active element** — prevent cursor blink artifacts:
+   ```javascript
+   document.activeElement?.blur();
+   ```
+
+5. **Brief settle** — allow a final paint:
+   ```javascript
+   await new Promise(resolve => setTimeout(resolve, 300));
+   ```
+
+Use `mcp__chrome-devtools-mcp__evaluate_script` to run these JavaScript snippets. If `evaluate_script` is not available, at minimum use `wait_for` with a reasonable timeout before capturing.
+
+## 5h. Route Testing (the core of E2E)
 
 Identify routes from changed files:
 
@@ -117,33 +184,67 @@ Identify routes from changed files:
 2. Parse templ file names to infer page routes
 3. If route detection fails, test the root path (`/`) as a baseline
 
-**For each route, execute the test:**
+**For each route, execute the FULL test sequence:**
 
-1. **Navigate:** `mcp__chrome-devtools-mcp__navigate_page` to `http://localhost:$PORT<route>`
-2. **Screenshot:** `mcp__chrome-devtools-mcp__take_screenshot` to capture the rendered page
-3. **Console check:** `mcp__chrome-devtools-mcp__list_console_messages` — check for JavaScript errors
-4. **Network check:** `mcp__chrome-devtools-mcp__list_network_requests` — verify no failed requests (5xx responses)
-5. **Form interaction** (if the page contains forms related to changed code):
-   - Use `mcp__chrome-devtools-mcp__fill` to populate form fields with test data
-   - Use `mcp__chrome-devtools-mcp__click` to submit
-   - Verify no errors after submission
+### 1. Navigate
+`mcp__chrome-devtools-mcp__navigate_page` to `http://localhost:$PORT<route>`
 
-**Record results** for each page tested: URL, HTTP status, console errors (if any), network failures, screenshot captured.
+### 2. Stabilize
+Run the Visual Stabilization Protocol (section 5g) to ensure the page is fully rendered.
 
-## 5g. Edge Case Testing
+### 3. Screenshot
+`mcp__chrome-devtools-mcp__take_screenshot` to capture the rendered page.
+
+### 4. READ THE SCREENSHOT (MANDATORY)
+
+**This is the most important step.** Use your multimodal vision to read the screenshot image and verify:
+
+- **Layout correctness:** Are elements positioned correctly? Is spacing reasonable? Are there overlapping elements or broken layouts?
+- **Content presence:** Is the expected text, data, and imagery visible? Are headings, labels, and body text present and readable?
+- **Styling:** Are colors, fonts, and visual hierarchy consistent? Does it look like a finished page or a broken one?
+- **Component rendering:** Are UI components (buttons, forms, tables, cards, navigation) rendered properly? No missing borders, broken icons, or placeholder text?
+- **Image/asset loading:** Are images displayed (not broken image icons)? Are SVGs and icons rendering?
+- **Responsive behavior:** Does the layout make sense at the current viewport width? Is anything overflowing or clipped?
+
+**Compare against the spec:** Check each item on the checklist you built in step 5b. If the spec says "add a user table with name and email columns" — verify you see a table with those columns. If the spec says "add a login form" — verify the form fields are visible and labeled correctly.
+
+**Document what you see in detail.** Not just "looks good" — describe the actual visual state:
+- "The dashboard shows a navigation sidebar on the left, main content area with a table of 3 users showing name and email columns, header with the app logo"
+- "The login form has email and password fields, a 'Sign In' button, and a 'Forgot Password' link below"
+
+**Flag any discrepancies** between what you see and what the spec requires. This is the output that matters.
+
+### 5. Console Check
+`mcp__chrome-devtools-mcp__list_console_messages` — check for JavaScript errors. Note: console errors are supplementary to visual verification, not a replacement.
+
+### 6. Network Check
+`mcp__chrome-devtools-mcp__list_network_requests` — verify no failed requests (5xx responses). Again, supplementary.
+
+### 7. Form Interaction (if the page contains forms related to changed code)
+- Use `mcp__chrome-devtools-mcp__fill` to populate form fields with test data
+- Use `mcp__chrome-devtools-mcp__click` to submit
+- **Take another screenshot AFTER submission**
+- **READ that screenshot** — verify the success/error state matches expectations
+- Check console/network for errors
+
+**Record results** for each page tested: URL, visual verification findings (what you saw vs. what was expected), console errors (if any), network failures, spec compliance (pass/fail with explanation).
+
+## 5i. Edge Case Testing
 
 After testing the primary routes, look for edge cases related to the changed code:
 
 1. **Old/new code paths:** If the PR adds a migration or schema change, insert test data that exercises both the old format and new format to verify backwards compatibility
 2. **Empty states:** Navigate to pages that may render differently with no data (empty lists, first-time user views)
+   - **Screenshot and READ** — verify empty state messaging is present and looks correct
 3. **Error states:** If the PR changes validation or error handling, submit invalid inputs to verify error messages render correctly
+   - **Screenshot and READ** — verify error messages are visible, properly styled, and informative
 4. **Boundary values:** If the PR adds pagination, filters, or limits, test with values at the boundary (0 items, 1 item, max items)
 
-For each edge case tested, record: description, expected behavior, actual behavior, pass/fail.
+For each edge case tested, record: description, expected behavior, **what you actually saw in the screenshot**, pass/fail.
 
 If test data was inserted for edge case testing, clean it up afterwards to avoid polluting the database.
 
-## 5h. Cleanup
+## 5j. Cleanup
 
 Kill the dev server (only if we started it):
 
@@ -156,10 +257,25 @@ fi
 Collect results:
 - `E2E_RESULT`: `pass`, `fail`, `partial`, or `skipped`
 - `PAGES_TESTED`: count of routes tested
-- Per-route results for the PR comment
+- Per-route results for the PR comment including **visual verification findings**
 
 **E2E failure handling:**
+- Visual discrepancy from spec → report as finding with description of what was expected vs. what was seen
 - Pages returning 500/404 → report as finding but do NOT block
 - Console JavaScript errors → report but do NOT block
 - MCP tool call fails mid-test → warn and skip remaining E2E tests
 - All results are informational — E2E issues are warnings, not gates
+
+## Visual Verification Checklist (self-check before completing Step 5)
+
+Before marking E2E testing as complete, confirm ALL of these:
+
+- [ ] I read the PR/issue spec BEFORE starting browser tests
+- [ ] I built a checklist of expected visual state from the spec
+- [ ] For EVERY screenshot I took, I READ the screenshot image (not just captured it)
+- [ ] For EVERY screenshot, I described what I saw in concrete terms
+- [ ] I compared what I saw against the spec checklist and noted matches/discrepancies
+- [ ] My results include visual findings, not just "screenshot captured"
+- [ ] If I found visual discrepancies, I documented them with specific details
+
+**If you cannot check all of these boxes, you have not completed E2E testing.**

--- a/plugins/go-workflow/skills/e2e-verify/e2e-test-execution.md
+++ b/plugins/go-workflow/skills/e2e-verify/e2e-test-execution.md
@@ -39,13 +39,20 @@ Before touching the browser, understand what you're verifying against. Read the 
 gh pr view "$PR_NUM" --json body,title --jq '"\(.title)\n\n\(.body)"'
 ```
 
-If the PR links to an issue, read that too:
+If the PR links to an issue, read those too. Use the GitHub API's structured closing references first (most reliable), then fall back to text parsing:
 
 ```bash
-ISSUE_NUM=$(gh pr view "$PR_NUM" --json body --jq '.body' | grep -oE '(closes|fixes|resolves) #[0-9]+' | grep -oE '[0-9]+' | head -1)
-if [ -n "$ISSUE_NUM" ]; then
-  gh issue view "$ISSUE_NUM" --json body,title --jq '"\(.title)\n\n\(.body)"'
+# Strategy 1: GitHub's structured closing references (catches all linking methods)
+ISSUE_NUMS=$(gh pr view "$PR_NUM" --json closingIssuesReferences --jq '.closingIssuesReferences[].number' 2>/dev/null)
+
+# Strategy 2: Fallback to text parsing (case-insensitive, handles owner/repo#N format)
+if [ -z "$ISSUE_NUMS" ]; then
+  ISSUE_NUMS=$(gh pr view "$PR_NUM" --json body --jq '.body' | grep -ioE '(closes|fixes|resolves|close|fix|resolve)\s+([a-z0-9/_-]+)?#[0-9]+' | grep -oE '[0-9]+$')
 fi
+
+for ISSUE_NUM in $ISSUE_NUMS; do
+  gh issue view "$ISSUE_NUM" --json body,title --jq '"\(.title)\n\n\(.body)"' 2>/dev/null
+done
 ```
 
 **Build a checklist** of what the spec says should be visible:
@@ -140,11 +147,21 @@ Detect if the app requires authentication:
 
 ## 5g. Visual Stabilization Protocol
 
-**Before every screenshot**, execute this stabilization sequence to ensure deterministic, accurate captures:
+**Before every screenshot**, execute this stabilization sequence to ensure deterministic, accurate captures. Use `mcp__chrome-devtools-mcp__evaluate_script` to run the JavaScript snippets below. If `evaluate_script` is not available, at minimum use `wait_for` with a reasonable timeout before capturing.
 
-1. **Wait for network idle** — no pending requests:
-   ```
-   mcp__chrome-devtools-mcp__wait_for selector="body" timeout=5000
+1. **Wait for network idle and DOM stability** — inject and execute:
+   ```javascript
+   // Wait for no in-flight fetch/XHR requests for 500ms
+   await new Promise(resolve => {
+     let timer = setTimeout(resolve, 500);
+     const observer = new PerformanceObserver(() => {
+       clearTimeout(timer);
+       timer = setTimeout(resolve, 500);
+     });
+     observer.observe({ entryTypes: ['resource'] });
+     // Fallback: resolve after 5s regardless
+     setTimeout(resolve, 5000);
+   });
    ```
 
 2. **Wait for fonts and images** — inject and execute:
@@ -160,12 +177,13 @@ Detect if the app requires authentication:
 3. **Disable animations** — inject CSS to freeze all motion:
    ```javascript
    const style = document.createElement('style');
-   style.textContent = '*, *::before, *::after { animation-duration: 0s !important; transition-duration: 0s !important; caret-color: transparent !important; scroll-behavior: auto !important; }';
+   style.textContent = '*, *::before, *::after { animation-duration: 0s !important; transition-duration: 0s !important; scroll-behavior: auto !important; }';
    document.head.appendChild(style);
    ```
 
-4. **Blur active element** — prevent cursor blink artifacts:
+4. **Conditionally blur active element** — only blur if you are NOT testing a focus-dependent state (e.g., form validation errors, keyboard navigation, active input fields). If the current test is verifying a focused state, skip this step:
    ```javascript
+   // Skip this if you're testing focus/validation states
    document.activeElement?.blur();
    ```
 
@@ -173,8 +191,6 @@ Detect if the app requires authentication:
    ```javascript
    await new Promise(resolve => setTimeout(resolve, 300));
    ```
-
-Use `mcp__chrome-devtools-mcp__evaluate_script` to run these JavaScript snippets. If `evaluate_script` is not available, at minimum use `wait_for` with a reasonable timeout before capturing.
 
 ## 5h. Route Testing (the core of E2E)
 

--- a/plugins/go-workflow/skills/e2e-verify/pr-results-comment.md
+++ b/plugins/go-workflow/skills/e2e-verify/pr-results-comment.md
@@ -28,7 +28,9 @@ Construct a structured markdown comment using the results from Steps 1-5:
 | /dashboard | Layout issue | No — missing sidebar | None | None |
 | ... | ... | ... | ... | ... |
 
-**Pages tested:** $PAGES_TESTED | **Spec matched:** $PAGES_MATCHED | **Discrepancies:** $PAGES_DISCREPANT
+**Pages tested:** $PAGES_TESTED
+
+*Count spec matches and discrepancies from the Visual Verification Findings below.*
 
 ### Visual Verification Findings
 

--- a/plugins/go-workflow/skills/e2e-verify/pr-results-comment.md
+++ b/plugins/go-workflow/skills/e2e-verify/pr-results-comment.md
@@ -20,15 +20,31 @@ Construct a structured markdown comment using the results from Steps 1-5:
 | `go test` | $TEST_RESULT (pass/fail) |
 | `golangci-lint` | $LINT_RESULT (pass/fail/skipped) |
 
-### E2E Test Results
+### E2E Visual Verification Results
 
-| Route | Status | Console Errors | Network Errors | Screenshot |
-|-------|--------|---------------|----------------|------------|
-| / | 200 OK | None | None | captured |
-| /dashboard | 200 OK | None | None | captured |
+| Route | Visual Status | Spec Match | Console Errors | Network Errors |
+|-------|--------------|------------|----------------|----------------|
+| / | Rendered correctly | Yes — matches spec | None | None |
+| /dashboard | Layout issue | No — missing sidebar | None | None |
 | ... | ... | ... | ... | ... |
 
-**Pages tested:** $PAGES_TESTED | **Passed:** $PAGES_PASSED | **Errors:** $PAGES_ERRORED
+**Pages tested:** $PAGES_TESTED | **Spec matched:** $PAGES_MATCHED | **Discrepancies:** $PAGES_DISCREPANT
+
+### Visual Verification Findings
+
+For each page tested, include a detailed description of what was visually observed and how it compares to the spec:
+
+**Route: /**
+- **Expected (from spec):** Homepage with hero section, navigation bar, and feature cards
+- **Observed:** Hero section renders with correct heading and CTA button. Navigation bar shows all 4 links. Feature cards display in a 3-column grid. All images loaded.
+- **Verdict:** PASS — matches spec
+
+**Route: /dashboard**
+- **Expected (from spec):** User dashboard with sidebar navigation and data table
+- **Observed:** Data table renders correctly with 3 columns. However, sidebar navigation is missing — only the main content area is visible. The layout appears to be full-width instead of the expected sidebar + content split.
+- **Verdict:** FAIL — sidebar navigation missing from layout
+
+*Each route MUST include Expected/Observed/Verdict. "Screenshot captured" is NOT a valid finding.*
 
 ### Screenshots
 
@@ -37,16 +53,17 @@ Construct a structured markdown comment using the results from Steps 1-5:
 | / | ![homepage](screenshot-homepage.png) |
 | /dashboard | ![dashboard](screenshot-dashboard.png) |
 
-*Screenshots saved locally. Refer to descriptions above for visual verification results.*
+*Screenshots saved locally. See Visual Verification Findings above for what was observed in each screenshot.*
 
 ### Edge Cases Tested
 
-| Case | Expected | Actual | Result |
-|------|----------|--------|--------|
-| Empty list view | Shows "no items" message | Rendered correctly | PASS |
-| Invalid form input | Shows validation error | Error displayed | PASS |
+| Case | Expected | Observed | Result |
+|------|----------|----------|--------|
+| Empty list view | Shows "no items" message | "No items found" text centered in empty table body | PASS |
+| Invalid form input | Shows validation error | Red border on email field, "Invalid email" message below | PASS |
 
-*Edge case section only appears if edge cases were tested in Step 5g.*
+*Edge case section only appears if edge cases were tested in Step 5i.*
+*The "Observed" column MUST describe what was actually seen in the screenshot, not just "Rendered correctly".*
 
 ### Summary
 
@@ -54,9 +71,14 @@ $OVERALL_VERDICT
 ```
 
 **Conditional sections:**
-- If E2E was skipped (MCP unavailable or no web components): replace the E2E Test Results section with: `*E2E tests skipped: $SKIP_REASON*`
+- If E2E was skipped (MCP unavailable or no web components): replace the E2E Visual Verification Results section with: `*E2E tests skipped: $SKIP_REASON*`
 - If build failed: add a prominent warning at the top: `> **Build failed — E2E tests were not run.**`
 - If investigate mode: add an "Investigation Findings" section with gap analysis
+
+**Quality gate for the comment:** Before posting, verify that:
+- Every tested route has Expected/Observed/Verdict entries (not just "captured" or "pass")
+- The Observed column contains actual visual descriptions (what elements were seen, their layout, their content)
+- Any discrepancies between Expected and Observed are called out clearly
 
 ## 6b. Post Comment
 


### PR DESCRIPTION
## Summary

- E2E skills were taking screenshots but never reading them — DOM-only checks (console errors, network requests) would pass while visual bugs went completely undetected
- Now every screenshot **must** be read via multimodal vision and compared against the PR/issue spec
- Adds visual stabilization protocol, spec-loading step, self-check gate, and Expected/Observed/Verdict reporting format

## Changes

- **`e2e-test-execution.md`**: Major rewrite — added spec loading (5b), visual stabilization protocol (5g), mandatory screenshot reading in route testing (5h), and completion checklist
- **`SKILL.md`**: Added "Core Principle: Visual Verification is Non-Negotiable" section at top
- **`pr-results-comment.md`**: Changed results format from "screenshot captured" to Expected/Observed/Verdict per route
- **4 allowed-tools lists**: Added `evaluate_script` for stabilization JS injection

## Test plan

- [ ] Run `/e2e-verify` on a PR with web changes and confirm it reads the spec before testing
- [ ] Verify screenshots are actually read (multimodal) and findings include visual descriptions
- [ ] Confirm PR comment includes Expected/Observed/Verdict format, not just "captured"
- [ ] Verify stabilization protocol runs (animations disabled, fonts loaded) before screenshots

🤖 Generated with [Claude Code](https://claude.com/claude-code)