### PR TITLE
fix(loops,llm): move loop state out of .claude/ + bump Codex to gpt-5.5

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,8 +4,8 @@
 # Build artifacts
 dist/
 
-# Loop debug logs
-.claude/loop-debug.log
+# Loop state & debug (lives outside .claude/ to bypass Claude Code's protected-path guard)
+/.local/state/
 
 # Codex local config
 .codex

--- a/plugins/go-dev/lib/loop-state.sh
+++ b/plugins/go-dev/lib/loop-state.sh
@@ -3,15 +3,16 @@
 # Used by stop-hook.sh and other loop-related scripts
 # Requires: jq
 
-# Debug log file location
-LOOP_DEBUG_LOG=".claude/loop-debug.log"
+# Debug log file location. Lives outside .claude/ so writes work under
+# Claude Code's bypassPermissions mode (which still guards .claude/).
+LOOP_DEBUG_LOG=".local/state/loop-debug.log"
 
 # Write a timestamped entry to the debug log
 loop_log() {
   local msg="$1"
   local ts
   ts=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
-  mkdir -p .claude
+  mkdir -p .local/state
   echo "[$ts] $msg" >> "$LOOP_DEBUG_LOG"
 }
 
@@ -123,7 +124,7 @@ check_completion_promise() {
 
 # Find all active loop state files
 find_active_loops() {
-  find .claude -name "*.loop.local.json" 2>/dev/null
+  find .local/state -name "*.loop.local.json" 2>/dev/null
 }
 
 # Get the count of active loops

--- a/plugins/go-dev/scripts/cleanup-loop.sh
+++ b/plugins/go-dev/scripts/cleanup-loop.sh
@@ -12,7 +12,7 @@ LOOP_NAME="${1:-}"
 if [ -n "$LOOP_NAME" ]; then
   # Clean up specific loop
   SAFE_LOOP_NAME=$(echo "$LOOP_NAME" | sed 's/[^a-zA-Z0-9_-]/-/g')
-  STATE_FILE=".claude/${SAFE_LOOP_NAME}.loop.local.json"
+  STATE_FILE=".local/state/${SAFE_LOOP_NAME}.loop.local.json"
 
   if [ -f "$STATE_FILE" ]; then
     rm -f "$STATE_FILE"
@@ -22,7 +22,7 @@ if [ -n "$LOOP_NAME" ]; then
   fi
 else
   # Clean up all loops
-  LOOP_FILES=$(find .claude -name "*.loop.local.json" 2>/dev/null || true)
+  LOOP_FILES=$(find .local/state -name "*.loop.local.json" 2>/dev/null || true)
 
   if [ -z "$LOOP_FILES" ]; then
     echo "No active loops found."

--- a/plugins/go-dev/scripts/setup-loop.sh
+++ b/plugins/go-dev/scripts/setup-loop.sh
@@ -24,10 +24,11 @@ fi
 
 # Sanitize loop name for use in filename
 SAFE_LOOP_NAME=$(echo "$LOOP_NAME" | sed 's/[^a-zA-Z0-9_-]/-/g')
-STATE_FILE=".claude/${SAFE_LOOP_NAME}.loop.local.json"
+# Loop state lives outside .claude/ to avoid Claude Code's protected-path
+# guard (.claude, .git, .vscode still prompt even under bypassPermissions).
+STATE_FILE=".local/state/${SAFE_LOOP_NAME}.loop.local.json"
 
-# Create .claude directory if it doesn't exist
-mkdir -p .claude
+mkdir -p .local/state
 
 # Check for existing loop — preserve phase and bot_review_baseline if re-initializing
 EXISTING_PHASE=""

--- a/plugins/go-web/lib/loop-state.sh
+++ b/plugins/go-web/lib/loop-state.sh
@@ -3,15 +3,16 @@
 # Used by stop-hook.sh and other loop-related scripts
 # Requires: jq
 
-# Debug log file location
-LOOP_DEBUG_LOG=".claude/loop-debug.log"
+# Debug log file location. Lives outside .claude/ so writes work under
+# Claude Code's bypassPermissions mode (which still guards .claude/).
+LOOP_DEBUG_LOG=".local/state/loop-debug.log"
 
 # Write a timestamped entry to the debug log
 loop_log() {
   local msg="$1"
   local ts
   ts=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
-  mkdir -p .claude
+  mkdir -p .local/state
   echo "[$ts] $msg" >> "$LOOP_DEBUG_LOG"
 }
 
@@ -123,7 +124,7 @@ check_completion_promise() {
 
 # Find all active loop state files
 find_active_loops() {
-  find .claude -name "*.loop.local.json" 2>/dev/null
+  find .local/state -name "*.loop.local.json" 2>/dev/null
 }
 
 # Get the count of active loops

--- a/plugins/go-web/scripts/cleanup-loop.sh
+++ b/plugins/go-web/scripts/cleanup-loop.sh
@@ -12,7 +12,7 @@ LOOP_NAME="${1:-}"
 if [ -n "$LOOP_NAME" ]; then
   # Clean up specific loop
   SAFE_LOOP_NAME=$(echo "$LOOP_NAME" | sed 's/[^a-zA-Z0-9_-]/-/g')
-  STATE_FILE=".claude/${SAFE_LOOP_NAME}.loop.local.json"
+  STATE_FILE=".local/state/${SAFE_LOOP_NAME}.loop.local.json"
 
   if [ -f "$STATE_FILE" ]; then
     rm -f "$STATE_FILE"
@@ -22,7 +22,7 @@ if [ -n "$LOOP_NAME" ]; then
   fi
 else
   # Clean up all loops
-  LOOP_FILES=$(find .claude -name "*.loop.local.json" 2>/dev/null || true)
+  LOOP_FILES=$(find .local/state -name "*.loop.local.json" 2>/dev/null || true)
 
   if [ -z "$LOOP_FILES" ]; then
     echo "No active loops found."

--- a/plugins/go-web/scripts/setup-loop.sh
+++ b/plugins/go-web/scripts/setup-loop.sh
@@ -24,10 +24,11 @@ fi
 
 # Sanitize loop name for use in filename
 SAFE_LOOP_NAME=$(echo "$LOOP_NAME" | sed 's/[^a-zA-Z0-9_-]/-/g')
-STATE_FILE=".claude/${SAFE_LOOP_NAME}.loop.local.json"
+# Loop state lives outside .claude/ to avoid Claude Code's protected-path
+# guard (.claude, .git, .vscode still prompt even under bypassPermissions).
+STATE_FILE=".local/state/${SAFE_LOOP_NAME}.loop.local.json"
 
-# Create .claude directory if it doesn't exist
-mkdir -p .claude
+mkdir -p .local/state
 
 # Check for existing loop — preserve phase and bot_review_baseline if re-initializing
 EXISTING_PHASE=""

--- a/plugins/go-workflow/commands/ship.md
+++ b/plugins/go-workflow/commands/ship.md
@@ -12,7 +12,7 @@ Before calling setup-loop, check if a state file already exists with a non-empty
 If so, **skip** setup-loop to preserve custom fields (`args`, `pass`, `pr_number`, `base_branch`, `no_merge`, `llm`, `discovered_bots`).
 
 ```bash
-STATE_FILE=".claude/ship.loop.local.json"
+STATE_FILE=".local/state/ship.loop.local.json"
 if [ -f "$STATE_FILE" ]; then
   EXISTING_PHASE=$(jq -r '.phase // empty' "$STATE_FILE" 2>/dev/null || true)
   if [ -n "$EXISTING_PHASE" ]; then
@@ -23,7 +23,7 @@ fi
 
 **Only call setup-loop on fresh starts** (no state file or empty phase):
 
-!`if [ -f ".claude/ship.loop.local.json" ] && [ -n "$(jq -r '.phase // empty' .claude/ship.loop.local.json 2>/dev/null)" ]; then echo "Re-entry detected — skipping setup-loop."; elif [ ! -x "${CLAUDE_PLUGIN_ROOT}/scripts/setup-loop.sh" ]; then echo "ERROR: Plugin cache stale. Run /gopher-ai-refresh (or refresh-plugins.sh) and restart Claude Code."; exit 1; else "${CLAUDE_PLUGIN_ROOT}/scripts/setup-loop.sh" "ship" "SHIPPED" 50 "" '{"reviewing":"Resume LLM review pass.","fixing":"Continue fixing LLM review findings.","verifying":"Re-run verification: build, test, lint.","coverage-check":"Resume coverage analysis for changed files.","e2e-testing":"Resume e2e testing. Restart dev server if needed.","pushing":"Resume push and PR creation.","ci-watch":"Resume CI monitoring. Run gh pr checks and fix any failures.","bot-watching":"Resume bot approval polling (Step 11). Check discovered bots for approval status. If bots request changes, go to Step 12. If all approved, go to Step 13.","addressing":"Resume addressing bot review feedback (Steps 2-11 of address-review). After fixes, return to CI watch.","merging":"Verify CI green and bot approval, then merge the PR."}'; fi`
+!`if [ -f ".local/state/ship.loop.local.json" ] && [ -n "$(jq -r '.phase // empty' .local/state/ship.loop.local.json 2>/dev/null)" ]; then echo "Re-entry detected — skipping setup-loop."; elif [ ! -x "${CLAUDE_PLUGIN_ROOT}/scripts/setup-loop.sh" ]; then echo "ERROR: Plugin cache stale. Run /gopher-ai-refresh (or refresh-plugins.sh) and restart Claude Code."; exit 1; else "${CLAUDE_PLUGIN_ROOT}/scripts/setup-loop.sh" "ship" "SHIPPED" 50 "" '{"reviewing":"Resume LLM review pass.","fixing":"Continue fixing LLM review findings.","verifying":"Re-run verification: build, test, lint.","coverage-check":"Resume coverage analysis for changed files.","e2e-testing":"Resume e2e testing. Restart dev server if needed.","pushing":"Resume push and PR creation.","ci-watch":"Resume CI monitoring. Run gh pr checks and fix any failures.","bot-watching":"Resume bot approval polling (Step 11). Check discovered bots for approval status. If bots request changes, go to Step 12. If all approved, go to Step 13.","addressing":"Resume addressing bot review feedback (Steps 2-11 of address-review). After fixes, return to CI watch.","merging":"Verify CI green and bot approval, then merge the PR."}'; fi`
 
 ## 1. Parse Arguments
 
@@ -39,10 +39,10 @@ Parse `$ARGUMENTS` to extract:
 
 Store as `LLM_CHOICE`, `MAX_PASSES`, `NO_MERGE`, `SKIP_COVERAGE`, `COVERAGE_THRESHOLD` (default: 60), `GEMINI_TIER`.
 
-**Persist arguments to state file** for re-entry recovery. After parsing, merge these fields into `.claude/ship.loop.local.json` using `jq`:
+**Persist arguments to state file** for re-entry recovery. After parsing, merge these fields into `.local/state/ship.loop.local.json` using `jq`:
 
 ```bash
-STATE_FILE=".claude/ship.loop.local.json"
+STATE_FILE=".local/state/ship.loop.local.json"
 TMP="$STATE_FILE.tmp"
 jq --arg args "$ARGUMENTS" --arg llm "$LLM_CHOICE" --argjson pass 0 \
    --arg no_merge "$NO_MERGE" --arg pr_number "" --arg base_branch "" \
@@ -61,7 +61,7 @@ Read the loop state file:
 
 ```bash
 source "${CLAUDE_PLUGIN_ROOT}/lib/loop-state.sh"
-STATE_FILE=".claude/ship.loop.local.json"
+STATE_FILE=".local/state/ship.loop.local.json"
 if [ -f "$STATE_FILE" ]; then
   read_loop_state "$STATE_FILE"
 fi
@@ -206,8 +206,8 @@ Set phase to `reviewing`:
 
 ```bash
 source "${CLAUDE_PLUGIN_ROOT}/lib/loop-state.sh"
-set_loop_phase ".claude/ship.loop.local.json" "reviewing"
-PASS=$(jq -r '.pass // 0' ".claude/ship.loop.local.json")
+set_loop_phase ".local/state/ship.loop.local.json" "reviewing"
+PASS=$(jq -r '.pass // 0' ".local/state/ship.loop.local.json")
 ```
 
 **Note:** The pass counter is incremented in Step 8 (after the review completes and findings are committed), not here. This prevents burning a pass number if the session exits during the review and re-enters.
@@ -313,11 +313,11 @@ CODEX_TIMEOUT="${CODEX_TIMEOUT:-120}"
 
 set +e
 if [ -n "$TIMEOUT_CMD" ]; then
-  REVIEW_JSON=$($TIMEOUT_CMD "${CODEX_TIMEOUT}" $CODEX_CMD exec -m "${MODEL:-gpt-5.4}" -s read-only \
+  REVIEW_JSON=$($TIMEOUT_CMD "${CODEX_TIMEOUT}" $CODEX_CMD exec -m "${MODEL:-gpt-5.5}" -s read-only \
     --output-schema "$SCHEMA_FILE" \
     - < "$PROMPT_FILE" 2>"/tmp/codex-review-stderr-$$")
 else
-  REVIEW_JSON=$($CODEX_CMD exec -m "${MODEL:-gpt-5.4}" -s read-only \
+  REVIEW_JSON=$($CODEX_CMD exec -m "${MODEL:-gpt-5.5}" -s read-only \
     --output-schema "$SCHEMA_FILE" \
     - < "$PROMPT_FILE" 2>"/tmp/codex-review-stderr-$$")
 fi
@@ -404,7 +404,7 @@ Rules:
 When the user selects `codex review --base` (from large-diff warning or timeout recovery), use the simpler review command. This is faster but limited to 2-3 findings per pass:
 
 ```bash
-$CODEX_CMD review --base "$BASE_BRANCH" -c model="${MODEL:-gpt-5.4}"
+$CODEX_CMD review --base "$BASE_BRANCH" -c model="${MODEL:-gpt-5.5}"
 ```
 
 Capture output as free-text `FINDINGS`. Set `CODEX_EXEC_FALLBACK=true` (tells Step 5c to skip JSON parsing and use free-text path). Persist `quick_mode=true` to state file for re-entry:
@@ -550,7 +550,7 @@ When `LLM_CHOICE` is `codex` and `CODEX_EXEC_FALLBACK` is not `true`:
 Set phase to `fixing`:
 
 ```bash
-set_loop_phase ".claude/ship.loop.local.json" "fixing"
+set_loop_phase ".local/state/ship.loop.local.json" "fixing"
 ```
 
 For each finding from Step 5c:
@@ -572,7 +572,7 @@ Track counts: `FIXED`, `SKIPPED` (with reasons).
 Set phase to `verifying`:
 
 ```bash
-set_loop_phase ".claude/ship.loop.local.json" "verifying"
+set_loop_phase ".local/state/ship.loop.local.json" "verifying"
 ```
 
 Auto-detect project type and run appropriate verification:
@@ -660,7 +660,7 @@ If any verification fails: analyze, fix, re-run until all pass.
 Set phase to `coverage-check`:
 
 ```bash
-set_loop_phase ".claude/ship.loop.local.json" "coverage-check"
+set_loop_phase ".local/state/ship.loop.local.json" "coverage-check"
 ```
 
 **Ship-specific skip condition:** Also skip this entire step if this is NOT the final pass (`PASS < MAX_PASSES - 1` AND findings were not clean). Proceed to Step 7.6.
@@ -670,7 +670,7 @@ Read `${CLAUDE_PLUGIN_ROOT}/skills/coverage/coverage-verification.md` and follow
 | Variable | Value |
 |----------|-------|
 | `BASE_BRANCH` | `origin/${BASE_BRANCH}` (from Step 3) |
-| `STATE_FILE` | `.claude/ship.loop.local.json` |
+| `STATE_FILE` | `.local/state/ship.loop.local.json` |
 | `SKIP_COVERAGE` | from parsed arguments |
 | `COVERAGE_THRESHOLD` | from parsed arguments (default: 60) |
 
@@ -714,7 +714,7 @@ If both `WEB_CHANGES` and `HANDLER_CHANGES` are empty → skip to Step 8.
 Set phase to `e2e-testing`:
 
 ```bash
-set_loop_phase ".claude/ship.loop.local.json" "e2e-testing"
+set_loop_phase ".local/state/ship.loop.local.json" "e2e-testing"
 ```
 
 Detect the dev server command:
@@ -783,10 +783,10 @@ kill $SERVER_PID 2>/dev/null || true
 Persist e2e results in state file:
 
 ```bash
-TMP=".claude/ship.loop.local.json.tmp"
+TMP=".local/state/ship.loop.local.json.tmp"
 jq --arg attempted "true" --arg result "$E2E_RESULT" --argjson pages "$PAGES_TESTED" \
    '.e2e_attempted = $attempted | .e2e_result = $result | .e2e_pages_tested = $pages' \
-   ".claude/ship.loop.local.json" > "$TMP" && mv "$TMP" ".claude/ship.loop.local.json"
+   ".local/state/ship.loop.local.json" > "$TMP" && mv "$TMP" ".local/state/ship.loop.local.json"
 ```
 
 Display e2e results:
@@ -812,7 +812,7 @@ Pages tested: 3 | Passed: 2 | Errors: 1
 Clean up transient files:
 
 ```bash
-rm -f .claude/coverage.out .claude/coverage.json 2>/dev/null || true
+rm -f .local/state/coverage.out .local/state/coverage.json 2>/dev/null || true
 ```
 
 ### Step 8: Commit, Increment Pass, and Loop Decision
@@ -827,17 +827,17 @@ git add <list of test files generated in Step 7.5f, if any>
 **Increment the pass counter** now that the review-fix-verify-coverage cycle is complete:
 
 ```bash
-CURRENT_PASS=$(jq -r '.pass // 0' ".claude/ship.loop.local.json")
+CURRENT_PASS=$(jq -r '.pass // 0' ".local/state/ship.loop.local.json")
 NEW_PASS=$((CURRENT_PASS + 1))
-TMP=".claude/ship.loop.local.json.tmp"
-jq --argjson p "$NEW_PASS" '.pass = $p' ".claude/ship.loop.local.json" > "$TMP" && mv "$TMP" ".claude/ship.loop.local.json"
+TMP=".local/state/ship.loop.local.json.tmp"
+jq --argjson p "$NEW_PASS" '.pass = $p' ".local/state/ship.loop.local.json" > "$TMP" && mv "$TMP" ".local/state/ship.loop.local.json"
 PASS=$NEW_PASS
 ```
 
 Only commit if there are staged changes:
 
 ```bash
-TESTS_GEN=$(jq -r '.coverage_tests_generated // 0' ".claude/ship.loop.local.json")
+TESTS_GEN=$(jq -r '.coverage_tests_generated // 0' ".local/state/ship.loop.local.json")
 if ! git diff --cached --quiet; then
   if [ "$TESTS_GEN" -gt 0 ] 2>/dev/null; then
     git commit -m "$(cat <<EOF
@@ -867,7 +867,7 @@ Check if we should continue reviewing:
 Set phase to `pushing`:
 
 ```bash
-set_loop_phase ".claude/ship.loop.local.json" "pushing"
+set_loop_phase ".local/state/ship.loop.local.json" "pushing"
 ```
 
 #### 9a. Push to remote
@@ -928,7 +928,7 @@ Persist both `head_sha` and `bot_review_baseline` in state file.
 Set phase to `ci-watch`:
 
 ```bash
-set_loop_phase ".claude/ship.loop.local.json" "ci-watch"
+set_loop_phase ".local/state/ship.loop.local.json" "ci-watch"
 ```
 
 First, check if CI workflow files exist:
@@ -954,7 +954,7 @@ The ENTIRE purpose of CI is to validate the EXACT code being merged. Stale check
 Read `head_sha` from state file (set during push in Step 9a, 10 retry, or 12c):
 
 ```bash
-HEAD_SHA=$(jq -r '.head_sha // empty' ".claude/ship.loop.local.json")
+HEAD_SHA=$(jq -r '.head_sha // empty' ".local/state/ship.loop.local.json")
 if [ -z "$HEAD_SHA" ]; then
   HEAD_SHA=$(git rev-parse HEAD)
 fi
@@ -1009,10 +1009,10 @@ if [ -n "$FINAL_SHA" ] && [ "$FINAL_SHA" != "$HEAD_SHA" ]; then
   git checkout "$PR_HEAD_BRANCH"
   git reset --hard "$BRANCH_REMOTE/$PR_HEAD_BRANCH"
   # Persist new HEAD SHA, reset pass counter, and set phase to reviewing for correct re-entry
-  TMP=".claude/ship.loop.local.json.tmp"
+  TMP=".local/state/ship.loop.local.json.tmp"
   jq --arg sha "$HEAD_SHA" --argjson pass 0 --arg rc "" --arg phase "reviewing" \
     '.head_sha = $sha | .pass = $pass | .review_clean = $rc | .phase = $phase' \
-    ".claude/ship.loop.local.json" > "$TMP" && mv "$TMP" ".claude/ship.loop.local.json"
+    ".local/state/ship.loop.local.json" > "$TMP" && mv "$TMP" ".local/state/ship.loop.local.json"
   # Go back to Step 5 (reviewing)
 fi
 ```
@@ -1037,7 +1037,7 @@ If CI fails:
 Set phase to `bot-watching` (distinct from address-review's `watching` phase to get ship-specific re-entry messages):
 
 ```bash
-set_loop_phase ".claude/ship.loop.local.json" "bot-watching"
+set_loop_phase ".local/state/ship.loop.local.json" "bot-watching"
 ```
 
 #### 11a. Discover review bots
@@ -1126,7 +1126,7 @@ Follow Steps 12a-12d from watch-loop.md:
 Set phase to `addressing` (distinct from `fixing` to ensure correct re-entry routing):
 
 ```bash
-set_loop_phase ".claude/ship.loop.local.json" "addressing"
+set_loop_phase ".local/state/ship.loop.local.json" "addressing"
 ```
 
 #### 12a. Fetch and rebase against base branch
@@ -1177,7 +1177,7 @@ Return to Step 10 (ci-watch) — set phase and re-watch CI for the new HEAD SHA 
 Set phase to `merging`:
 
 ```bash
-set_loop_phase ".claude/ship.loop.local.json" "merging"
+set_loop_phase ".local/state/ship.loop.local.json" "merging"
 ```
 
 #### 13a. Final checks
@@ -1317,12 +1317,12 @@ If the merge command fails (non-zero exit code):
 Read coverage and e2e results from state file:
 
 ```bash
-COV_RESULT=$(jq -r '.coverage_result // "skipped"' ".claude/ship.loop.local.json")
-COV_THRESHOLD=$(jq -r '.coverage_threshold // "60"' ".claude/ship.loop.local.json")
-TESTS_GEN=$(jq -r '.coverage_tests_generated // 0' ".claude/ship.loop.local.json")
-E2E_ATTEMPTED=$(jq -r '.e2e_attempted // ""' ".claude/ship.loop.local.json")
-E2E_RESULT=$(jq -r '.e2e_result // "skipped"' ".claude/ship.loop.local.json")
-E2E_PAGES=$(jq -r '.e2e_pages_tested // 0' ".claude/ship.loop.local.json")
+COV_RESULT=$(jq -r '.coverage_result // "skipped"' ".local/state/ship.loop.local.json")
+COV_THRESHOLD=$(jq -r '.coverage_threshold // "60"' ".local/state/ship.loop.local.json")
+TESTS_GEN=$(jq -r '.coverage_tests_generated // 0' ".local/state/ship.loop.local.json")
+E2E_ATTEMPTED=$(jq -r '.e2e_attempted // ""' ".local/state/ship.loop.local.json")
+E2E_RESULT=$(jq -r '.e2e_result // "skipped"' ".local/state/ship.loop.local.json")
+E2E_PAGES=$(jq -r '.e2e_pages_tested // 0' ".local/state/ship.loop.local.json")
 ```
 
 ```

--- a/plugins/go-workflow/commands/start-issue.md
+++ b/plugins/go-workflow/commands/start-issue.md
@@ -461,7 +461,7 @@ Read `${CLAUDE_PLUGIN_ROOT}/skills/coverage/coverage-verification.md` and follow
 | Variable | Value |
 |----------|-------|
 | `BASE_BRANCH` | `origin/${DEFAULT_BRANCH}` (compute DEFAULT_BRANCH if not already set: `git remote show origin 2>/dev/null \| grep 'HEAD branch' \| sed 's/.*: //' \|\| echo "main"`) |
-| `STATE_FILE` | Absolute path to `.claude/start-issue-$ISSUE_NUM.loop.local.json` (in the original repo, not the worktree) |
+| `STATE_FILE` | Absolute path to `.local/state/start-issue-$ISSUE_NUM.loop.local.json` (in the original repo, not the worktree) |
 | `SKIP_COVERAGE` | from parsed flags (default: `false`) |
 | `COVERAGE_THRESHOLD` | from parsed flags (default: `60`) |
 

--- a/plugins/go-workflow/hooks/stop-hook.sh
+++ b/plugins/go-workflow/hooks/stop-hook.sh
@@ -4,7 +4,7 @@
 #
 # How it works:
 # 1. Read hook input from stdin to get transcript path
-# 2. Check for any active loop state files (.claude/*.loop.local.json)
+# 2. Check for any active loop state files (.local/state/*.loop.local.json)
 # 3. If no active loop, allow normal exit
 # 4. If loop active, check for completion (max iterations or completion promise in transcript)
 # 5. If not complete, block exit and re-feed the prompt

--- a/plugins/go-workflow/lib/loop-state.sh
+++ b/plugins/go-workflow/lib/loop-state.sh
@@ -3,15 +3,16 @@
 # Used by stop-hook.sh and other loop-related scripts
 # Requires: jq
 
-# Debug log file location
-LOOP_DEBUG_LOG=".claude/loop-debug.log"
+# Debug log file location. Lives outside .claude/ so writes work under
+# Claude Code's bypassPermissions mode (which still guards .claude/).
+LOOP_DEBUG_LOG=".local/state/loop-debug.log"
 
 # Write a timestamped entry to the debug log
 loop_log() {
   local msg="$1"
   local ts
   ts=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
-  mkdir -p .claude
+  mkdir -p .local/state
   echo "[$ts] $msg" >> "$LOOP_DEBUG_LOG"
 }
 
@@ -123,7 +124,7 @@ check_completion_promise() {
 
 # Find all active loop state files
 find_active_loops() {
-  find .claude -name "*.loop.local.json" 2>/dev/null
+  find .local/state -name "*.loop.local.json" 2>/dev/null
 }
 
 # Get the count of active loops

--- a/plugins/go-workflow/scripts/cleanup-loop.sh
+++ b/plugins/go-workflow/scripts/cleanup-loop.sh
@@ -12,7 +12,7 @@ LOOP_NAME="${1:-}"
 if [ -n "$LOOP_NAME" ]; then
   # Clean up specific loop
   SAFE_LOOP_NAME=$(echo "$LOOP_NAME" | sed 's/[^a-zA-Z0-9_-]/-/g')
-  STATE_FILE=".claude/${SAFE_LOOP_NAME}.loop.local.json"
+  STATE_FILE=".local/state/${SAFE_LOOP_NAME}.loop.local.json"
 
   if [ -f "$STATE_FILE" ]; then
     rm -f "$STATE_FILE"
@@ -22,7 +22,7 @@ if [ -n "$LOOP_NAME" ]; then
   fi
 else
   # Clean up all loops
-  LOOP_FILES=$(find .claude -name "*.loop.local.json" 2>/dev/null || true)
+  LOOP_FILES=$(find .local/state -name "*.loop.local.json" 2>/dev/null || true)
 
   if [ -z "$LOOP_FILES" ]; then
     echo "No active loops found."

--- a/plugins/go-workflow/scripts/setup-loop.sh
+++ b/plugins/go-workflow/scripts/setup-loop.sh
@@ -24,10 +24,11 @@ fi
 
 # Sanitize loop name for use in filename
 SAFE_LOOP_NAME=$(echo "$LOOP_NAME" | sed 's/[^a-zA-Z0-9_-]/-/g')
-STATE_FILE=".claude/${SAFE_LOOP_NAME}.loop.local.json"
+# Loop state lives outside .claude/ to avoid Claude Code's protected-path
+# guard (.claude, .git, .vscode still prompt even under bypassPermissions).
+STATE_FILE=".local/state/${SAFE_LOOP_NAME}.loop.local.json"
 
-# Create .claude directory if it doesn't exist
-mkdir -p .claude
+mkdir -p .local/state
 
 # Check for existing loop — preserve phase and bot_review_baseline if re-initializing
 EXISTING_PHASE=""

--- a/plugins/go-workflow/skills/address-review/fix-cycle.md
+++ b/plugins/go-workflow/skills/address-review/fix-cycle.md
@@ -13,7 +13,7 @@
 - **If `CURRENT_PHASE` is `fixing` AND `WATCH_MODE` is `true` AND bots detected:** Set phase to `watching`, skip to Step 12:
   ```bash
   SAFE_LOOP_NAME=$(echo "address-review-${RESOLVED_PR:-auto}" | sed 's/[^a-zA-Z0-9_-]/-/g')
-  LOOP_STATE_FILE=".claude/${SAFE_LOOP_NAME}.loop.local.json"
+  LOOP_STATE_FILE=".local/state/${SAFE_LOOP_NAME}.loop.local.json"
   if [ -f "$LOOP_STATE_FILE" ]; then
     source "${CLAUDE_PLUGIN_ROOT}/lib/loop-state.sh"
     set_loop_phase "$LOOP_STATE_FILE" "watching"
@@ -36,7 +36,7 @@ Address feedback, but note: "This PR has pending review feedback that cannot be 
 
 ```bash
 SAFE_LOOP_NAME=$(echo "address-review-${RESOLVED_PR:-auto}" | sed 's/[^a-zA-Z0-9_-]/-/g')
-LOOP_STATE_FILE=".claude/${SAFE_LOOP_NAME}.loop.local.json"
+LOOP_STATE_FILE=".local/state/${SAFE_LOOP_NAME}.loop.local.json"
 if [ -f "$LOOP_STATE_FILE" ]; then
   source "${CLAUDE_PLUGIN_ROOT}/lib/loop-state.sh"
   set_loop_phase "$LOOP_STATE_FILE" "fixing"

--- a/plugins/go-workflow/skills/address-review/loop-management.md
+++ b/plugins/go-workflow/skills/address-review/loop-management.md
@@ -10,7 +10,7 @@ Check if resuming from a previous watching phase:
 
 ```bash
 SAFE_LOOP_NAME=$(echo "address-review-${RESOLVED_PR:-auto}" | sed 's/[^a-zA-Z0-9_-]/-/g')
-LOOP_STATE_FILE=".claude/${SAFE_LOOP_NAME}.loop.local.json"
+LOOP_STATE_FILE=".local/state/${SAFE_LOOP_NAME}.loop.local.json"
 CURRENT_PHASE=""
 if [ -f "$LOOP_STATE_FILE" ]; then
   source "${CLAUDE_PLUGIN_ROOT}/lib/loop-state.sh"

--- a/plugins/go-workflow/skills/address-review/watch-loop.md
+++ b/plugins/go-workflow/skills/address-review/watch-loop.md
@@ -6,7 +6,7 @@ Before entering the watch loop, update the loop state phase so that any stop-hoo
 
 ```bash
 SAFE_LOOP_NAME=$(echo "address-review-${RESOLVED_PR:-auto}" | sed 's/[^a-zA-Z0-9_-]/-/g')
-LOOP_STATE_FILE=".claude/${SAFE_LOOP_NAME}.loop.local.json"
+LOOP_STATE_FILE=".local/state/${SAFE_LOOP_NAME}.loop.local.json"
 if [ -f "$LOOP_STATE_FILE" ]; then
   source "${CLAUDE_PLUGIN_ROOT}/lib/loop-state.sh"
   set_loop_phase "$LOOP_STATE_FILE" "watching"
@@ -83,7 +83,7 @@ After the quiet period ends and new unresolved comments/threads exist:
 
 ```bash
 SAFE_LOOP_NAME=$(echo "address-review-${RESOLVED_PR:-auto}" | sed 's/[^a-zA-Z0-9_-]/-/g')
-LOOP_STATE_FILE=".claude/${SAFE_LOOP_NAME}.loop.local.json"
+LOOP_STATE_FILE=".local/state/${SAFE_LOOP_NAME}.loop.local.json"
 if [ -f "$LOOP_STATE_FILE" ]; then
   source "${CLAUDE_PLUGIN_ROOT}/lib/loop-state.sh"
   set_loop_phase "$LOOP_STATE_FILE" "fixing"

--- a/plugins/go-workflow/skills/complete-issue/SKILL.md
+++ b/plugins/go-workflow/skills/complete-issue/SKILL.md
@@ -50,7 +50,7 @@ echo "Issue: $ISSUE_NUM | Flags: $FLAGS"
 ## Loop Initialization & Re-entry
 
 ```bash
-STATE_FILE=".claude/complete-issue-${ISSUE_NUM}.loop.local.json"
+STATE_FILE=".local/state/complete-issue-${ISSUE_NUM}.loop.local.json"
 if [ -f "$STATE_FILE" ] && [ -n "$(jq -r '.phase // empty' "$STATE_FILE" 2>/dev/null)" ]; then
   echo "Re-entry detected — skipping setup-loop."
 else
@@ -120,7 +120,8 @@ if [ "$GIT_DIR_ABS" != "$GIT_COMMON_ABS" ]; then
 fi
 
 # Reassign STATE_FILE to absolute path so it resolves correctly after CWD changes
-STATE_FILE="$(pwd)/.claude/complete-issue-${ISSUE_NUM}.loop.local.json"
+STATE_FILE="$(pwd)/.local/state/complete-issue-${ISSUE_NUM}.loop.local.json"
+mkdir -p "$(dirname "$STATE_FILE")"
 
 TMP="$STATE_FILE.tmp"
 jq --arg pr_number "$PR_NUM" --arg worktree_path "${WORKTREE_PATH:-}" \

--- a/plugins/go-workflow/skills/coverage/coverage-verification.md
+++ b/plugins/go-workflow/skills/coverage/coverage-verification.md
@@ -9,11 +9,11 @@ The calling command MUST set these variables before invoking this workflow:
 | Variable | Description | Example |
 |----------|-------------|---------|
 | `BASE_BRANCH` | Branch to diff against | `origin/main` |
-| `STATE_FILE` | **Absolute path** to the loop state JSON file | `/path/to/.claude/ship.loop.local.json` |
+| `STATE_FILE` | **Absolute path** to the loop state JSON file | `/path/to/.local/state/ship.loop.local.json` |
 | `SKIP_COVERAGE` | Whether to skip coverage entirely | `true` or `false` |
 | `COVERAGE_THRESHOLD` | Minimum coverage percentage for changed files | `60` |
 
-**Worktree note:** When running in a worktree, `STATE_FILE` MUST be an absolute path to the state file (which lives in the original repo's `.claude/` directory, not the worktree). Coverage artifacts (`.claude/coverage.out`) are written relative to the current working directory — ensure `.claude/` exists via `mkdir -p .claude` before running coverage commands.
+**Worktree note:** When running in a worktree, `STATE_FILE` MUST be an absolute path to the state file (which lives in the original repo's `.local/state/` directory, not the worktree). Coverage artifacts (`.local/state/coverage.out`) are written relative to the current working directory — ensure `.local/state/` exists via `mkdir -p .local/state` before running coverage commands.
 
 ## Step A: Skip Conditions
 
@@ -27,8 +27,8 @@ Skip this entire workflow (return to the calling command's next step) if ANY of 
 Detect changed files including committed, uncommitted, staged, and untracked files (uncommitted/untracked changes are common when called from `/start-issue` before the commit step):
 
 ```bash
-mkdir -p .claude
-rm -f .claude/coverage.out .claude/coverage.json 2>/dev/null
+mkdir -p .local/state
+rm -f .local/state/coverage.out .local/state/coverage.json 2>/dev/null
 CHANGED_FILES=$( (git diff --name-only "${BASE_BRANCH}...HEAD" 2>/dev/null; git diff --name-only HEAD 2>/dev/null; git diff --name-only --cached HEAD 2>/dev/null; git ls-files --others --exclude-standard 2>/dev/null) | sort -u )
 ```
 
@@ -79,15 +79,15 @@ Run the coverage tool appropriate for the detected project type. Store coverage 
 
 **Go** (built-in — always available):
 ```bash
-go test -coverprofile=.claude/coverage.out ./... 2>/dev/null || true
-go tool cover -func=.claude/coverage.out 2>/dev/null
+go test -coverprofile=.local/state/coverage.out ./... 2>/dev/null || true
+go tool cover -func=.local/state/coverage.out 2>/dev/null
 ```
 
 Then extract coverage for changed files specifically:
 
 ```bash
 for f in $CHANGED_SRC; do
-  grep "^${f}:" .claude/coverage.out 2>/dev/null
+  grep "^${f}:" .local/state/coverage.out 2>/dev/null
 done
 ```
 
@@ -120,18 +120,18 @@ Extract `lines.pct` for each changed file to compute per-file and aggregate cove
 **Rust**:
 ```bash
 if command -v cargo-llvm-cov >/dev/null 2>&1; then
-  cargo llvm-cov --json > .claude/coverage.json 2>/dev/null || true
+  cargo llvm-cov --json > .local/state/coverage.json 2>/dev/null || true
 elif command -v cargo-tarpaulin >/dev/null 2>&1; then
-  cargo tarpaulin --out Json --output-dir .claude 2>/dev/null || true
+  cargo tarpaulin --out Json --output-dir .local/state 2>/dev/null || true
 fi
 ```
 
 **Python**:
 ```bash
 if command -v pytest >/dev/null 2>&1 && python3 -c "import pytest_cov" 2>/dev/null; then
-  pytest --cov --cov-report=json:.claude/coverage.json 2>/dev/null || true
+  pytest --cov --cov-report=json:.local/state/coverage.json 2>/dev/null || true
 elif command -v coverage >/dev/null 2>&1; then
-  coverage run -m pytest 2>/dev/null && coverage json -o .claude/coverage.json 2>/dev/null || true
+  coverage run -m pytest 2>/dev/null && coverage json -o .local/state/coverage.json 2>/dev/null || true
 fi
 ```
 
@@ -154,7 +154,7 @@ file.go:startLine.startCol,endLine.endCol numStatements hitCount
 Use statement counts weighted by whether they were hit:
 
 ```bash
-COVERAGE_FUNC=$(go tool cover -func=.claude/coverage.out 2>/dev/null)
+COVERAGE_FUNC=$(go tool cover -func=.local/state/coverage.out 2>/dev/null)
 AGGREGATE_COVERAGE=""
 FILE_REPORT=""
 UNCOVERED_FUNCS=""
@@ -162,7 +162,7 @@ TOTAL_STMTS=0
 TOTAL_COVERED=0
 
 for f in $CHANGED_SRC; do
-  FILE_STMTS=$(grep "^${f}:" .claude/coverage.out 2>/dev/null | awk '{
+  FILE_STMTS=$(grep "^${f}:" .local/state/coverage.out 2>/dev/null | awk '{
     split($2, a, " "); stmts=$2; hit=$3
     total+=stmts; if(hit>0) covered+=stmts
   } END {printf "%d %d", total, covered}')
@@ -319,7 +319,7 @@ Generate tests appropriate for the detected project type. For each target uncove
 - Detect: stdlib `testing` vs `testify`, table-driven patterns (`tests := []struct`), naming conventions
 - Generate table-driven tests with `t.Run()`, `t.Parallel()`, following `test-gen.md` patterns
 - Verify: `go test ./path/to/package/... -run "TestFunctionName" -v`
-- Re-run coverage: `go test -coverprofile=.claude/coverage.out ./... 2>/dev/null || true`
+- Re-run coverage: `go test -coverprofile=.local/state/coverage.out ./... 2>/dev/null || true`
 
 **Node/TypeScript:**
 - Check for existing test files: `*.test.ts`, `*.spec.ts`, `__tests__/*.ts`

--- a/plugins/go-workflow/skills/e2e-verify/SKILL.md
+++ b/plugins/go-workflow/skills/e2e-verify/SKILL.md
@@ -60,7 +60,7 @@ echo "Working on PR #$PR_NUM in mode: $MODE"
 ### State File Bootstrap
 
 ```bash
-STATE_FILE=".claude/e2e-verify-${PR_NUM}.loop.local.json"
+STATE_FILE=".local/state/e2e-verify-${PR_NUM}.loop.local.json"
 if [ -f "$STATE_FILE" ]; then
   EXISTING_PHASE=$(jq -r '.phase // empty' "$STATE_FILE" 2>/dev/null || true)
   if [ -n "$EXISTING_PHASE" ]; then
@@ -83,7 +83,7 @@ fi
 ### Persist Arguments
 
 ```bash
-STATE_FILE=".claude/e2e-verify-${PR_NUM}.loop.local.json"
+STATE_FILE=".local/state/e2e-verify-${PR_NUM}.loop.local.json"
 TMP="$STATE_FILE.tmp"
 jq --arg mode "$MODE" --arg pr_number "$PR_NUM" --arg build_result "" \
    --arg e2e_result "" --argjson pages_tested 0 --arg base_branch "" \

--- a/plugins/llm-tools/commands/codex.md
+++ b/plugins/llm-tools/commands/codex.md
@@ -33,8 +33,8 @@ All commands use recommended defaults automatically. Add `--ask` to customize mo
 
 | Model | Best For |
 |-------|----------|
-| `gpt-5.4` | Latest frontier model, best overall (default) |
-| `gpt-5.4-pro` | Maximum performance on complex tasks |
+| `gpt-5.5` | Latest frontier model, best overall (default) |
+| `gpt-5.5-pro` | Maximum performance on complex tasks |
 | `gpt-5.3-codex` | Previous generation frontier model |
 | `gpt-5.1-codex-mini` | Simple tasks, cost-efficient |
 
@@ -166,11 +166,11 @@ Use recommended defaults without prompting. Display a brief configuration summar
 Review config (defaults — add --ask to customize):
   Review type:  Changes vs branch
   Context:      Auto-detect
-  Model:        gpt-5.4
+  Model:        gpt-5.5
   Depth:        Exhaustive
 ```
 
-Store these selections: review type = "Changes vs branch", context = "Auto-detect", model = "gpt-5.4", depth = "Exhaustive". Proceed directly to R1.5.
+Store these selections: review type = "Changes vs branch", context = "Auto-detect", model = "gpt-5.5", depth = "Exhaustive". Proceed directly to R1.5.
 
 #### If `INTERACTIVE_MODE` is `true` (`--ask` flag provided)
 
@@ -199,8 +199,8 @@ Ask all review configuration questions in a **single `AskUserQuestion` call** wi
 
 | Option | Description |
 |--------|-------------|
-| gpt-5.4 (Recommended) | Latest frontier model, best overall |
-| gpt-5.4-pro | Maximum performance on complex tasks |
+| gpt-5.5 (Recommended) | Latest frontier model, best overall |
+| gpt-5.5-pro | Maximum performance on complex tasks |
 | gpt-5.3-codex | Previous generation frontier model |
 | gpt-5.1-codex-mini | Simple tasks, cost-efficient |
 
@@ -761,12 +761,12 @@ Use recommended defaults without prompting. Display a brief configuration summar
 
 ```
 Exec config (defaults — add --ask to customize):
-  Model:    gpt-5.4
+  Model:    gpt-5.5
   Context:  None
   Sandbox:  workspace-write
 ```
 
-Store selections: model = "gpt-5.4", context = "No", sandbox = "workspace-write". Proceed directly to Step 4 (Run Codex).
+Store selections: model = "gpt-5.5", context = "No", sandbox = "workspace-write". Proceed directly to Step 4 (Run Codex).
 
 #### If `INTERACTIVE_MODE` is `true` (`--ask` flag provided)
 
@@ -776,12 +776,12 @@ Ask the user which model to use:
 
 | Model | Best For |
 |-------|----------|
-| gpt-5.4 | Latest frontier model, best overall |
-| gpt-5.4-pro | Maximum performance on complex tasks |
+| gpt-5.5 | Latest frontier model, best overall |
+| gpt-5.5-pro | Maximum performance on complex tasks |
 | gpt-5.3-codex | Previous generation frontier model |
 | gpt-5.1-codex-mini | Simple tasks, cost-efficient |
 
-Default: `gpt-5.4`
+Default: `gpt-5.5`
 
 ### 2. Include Session Context (Optional)
 

--- a/plugins/llm-tools/commands/review-loop.md
+++ b/plugins/llm-tools/commands/review-loop.md
@@ -20,10 +20,10 @@ Parse `$ARGUMENTS` to extract:
 
 Store as `LLM_CHOICE`, `MAX_PASSES`, `QUICK_MODE` (default: `false`), `GEMINI_TIER`, and `SCOPE_HINT`.
 
-**Persist arguments to state file** for re-entry recovery. After parsing, merge these fields into `.claude/review-loop.loop.local.json` using `jq`:
+**Persist arguments to state file** for re-entry recovery. After parsing, merge these fields into `.local/state/review-loop.loop.local.json` using `jq`:
 
 ```bash
-STATE_FILE=".claude/review-loop.loop.local.json"
+STATE_FILE=".local/state/review-loop.loop.local.json"
 TMP="$STATE_FILE.tmp"
 jq --arg args "$ARGUMENTS" --argjson pass 0 --arg quick_mode "$QUICK_MODE" --arg gemini_tier "$GEMINI_TIER" \
    '. + {args: $args, pass: $pass, quick_mode: $quick_mode, gemini_tier: $gemini_tier}' "$STATE_FILE" > "$TMP" && mv "$TMP" "$STATE_FILE"
@@ -100,11 +100,11 @@ If `LLM_AVAILABLE` is `false`:
 
 ## 3. Re-entry Check
 
-Read the loop state file at `.claude/review-loop.loop.local.json`:
+Read the loop state file at `.local/state/review-loop.loop.local.json`:
 
 ```bash
 source "${CLAUDE_PLUGIN_ROOT}/lib/loop-state.sh"
-STATE_FILE=".claude/review-loop.loop.local.json"
+STATE_FILE=".local/state/review-loop.loop.local.json"
 if [ -f "$STATE_FILE" ]; then
   read_loop_state "$STATE_FILE"
 fi
@@ -182,8 +182,8 @@ Show model options based on `LLM_CHOICE`:
 
 | Model | Description |
 |-------|-------------|
-| gpt-5.4 (Recommended) | Latest frontier model, best overall |
-| gpt-5.4-pro | Maximum performance on complex tasks |
+| gpt-5.5 (Recommended) | Latest frontier model, best overall |
+| gpt-5.5-pro | Maximum performance on complex tasks |
 | gpt-5.3-codex | Previous generation frontier model |
 | gpt-5.1-codex-mini | Cost-efficient |
 
@@ -228,10 +228,10 @@ Display: "Detected base branch: `$BASE_BRANCH`". If the user corrects it (e.g., 
 
 Store all selections: `REVIEW_SCOPE`, `BASE_BRANCH`, `MODEL`, `FILE_PATHS`.
 
-**Persist scope/model to state file** for re-entry recovery. Merge these fields into `.claude/review-loop.loop.local.json`:
+**Persist scope/model to state file** for re-entry recovery. Merge these fields into `.local/state/review-loop.loop.local.json`:
 
 ```bash
-STATE_FILE=".claude/review-loop.loop.local.json"
+STATE_FILE=".local/state/review-loop.loop.local.json"
 TMP="$STATE_FILE.tmp"
 jq --arg scope "$REVIEW_SCOPE" --arg base_branch "$BASE_BRANCH" \
    --arg model "$MODEL" --arg file_paths "${FILE_PATHS:-}" \
@@ -247,7 +247,7 @@ Set phase to `reviewing` and increment the `pass:` field in the state file:
 
 ```bash
 source "${CLAUDE_PLUGIN_ROOT}/lib/loop-state.sh"
-set_loop_phase ".claude/review-loop.loop.local.json" "reviewing"
+set_loop_phase ".local/state/review-loop.loop.local.json" "reviewing"
 # Increment pass counter in state file (read current value, increment, write back)
 ```
 
@@ -541,7 +541,7 @@ After capturing the LLM review output as `FINDINGS`:
 Set phase to `fixing`:
 
 ```bash
-set_loop_phase ".claude/review-loop.loop.local.json" "fixing"
+set_loop_phase ".local/state/review-loop.loop.local.json" "fixing"
 ```
 
 ### Parallel Fix Dispatch (when 3+ findings target different files)
@@ -614,7 +614,7 @@ Track counts: `FIXED`, `SKIPPED` (with reasons).
 Set phase to `verifying`:
 
 ```bash
-set_loop_phase ".claude/review-loop.loop.local.json" "verifying"
+set_loop_phase ".local/state/review-loop.loop.local.json" "verifying"
 ```
 
 Auto-detect project type and run appropriate verification:

--- a/plugins/llm-tools/lib/loop-state.sh
+++ b/plugins/llm-tools/lib/loop-state.sh
@@ -3,15 +3,16 @@
 # Used by stop-hook.sh and other loop-related scripts
 # Requires: jq
 
-# Debug log file location
-LOOP_DEBUG_LOG=".claude/loop-debug.log"
+# Debug log file location. Lives outside .claude/ so writes work under
+# Claude Code's bypassPermissions mode (which still guards .claude/).
+LOOP_DEBUG_LOG=".local/state/loop-debug.log"
 
 # Write a timestamped entry to the debug log
 loop_log() {
   local msg="$1"
   local ts
   ts=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
-  mkdir -p .claude
+  mkdir -p .local/state
   echo "[$ts] $msg" >> "$LOOP_DEBUG_LOG"
 }
 
@@ -123,7 +124,7 @@ check_completion_promise() {
 
 # Find all active loop state files
 find_active_loops() {
-  find .claude -name "*.loop.local.json" 2>/dev/null
+  find .local/state -name "*.loop.local.json" 2>/dev/null
 }
 
 # Get the count of active loops

--- a/plugins/llm-tools/scripts/cleanup-loop.sh
+++ b/plugins/llm-tools/scripts/cleanup-loop.sh
@@ -12,7 +12,7 @@ LOOP_NAME="${1:-}"
 if [ -n "$LOOP_NAME" ]; then
   # Clean up specific loop
   SAFE_LOOP_NAME=$(echo "$LOOP_NAME" | sed 's/[^a-zA-Z0-9_-]/-/g')
-  STATE_FILE=".claude/${SAFE_LOOP_NAME}.loop.local.json"
+  STATE_FILE=".local/state/${SAFE_LOOP_NAME}.loop.local.json"
 
   if [ -f "$STATE_FILE" ]; then
     rm -f "$STATE_FILE"
@@ -22,7 +22,7 @@ if [ -n "$LOOP_NAME" ]; then
   fi
 else
   # Clean up all loops
-  LOOP_FILES=$(find .claude -name "*.loop.local.json" 2>/dev/null || true)
+  LOOP_FILES=$(find .local/state -name "*.loop.local.json" 2>/dev/null || true)
 
   if [ -z "$LOOP_FILES" ]; then
     echo "No active loops found."

--- a/plugins/llm-tools/scripts/setup-loop.sh
+++ b/plugins/llm-tools/scripts/setup-loop.sh
@@ -24,10 +24,11 @@ fi
 
 # Sanitize loop name for use in filename
 SAFE_LOOP_NAME=$(echo "$LOOP_NAME" | sed 's/[^a-zA-Z0-9_-]/-/g')
-STATE_FILE=".claude/${SAFE_LOOP_NAME}.loop.local.json"
+# Loop state lives outside .claude/ to avoid Claude Code's protected-path
+# guard (.claude, .git, .vscode still prompt even under bypassPermissions).
+STATE_FILE=".local/state/${SAFE_LOOP_NAME}.loop.local.json"
 
-# Create .claude directory if it doesn't exist
-mkdir -p .claude
+mkdir -p .local/state
 
 # Check for existing loop — preserve phase and bot_review_baseline if re-initializing
 EXISTING_PHASE=""

--- a/plugins/tailwind/lib/loop-state.sh
+++ b/plugins/tailwind/lib/loop-state.sh
@@ -3,15 +3,16 @@
 # Used by stop-hook.sh and other loop-related scripts
 # Requires: jq
 
-# Debug log file location
-LOOP_DEBUG_LOG=".claude/loop-debug.log"
+# Debug log file location. Lives outside .claude/ so writes work under
+# Claude Code's bypassPermissions mode (which still guards .claude/).
+LOOP_DEBUG_LOG=".local/state/loop-debug.log"
 
 # Write a timestamped entry to the debug log
 loop_log() {
   local msg="$1"
   local ts
   ts=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
-  mkdir -p .claude
+  mkdir -p .local/state
   echo "[$ts] $msg" >> "$LOOP_DEBUG_LOG"
 }
 
@@ -123,7 +124,7 @@ check_completion_promise() {
 
 # Find all active loop state files
 find_active_loops() {
-  find .claude -name "*.loop.local.json" 2>/dev/null
+  find .local/state -name "*.loop.local.json" 2>/dev/null
 }
 
 # Get the count of active loops

--- a/plugins/tailwind/scripts/cleanup-loop.sh
+++ b/plugins/tailwind/scripts/cleanup-loop.sh
@@ -12,7 +12,7 @@ LOOP_NAME="${1:-}"
 if [ -n "$LOOP_NAME" ]; then
   # Clean up specific loop
   SAFE_LOOP_NAME=$(echo "$LOOP_NAME" | sed 's/[^a-zA-Z0-9_-]/-/g')
-  STATE_FILE=".claude/${SAFE_LOOP_NAME}.loop.local.json"
+  STATE_FILE=".local/state/${SAFE_LOOP_NAME}.loop.local.json"
 
   if [ -f "$STATE_FILE" ]; then
     rm -f "$STATE_FILE"
@@ -22,7 +22,7 @@ if [ -n "$LOOP_NAME" ]; then
   fi
 else
   # Clean up all loops
-  LOOP_FILES=$(find .claude -name "*.loop.local.json" 2>/dev/null || true)
+  LOOP_FILES=$(find .local/state -name "*.loop.local.json" 2>/dev/null || true)
 
   if [ -z "$LOOP_FILES" ]; then
     echo "No active loops found."

--- a/plugins/tailwind/scripts/setup-loop.sh
+++ b/plugins/tailwind/scripts/setup-loop.sh
@@ -24,10 +24,11 @@ fi
 
 # Sanitize loop name for use in filename
 SAFE_LOOP_NAME=$(echo "$LOOP_NAME" | sed 's/[^a-zA-Z0-9_-]/-/g')
-STATE_FILE=".claude/${SAFE_LOOP_NAME}.loop.local.json"
+# Loop state lives outside .claude/ to avoid Claude Code's protected-path
+# guard (.claude, .git, .vscode still prompt even under bypassPermissions).
+STATE_FILE=".local/state/${SAFE_LOOP_NAME}.loop.local.json"
 
-# Create .claude directory if it doesn't exist
-mkdir -p .claude
+mkdir -p .local/state
 
 # Check for existing loop — preserve phase and bot_review_baseline if re-initializing
 EXISTING_PHASE=""

--- a/scripts/test-loop-state.sh
+++ b/scripts/test-loop-state.sh
@@ -30,23 +30,23 @@ echo ""
 
 # --- Test 1: setup-loop creates valid JSON ---
 echo "Test 1: setup-loop.sh creates valid JSON"
-rm -f .claude/test-loop.loop.local.json
+rm -f .local/state/test-loop.loop.local.json
 ./shared/scripts/setup-loop.sh "test-loop" "TEST_DONE" 10 "init" '{"init":"Start the task.","fixing":"Fix the issues."}' > /dev/null
-assert_eq "state file exists" "true" "$([ -f .claude/test-loop.loop.local.json ] && echo true || echo false)"
-assert_eq "valid JSON" "true" "$(jq empty .claude/test-loop.loop.local.json 2>/dev/null && echo true || echo false)"
-assert_eq "loop_name" "test-loop" "$(jq -r '.loop_name' .claude/test-loop.loop.local.json)"
-assert_eq "iteration" "1" "$(jq -r '.iteration' .claude/test-loop.loop.local.json)"
-assert_eq "max_iterations" "10" "$(jq -r '.max_iterations' .claude/test-loop.loop.local.json)"
-assert_eq "completion_promise" "TEST_DONE" "$(jq -r '.completion_promise' .claude/test-loop.loop.local.json)"
-assert_eq "phase" "init" "$(jq -r '.phase' .claude/test-loop.loop.local.json)"
-assert_eq "session_id field exists" "true" "$(jq -e 'has("session_id")' .claude/test-loop.loop.local.json >/dev/null 2>&1 && echo true || echo false)"
-assert_eq "phase_messages.init" "Start the task." "$(jq -r '.phase_messages.init' .claude/test-loop.loop.local.json)"
-assert_eq "phase_messages.fixing" "Fix the issues." "$(jq -r '.phase_messages.fixing' .claude/test-loop.loop.local.json)"
+assert_eq "state file exists" "true" "$([ -f .local/state/test-loop.loop.local.json ] && echo true || echo false)"
+assert_eq "valid JSON" "true" "$(jq empty .local/state/test-loop.loop.local.json 2>/dev/null && echo true || echo false)"
+assert_eq "loop_name" "test-loop" "$(jq -r '.loop_name' .local/state/test-loop.loop.local.json)"
+assert_eq "iteration" "1" "$(jq -r '.iteration' .local/state/test-loop.loop.local.json)"
+assert_eq "max_iterations" "10" "$(jq -r '.max_iterations' .local/state/test-loop.loop.local.json)"
+assert_eq "completion_promise" "TEST_DONE" "$(jq -r '.completion_promise' .local/state/test-loop.loop.local.json)"
+assert_eq "phase" "init" "$(jq -r '.phase' .local/state/test-loop.loop.local.json)"
+assert_eq "session_id field exists" "true" "$(jq -e 'has("session_id")' .local/state/test-loop.loop.local.json >/dev/null 2>&1 && echo true || echo false)"
+assert_eq "phase_messages.init" "Start the task." "$(jq -r '.phase_messages.init' .local/state/test-loop.loop.local.json)"
+assert_eq "phase_messages.fixing" "Fix the issues." "$(jq -r '.phase_messages.fixing' .local/state/test-loop.loop.local.json)"
 echo ""
 
 # --- Test 2: read_loop_state ---
 echo "Test 2: read_loop_state reads JSON correctly"
-read_loop_state ".claude/test-loop.loop.local.json"
+read_loop_state ".local/state/test-loop.loop.local.json"
 assert_eq "LOOP_NAME" "test-loop" "$LOOP_NAME"
 assert_eq "ITERATION" "1" "$ITERATION"
 assert_eq "MAX_ITERATIONS" "10" "$MAX_ITERATIONS"
@@ -56,26 +56,26 @@ echo ""
 
 # --- Test 3: increment_iteration ---
 echo "Test 3: increment_iteration"
-increment_iteration ".claude/test-loop.loop.local.json"
-assert_eq "iteration after increment" "2" "$(jq -r '.iteration' .claude/test-loop.loop.local.json)"
-increment_iteration ".claude/test-loop.loop.local.json"
-assert_eq "iteration after 2nd increment" "3" "$(jq -r '.iteration' .claude/test-loop.loop.local.json)"
+increment_iteration ".local/state/test-loop.loop.local.json"
+assert_eq "iteration after increment" "2" "$(jq -r '.iteration' .local/state/test-loop.loop.local.json)"
+increment_iteration ".local/state/test-loop.loop.local.json"
+assert_eq "iteration after 2nd increment" "3" "$(jq -r '.iteration' .local/state/test-loop.loop.local.json)"
 echo ""
 
 # --- Test 4: set_loop_phase ---
 echo "Test 4: set_loop_phase"
-set_loop_phase ".claude/test-loop.loop.local.json" "fixing"
-assert_eq "phase after set" "fixing" "$(jq -r '.phase' .claude/test-loop.loop.local.json)"
-set_loop_phase ".claude/test-loop.loop.local.json" "watching"
-assert_eq "phase after 2nd set" "watching" "$(jq -r '.phase' .claude/test-loop.loop.local.json)"
+set_loop_phase ".local/state/test-loop.loop.local.json" "fixing"
+assert_eq "phase after set" "fixing" "$(jq -r '.phase' .local/state/test-loop.loop.local.json)"
+set_loop_phase ".local/state/test-loop.loop.local.json" "watching"
+assert_eq "phase after 2nd set" "watching" "$(jq -r '.phase' .local/state/test-loop.loop.local.json)"
 echo ""
 
 # --- Test 5: get/set custom fields ---
 echo "Test 5: get_loop_field / set_loop_field"
-set_loop_field ".claude/test-loop.loop.local.json" "pr_number" "42"
-assert_eq "pr_number set" "42" "$(get_loop_field .claude/test-loop.loop.local.json pr_number)"
-set_loop_field ".claude/test-loop.loop.local.json" "discovered_bots" "coderabbitai[bot],copilot[bot]"
-assert_eq "discovered_bots" "coderabbitai[bot],copilot[bot]" "$(get_loop_field .claude/test-loop.loop.local.json discovered_bots)"
+set_loop_field ".local/state/test-loop.loop.local.json" "pr_number" "42"
+assert_eq "pr_number set" "42" "$(get_loop_field .local/state/test-loop.loop.local.json pr_number)"
+set_loop_field ".local/state/test-loop.loop.local.json" "discovered_bots" "coderabbitai[bot],copilot[bot]"
+assert_eq "discovered_bots" "coderabbitai[bot],copilot[bot]" "$(get_loop_field .local/state/test-loop.loop.local.json discovered_bots)"
 echo ""
 
 # --- Test 6: find_active_loops ---
@@ -86,40 +86,40 @@ echo ""
 
 # --- Test 7: cleanup_loop ---
 echo "Test 7: cleanup_loop"
-cleanup_loop ".claude/test-loop.loop.local.json"
-assert_eq "state file removed" "false" "$([ -f .claude/test-loop.loop.local.json ] && echo true || echo false)"
+cleanup_loop ".local/state/test-loop.loop.local.json"
+assert_eq "state file removed" "false" "$([ -f .local/state/test-loop.loop.local.json ] && echo true || echo false)"
 echo ""
 
 # --- Test 8: cleanup-loop.sh by name ---
 echo "Test 8: cleanup-loop.sh specific loop"
 ./shared/scripts/setup-loop.sh "cleanup-test" "DONE" > /dev/null
-assert_eq "created" "true" "$([ -f .claude/cleanup-test.loop.local.json ] && echo true || echo false)"
+assert_eq "created" "true" "$([ -f .local/state/cleanup-test.loop.local.json ] && echo true || echo false)"
 ./shared/scripts/cleanup-loop.sh "cleanup-test" > /dev/null
-assert_eq "removed" "false" "$([ -f .claude/cleanup-test.loop.local.json ] && echo true || echo false)"
+assert_eq "removed" "false" "$([ -f .local/state/cleanup-test.loop.local.json ] && echo true || echo false)"
 echo ""
 
 # --- Test 9: setup-loop preserves phase on re-init ---
 echo "Test 9: setup-loop preserves phase on re-init"
 ./shared/scripts/setup-loop.sh "reinit-test" "DONE" 5 "initial" > /dev/null
-set_loop_phase ".claude/reinit-test.loop.local.json" "watching"
+set_loop_phase ".local/state/reinit-test.loop.local.json" "watching"
 ./shared/scripts/setup-loop.sh "reinit-test" "DONE" 5 "initial" > /dev/null 2>&1
-assert_eq "phase preserved" "watching" "$(jq -r '.phase' .claude/reinit-test.loop.local.json)"
-cleanup_loop ".claude/reinit-test.loop.local.json"
+assert_eq "phase preserved" "watching" "$(jq -r '.phase' .local/state/reinit-test.loop.local.json)"
+cleanup_loop ".local/state/reinit-test.loop.local.json"
 echo ""
 
 # --- Test 10: atomic writes don't corrupt on concurrent access ---
 echo "Test 10: no .tmp files left behind"
 ./shared/scripts/setup-loop.sh "tmp-test" "DONE" > /dev/null
-set_loop_phase ".claude/tmp-test.loop.local.json" "phase1"
-increment_iteration ".claude/tmp-test.loop.local.json"
-set_loop_field ".claude/tmp-test.loop.local.json" "custom" "value"
-TMP_COUNT=$(find .claude -name "*.tmp" 2>/dev/null | wc -l | tr -d ' ')
+set_loop_phase ".local/state/tmp-test.loop.local.json" "phase1"
+increment_iteration ".local/state/tmp-test.loop.local.json"
+set_loop_field ".local/state/tmp-test.loop.local.json" "custom" "value"
+TMP_COUNT=$(find .local/state -name "*.tmp" 2>/dev/null | wc -l | tr -d ' ')
 assert_eq "no tmp files" "0" "$TMP_COUNT"
-cleanup_loop ".claude/tmp-test.loop.local.json"
+cleanup_loop ".local/state/tmp-test.loop.local.json"
 echo ""
 
 # --- Cleanup debug log ---
-rm -f .claude/loop-debug.log
+rm -f .local/state/loop-debug.log
 
 # --- Summary ---
 echo "==========================="

--- a/shared/hooks/stop-hook.sh
+++ b/shared/hooks/stop-hook.sh
@@ -4,7 +4,7 @@
 #
 # How it works:
 # 1. Read hook input from stdin to get transcript path
-# 2. Check for any active loop state files (.claude/*.loop.local.json)
+# 2. Check for any active loop state files (.local/state/*.loop.local.json)
 # 3. If no active loop, allow normal exit
 # 4. If loop active, check for completion (max iterations or completion promise in transcript)
 # 5. If not complete, block exit and re-feed the prompt

--- a/shared/lib/loop-state.sh
+++ b/shared/lib/loop-state.sh
@@ -3,15 +3,16 @@
 # Used by stop-hook.sh and other loop-related scripts
 # Requires: jq
 
-# Debug log file location
-LOOP_DEBUG_LOG=".claude/loop-debug.log"
+# Debug log file location. Lives outside .claude/ so writes work under
+# Claude Code's bypassPermissions mode (which still guards .claude/).
+LOOP_DEBUG_LOG=".local/state/loop-debug.log"
 
 # Write a timestamped entry to the debug log
 loop_log() {
   local msg="$1"
   local ts
   ts=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
-  mkdir -p .claude
+  mkdir -p .local/state
   echo "[$ts] $msg" >> "$LOOP_DEBUG_LOG"
 }
 
@@ -123,7 +124,7 @@ check_completion_promise() {
 
 # Find all active loop state files
 find_active_loops() {
-  find .claude -name "*.loop.local.json" 2>/dev/null
+  find .local/state -name "*.loop.local.json" 2>/dev/null
 }
 
 # Get the count of active loops

--- a/shared/scripts/cleanup-loop.sh
+++ b/shared/scripts/cleanup-loop.sh
@@ -12,7 +12,7 @@ LOOP_NAME="${1:-}"
 if [ -n "$LOOP_NAME" ]; then
   # Clean up specific loop
   SAFE_LOOP_NAME=$(echo "$LOOP_NAME" | sed 's/[^a-zA-Z0-9_-]/-/g')
-  STATE_FILE=".claude/${SAFE_LOOP_NAME}.loop.local.json"
+  STATE_FILE=".local/state/${SAFE_LOOP_NAME}.loop.local.json"
 
   if [ -f "$STATE_FILE" ]; then
     rm -f "$STATE_FILE"
@@ -22,7 +22,7 @@ if [ -n "$LOOP_NAME" ]; then
   fi
 else
   # Clean up all loops
-  LOOP_FILES=$(find .claude -name "*.loop.local.json" 2>/dev/null || true)
+  LOOP_FILES=$(find .local/state -name "*.loop.local.json" 2>/dev/null || true)
 
   if [ -z "$LOOP_FILES" ]; then
     echo "No active loops found."

--- a/shared/scripts/setup-loop.sh
+++ b/shared/scripts/setup-loop.sh
@@ -24,10 +24,11 @@ fi
 
 # Sanitize loop name for use in filename
 SAFE_LOOP_NAME=$(echo "$LOOP_NAME" | sed 's/[^a-zA-Z0-9_-]/-/g')
-STATE_FILE=".claude/${SAFE_LOOP_NAME}.loop.local.json"
+# Loop state lives outside .claude/ to avoid Claude Code's protected-path
+# guard (.claude, .git, .vscode still prompt even under bypassPermissions).
+STATE_FILE=".local/state/${SAFE_LOOP_NAME}.loop.local.json"
 
-# Create .claude directory if it doesn't exist
-mkdir -p .claude
+mkdir -p .local/state
 
 # Check for existing loop — preserve phase and bot_review_baseline if re-initializing
 EXISTING_PHASE=""


### PR DESCRIPTION
## Summary

- **Loop state migration**: `.claude/*.loop.local.json`, `.claude/coverage.{out,json}`, and `.claude/loop-debug.log` move to `.local/state/`. Claude Code's `bypassPermissions` mode still guards `.claude/` as a protected path (intentional hardening since v2.1.78 — see [#32466](https://github.com/anthropics/claude-code/issues/32466), [#36778](https://github.com/anthropics/claude-code/issues/36778), [#40852](https://github.com/anthropics/claude-code/issues/40852), [#41848](https://github.com/anthropics/claude-code/issues/41848) and the 2.1.97/98 changelog entries). Every `/ship`, `/complete-issue`, and review-loop iteration was hitting per-command permission prompts even under `--dangerously-skip-permissions`; moving off the protected path restores autonomous execution.
- **Model bump**: Codex default goes from `gpt-5.4` → `gpt-5.5` across `codex.md`, `ship.md`, and `review-loop.md` for the [OpenAI 2026-04-23 release](https://openai.com/index/introducing-gpt-5-5/). `gpt-5.4-pro` → `gpt-5.5-pro`. Older `-codex` and `-mini` IDs left alone (no `gpt-5.5-codex` or `gpt-5.5-mini` ship yet per [developers.openai.com/codex/models](https://developers.openai.com/codex/models)).
- **BREAKING**: Active loops in `.claude/*.loop.local.json` will not auto-migrate. Run `/cancel-loop` before upgrading.

## Changes

- `shared/{scripts,lib,hooks}/` — canonical sources; synced to all loop plugins via pre-commit hook
- `scripts/test-loop-state.sh` — regression tests updated; 27/27 pass
- `.gitignore` — ignore `/.local/state/` (scoped, not entire `/.local/`)
- `plugins/go-workflow/commands/ship.md`, `plugins/go-workflow/commands/start-issue.md`, `plugins/go-workflow/skills/{address-review,complete-issue,coverage,e2e-verify}/**` — path references updated
- `plugins/llm-tools/commands/{codex,review-loop}.md` — path + model updates
- `plugins/{go-dev,go-web,tailwind,llm-tools}/{scripts,lib}/` — synced copies of shared loop infra

## Test plan

- [x] `./scripts/test-loop-state.sh` — 27/27 pass against `.local/state/` paths
- [x] `./scripts/check-shared-sync.sh` — all plugins in sync with `shared/`
- [x] Smoke: `./shared/scripts/setup-loop.sh smoketest DONE 5` + `cleanup-loop.sh smoketest` — clean, no prompts
- [x] `bash -n` on all shell scripts — syntactically OK
- [x] Grep audit: zero `.claude/<coverage|loop|debug|state>` references remain
- [x] Codex review (`gpt-5.4`) raised 6 findings; 4 fixed, 2 migration-story items accepted as-is (cancel-and-restart on upgrade, no backward-compat code)
- [ ] Post-merge: run `/ship` end-to-end under `--dangerously-skip-permissions` on a throwaway PR and confirm no mid-loop permission prompts

## Sources

- [Claude Code Changelog — 2.1.97/98 protected-path hardening](https://code.claude.com/docs/en/changelog)
- [Claude Code auto mode (Anthropic)](https://www.anthropic.com/engineering/claude-code-auto-mode)
- [Introducing GPT-5.5 (OpenAI)](https://openai.com/index/introducing-gpt-5-5/)
- [Codex Models (OpenAI Developers)](https://developers.openai.com/codex/models)

🤖 Generated with [Claude Code](https://claude.com/claude-code)