### PR TITLE
fix(scripts): use absolute paths in user-level Codex marketplace

### DIFF
--- a/scripts/install-codex.sh
+++ b/scripts/install-codex.sh
@@ -108,15 +108,31 @@ copy_user_plugins() {
     done
 }
 
+build_user_marketplace() {
+    local output_file="$1"
+    local plugins_home="$HOME/.codex/plugins"
+
+    jq --arg prefix "$plugins_home" '
+        .plugins |= map(
+            .source.path |= sub("^\\./\\.codex/plugins/"; ($prefix + "/"))
+        )
+    ' "$DIST_DIR/plugins/marketplace.json" >"$output_file"
+}
+
 write_user_marketplace() {
     local marketplace_dir="$HOME/.agents/plugins"
     local marketplace_file="$marketplace_dir/marketplace.json"
-    local tmp_file
-    tmp_file="$(mktemp)"
+    local incoming_file
+    local merged_file
+
+    incoming_file="$(mktemp)"
+    merged_file="$(mktemp)"
 
     mkdir -p "$marketplace_dir"
-    merge_marketplace "$marketplace_file" "$DIST_DIR/plugins/marketplace.json" "$tmp_file"
-    mv "$tmp_file" "$marketplace_file"
+    build_user_marketplace "$incoming_file"
+    merge_marketplace "$marketplace_file" "$incoming_file" "$merged_file"
+    mv "$merged_file" "$marketplace_file"
+    rm -f "$incoming_file"
     echo "updated marketplace: $marketplace_file"
 }
 

--- a/scripts/test-installation.sh
+++ b/scripts/test-installation.sh
@@ -175,15 +175,20 @@ else
   USER_MARKETPLACE="$TMP_HOME/.agents/plugins/marketplace.json"
   ACTUAL_COUNT=$(jq '.plugins | length' "$USER_MARKETPLACE")
   MISSING_DIRS=""
+  BAD_RELATIVE=""
   for i in $(seq 0 $((ACTUAL_COUNT - 1))); do
     PLUGIN_PATH=$(jq -r ".plugins[$i].source.path" "$USER_MARKETPLACE")
-    if [ ! -d "$TMP_HOME/${PLUGIN_PATH#./}" ]; then
+    # User-level paths must be absolute (not relative) so they resolve from any CWD
+    if [[ "$PLUGIN_PATH" == ./* ]]; then
+      BAD_RELATIVE="$BAD_RELATIVE $PLUGIN_PATH"
+    elif [ ! -d "$PLUGIN_PATH" ]; then
       MISSING_DIRS="$MISSING_DIRS $PLUGIN_PATH"
     fi
   done
-  if [ "$ACTUAL_COUNT" -ne "$CODEX_PLUGIN_COUNT" ] || [ -n "$MISSING_DIRS" ]; then
+  if [ "$ACTUAL_COUNT" -ne "$CODEX_PLUGIN_COUNT" ] || [ -n "$MISSING_DIRS" ] || [ -n "$BAD_RELATIVE" ]; then
     echo "FAIL"
     [ "$ACTUAL_COUNT" -ne "$CODEX_PLUGIN_COUNT" ] && echo "expected $CODEX_PLUGIN_COUNT plugins, got $ACTUAL_COUNT"
+    [ -n "$BAD_RELATIVE" ] && echo "relative paths in user marketplace (must be absolute):$BAD_RELATIVE"
     [ -n "$MISSING_DIRS" ] && echo "missing plugin dirs:$MISSING_DIRS"
     ERRORS=$((ERRORS + 1))
   else


### PR DESCRIPTION
## Summary

- **Bug**: `install-codex.sh --user` wrote relative paths (`./.codex/plugins/<name>`) into `~/.agents/plugins/marketplace.json`. These only resolve when CWD is `$HOME` — Codex sessions in worktrees or other directories can't find plugins, causing skills like `$e2e-verify` to silently not load.
- **Fix**: Added `build_user_marketplace()` that rewrites paths to absolute `$HOME/.codex/plugins/<name>`, mirroring how `build_repo_marketplace()` already handles `--repo` installs.
- **Test**: Updated the user-install test to reject relative paths in the marketplace (previously it worked around the bug by resolving `$TMP_HOME/${path}` which masked the real-world failure).

## Test plan

- [x] `scripts/test-installation.sh` passes — validates absolute paths and directory existence
- [ ] Re-run `./scripts/install-codex.sh --user` on target machine, verify `~/.agents/plugins/marketplace.json` has absolute paths
- [ ] Start Codex in a worktree, run `/plugins` and confirm `go-workflow` skills are visible

🤖 Generated with [Claude Code](https://claude.com/claude-code)