### PR TITLE
chore: add .codex to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,6 @@ dist/
 
 # Loop debug logs
 .claude/loop-debug.log
+
+# Codex local config
+.codex


### PR DESCRIPTION
## Summary

- Add `.codex` to `.gitignore` to keep Codex local config out of the repo

## Test plan

- [x] `git status` clean after change

🤖 Generated with [Claude Code](https://claude.com/claude-code)