### PR TITLE
fix(scripts): install gopher-ai as flat skills for global Codex availability

### DIFF
--- a/scripts/install-codex.sh
+++ b/scripts/install-codex.sh
@@ -18,7 +18,7 @@ Usage:
 Installs or updates gopher-ai Codex plugins using the current plugin-based layout.
 
 Options:
-  --user        Install into ~/.codex/plugins and merge entries into ~/.agents/plugins/marketplace.json
+  --user        Install skills into ~/.codex/skills/ for global availability
   --repo PATH   Install into PATH/plugins and merge entries into PATH/.agents/plugins/marketplace.json
   --help        Show this help text
 EOF
@@ -93,47 +93,19 @@ merge_marketplace() {
     fi
 }
 
-copy_user_plugins() {
-    local plugins_home="$HOME/.codex/plugins"
-    mkdir -p "$plugins_home"
+install_user_skills() {
+    local skills_home="$HOME/.codex/skills"
+    mkdir -p "$skills_home"
 
-    local plugin_path
-    for plugin_path in "$DIST_DIR"/plugins/*; do
-        [[ -d "$plugin_path" ]] || continue
-        local plugin_name
-        plugin_name="$(basename "$plugin_path")"
-        rm -rf "${plugins_home:?}/$plugin_name"
-        cp -R "$plugin_path" "$plugins_home/"
-        echo "installed plugin: $plugins_home/$plugin_name"
+    local skill_dir
+    for skill_dir in "$DIST_DIR"/skills/*; do
+        [[ -d "$skill_dir" ]] || continue
+        local skill_name
+        skill_name="$(basename "$skill_dir")"
+        rm -rf "${skills_home:?}/$skill_name"
+        cp -R "$skill_dir" "$skills_home/"
+        echo "installed skill: $skills_home/$skill_name"
     done
-}
-
-build_user_marketplace() {
-    local output_file="$1"
-    local plugins_home="$HOME/.codex/plugins"
-
-    jq --arg prefix "$plugins_home" '
-        .plugins |= map(
-            .source.path |= sub("^\\./\\.codex/plugins/"; ($prefix + "/"))
-        )
-    ' "$DIST_DIR/plugins/marketplace.json" >"$output_file"
-}
-
-write_user_marketplace() {
-    local marketplace_dir="$HOME/.agents/plugins"
-    local marketplace_file="$marketplace_dir/marketplace.json"
-    local incoming_file
-    local merged_file
-
-    incoming_file="$(mktemp)"
-    merged_file="$(mktemp)"
-
-    mkdir -p "$marketplace_dir"
-    build_user_marketplace "$incoming_file"
-    merge_marketplace "$marketplace_file" "$incoming_file" "$merged_file"
-    mv "$merged_file" "$marketplace_file"
-    rm -f "$incoming_file"
-    echo "updated marketplace: $marketplace_file"
 }
 
 build_repo_marketplace() {
@@ -190,8 +162,7 @@ main() {
             ;;
         --user)
             ensure_dist
-            copy_user_plugins
-            write_user_marketplace
+            install_user_skills
             ;;
         --repo)
             if [[ $# -lt 2 ]]; then

--- a/scripts/test-installation.sh
+++ b/scripts/test-installation.sh
@@ -172,27 +172,25 @@ if ! HOME="$TMP_HOME" GOPHER_AI_ARCHIVE_URL="file://$TMP_ARCHIVE_DIR/gopher-ai-m
   sed -n '1,120p' /tmp/gopher-ai-install-user.log
   ERRORS=$((ERRORS + 1))
 else
-  USER_MARKETPLACE="$TMP_HOME/.agents/plugins/marketplace.json"
-  ACTUAL_COUNT=$(jq '.plugins | length' "$USER_MARKETPLACE")
-  MISSING_DIRS=""
-  BAD_RELATIVE=""
-  for i in $(seq 0 $((ACTUAL_COUNT - 1))); do
-    PLUGIN_PATH=$(jq -r ".plugins[$i].source.path" "$USER_MARKETPLACE")
-    # User-level paths must be absolute (not relative) so they resolve from any CWD
-    if [[ "$PLUGIN_PATH" == ./* ]]; then
-      BAD_RELATIVE="$BAD_RELATIVE $PLUGIN_PATH"
-    elif [ ! -d "$PLUGIN_PATH" ]; then
-      MISSING_DIRS="$MISSING_DIRS $PLUGIN_PATH"
+  SKILLS_DIR="$TMP_HOME/.codex/skills"
+  CODEX_DIST_DIR="$ROOT_DIR/dist/codex"
+  # Check that dist skills were copied to ~/.codex/skills/
+  DIST_SKILL_COUNT=$(find "$CODEX_DIST_DIR/skills" -mindepth 1 -maxdepth 1 -type d 2>/dev/null | wc -l)
+  INSTALLED_SKILL_COUNT=$(find "$SKILLS_DIR" -mindepth 1 -maxdepth 1 -type d 2>/dev/null | wc -l)
+  MISSING_SKILLS=""
+  for skill_dir in "$CODEX_DIST_DIR"/skills/*/; do
+    skill_name=$(basename "$skill_dir")
+    if [ ! -f "$SKILLS_DIR/$skill_name/SKILL.md" ]; then
+      MISSING_SKILLS="$MISSING_SKILLS $skill_name"
     fi
   done
-  if [ "$ACTUAL_COUNT" -ne "$CODEX_PLUGIN_COUNT" ] || [ -n "$MISSING_DIRS" ] || [ -n "$BAD_RELATIVE" ]; then
+  if [ "$INSTALLED_SKILL_COUNT" -lt "$DIST_SKILL_COUNT" ] || [ -n "$MISSING_SKILLS" ]; then
     echo "FAIL"
-    [ "$ACTUAL_COUNT" -ne "$CODEX_PLUGIN_COUNT" ] && echo "expected $CODEX_PLUGIN_COUNT plugins, got $ACTUAL_COUNT"
-    [ -n "$BAD_RELATIVE" ] && echo "relative paths in user marketplace (must be absolute):$BAD_RELATIVE"
-    [ -n "$MISSING_DIRS" ] && echo "missing plugin dirs:$MISSING_DIRS"
+    [ "$INSTALLED_SKILL_COUNT" -lt "$DIST_SKILL_COUNT" ] && echo "expected $DIST_SKILL_COUNT skills, got $INSTALLED_SKILL_COUNT"
+    [ -n "$MISSING_SKILLS" ] && echo "missing skills:$MISSING_SKILLS"
     ERRORS=$((ERRORS + 1))
   else
-    echo "OK"
+    echo "OK ($INSTALLED_SKILL_COUNT skills)"
   fi
 fi
 rm -rf "$TMP_HOME" "$TMP_SCRIPT_DIR" "$TMP_ARCHIVE_DIR"


### PR DESCRIPTION
## Summary

- **Root cause**: Codex's plugin registry only discovers the hardcoded `openai-curated` registry at `~/.codex/.tmp/plugins/`. Third-party plugin registries (under `.tmp/`, `~/.agents/plugins/`, or `~/.codex/plugins/`) aren't supported — `config.toml` entries like `plugins."go-workflow@gopher-ai"` are silently ignored.
- **Fix**: `--user` install now copies flat skills to `~/.codex/skills/` (the global skills directory Codex actually scans). This is the same mechanism the built-in skills (`imagegen`, `openai-docs`, etc.) use.
- **Verified**: `codex debug prompt-input` shows all 26 gopher-ai skills loaded from any CWD.

Supersedes #138 which fixed the path issue but didn't address the plugin discovery gap.

## Test plan

- [x] `scripts/test-installation.sh` passes (26 skills validated)
- [x] `codex debug prompt-input` shows all gopher-ai skills in Available Skills
- [ ] Run `./scripts/install-codex.sh --user` on other machine, verify skills load in worktree sessions

🤖 Generated with [Claude Code](https://claude.com/claude-code)