### PR TITLE
fix(go-workflow): soften start-issue migration gate

### DIFF
--- a/plugins/go-workflow/commands/start-issue.md
+++ b/plugins/go-workflow/commands/start-issue.md
@@ -339,16 +339,18 @@ Store the results: RELEVANT_FILES, PATTERNS, ROOT_CAUSE (bugs) or INTEGRATION_PO
 
 ### Step 4: Design Approach (Features Only)
 
-**HARD GATE: Do NOT start implementation until the user has confirmed the approach.**
+Present the plan before implementing. Plan approval is the gate — once the user accepts the plan, you have approval for everything in it (including data migrations, schema changes, and new packages). Do not stop again to re-confirm individual items that were already in the approved plan.
 
 Using the Explore results, propose 2-3 approaches with concrete trade-offs:
-- What it changes (files, types, APIs)
+- What it changes (files, types, APIs, schema/migrations)
 - Trade-offs (complexity vs simplicity, performance vs maintainability)
-- Why you would or wouldn't recommend it
+- Your recommendation and why
 
-**For trivial features** (single function, obvious implementation): "I'll implement X using Y pattern — proceeding unless you object" with a 5-second pause.
+**Surface migrations and schema changes explicitly in the plan** so the user can see them and approve in one shot. Do not treat migrations as a separate hard gate.
 
-**For non-trivial features** (new package, API changes, data model changes): present approaches and WAIT for explicit user approval via AskUserQuestion.
+**For trivial features** (single function, obvious implementation): state your plan and proceed unless the user objects.
+
+**For non-trivial features** (new package, API changes, data model changes): present approaches and recommend one. Use your judgment on whether to wait for an explicit reply — if the change is risky, irreversible, or you're genuinely uncertain which approach the user wants, ask. Otherwise, state the recommended plan and proceed unless the user objects.
 
 ### Step 5: Task Decomposition
 

--- a/plugins/go-workflow/skills/start-issue/SKILL.md
+++ b/plugins/go-workflow/skills/start-issue/SKILL.md
@@ -85,16 +85,18 @@ Before writing any code:
 
 ### Step 6: Design Approach (Features Only)
 
-**Do not start coding until the user confirms the approach.**
+Present the plan before coding. Plan approval is the gate — once the user accepts the plan, everything inside it (including migrations, schema changes, new packages) is approved. Do not re-prompt for items that were already in the approved plan.
 
 Propose 2-3 approaches with concrete trade-offs:
-- What files/types/APIs each approach changes
+- What files/types/APIs/migrations each approach changes
 - Complexity vs simplicity, performance vs maintainability
 - Your recommendation and why
 
+Surface migrations and schema changes explicitly in the plan so they get approved in one shot. Do not treat migrations as a separate hard stop.
+
 For trivial features (single function, obvious implementation), state your plan and proceed unless the user objects.
 
-For non-trivial features (new package, API changes, data model), wait for explicit user approval.
+For non-trivial features (new package, API changes, data model), state the recommended plan and proceed unless the user objects. Use judgment: only wait for an explicit reply when the change is genuinely risky or you're uncertain which approach the user wants.
 
 ### Step 7: TDD Red — Write Failing Tests First
 


### PR DESCRIPTION
## Summary
- `/start-issue` no longer treats data-model / migration changes as a hard `AskUserQuestion` gate
- Plan itself becomes the gate: list migrations explicitly in the proposed approach; plan approval = migration approval
- AI uses judgment on whether a change is risky enough to warrant a separate explicit confirmation

## Why
The previous **HARD GATE** rule fired on nearly every issue for users whose work routinely involves migrations, stalling the workflow with prompts like *"I did not start #N because it needs explicit migration approval."* That's redundant when the user has already approved a plan that contains the migration.

## Changes
- `plugins/go-workflow/commands/start-issue.md` Step 4
- `plugins/go-workflow/skills/start-issue/SKILL.md` Step 6

Both now:
1. Frame plan approval as the gate.
2. Require migrations/schema changes to be surfaced in the plan.
3. Defer to AI judgment on whether to wait for an explicit reply (only for genuinely risky/uncertain cases).

## Test plan
- [ ] Run `/start-issue <num>` on an issue that involves a migration; confirm the workflow surfaces the migration in the proposed plan and proceeds after plan approval without a second AskUserQuestion prompt
- [ ] Run `/start-issue <num>` on a trivial bug; confirm behavior is unchanged
- [ ] Run `/start-issue <num>` on a non-trivial feature with no migration; confirm AI still presents 2-3 approaches and recommends one

🤖 Generated with [Claude Code](https://claude.com/claude-code)