### PR TITLE
fix(coverage): exclude package main files from gate aggregate

### DIFF
--- a/plugins/go-workflow/commands/ship.md
+++ b/plugins/go-workflow/commands/ship.md
@@ -1314,15 +1314,31 @@ If the merge command fails (non-zero exit code):
 
 #### 13f. Display summary
 
-Read coverage and e2e results from state file:
+Read coverage and e2e results from state file. The coverage workflow may
+have skipped the gate (e.g. all changed files were `package main`); in that
+case `coverage_skip_reason` is set and `coverage_result` is empty. Render a
+textual reason in the summary instead of `<COV_RESULT>%`:
 
 ```bash
-COV_RESULT=$(jq -r '.coverage_result // "skipped"' ".local/state/ship.loop.local.json")
+COV_RESULT=$(jq -r '.coverage_result // ""' ".local/state/ship.loop.local.json")
+COV_SKIP_REASON=$(jq -r '.coverage_skip_reason // ""' ".local/state/ship.loop.local.json")
 COV_THRESHOLD=$(jq -r '.coverage_threshold // "60"' ".local/state/ship.loop.local.json")
 TESTS_GEN=$(jq -r '.coverage_tests_generated // 0' ".local/state/ship.loop.local.json")
 E2E_ATTEMPTED=$(jq -r '.e2e_attempted // ""' ".local/state/ship.loop.local.json")
 E2E_RESULT=$(jq -r '.e2e_result // "skipped"' ".local/state/ship.loop.local.json")
 E2E_PAGES=$(jq -r '.e2e_pages_tested // 0' ".local/state/ship.loop.local.json")
+
+# Coverage line: prefer skip_reason when present, then numeric value, else "skipped".
+if [ -n "$COV_SKIP_REASON" ]; then
+  case "$COV_SKIP_REASON" in
+    all-main) COV_LINE="skipped — all changed files are \`package main\`" ;;
+    *)        COV_LINE="skipped — $COV_SKIP_REASON" ;;
+  esac
+elif [ -n "$COV_RESULT" ]; then
+  COV_LINE="${COV_RESULT}% (threshold: ${COV_THRESHOLD}%)"
+else
+  COV_LINE="skipped"
+fi
 ```
 
 ```
@@ -1332,7 +1348,7 @@ E2E_PAGES=$(jq -r '.e2e_pages_tested // 0' ".local/state/ship.loop.local.json")
 - **LLM:** <llm>
 - **Review passes:** <n>
 - **Findings addressed:** <n>
-- **Coverage (changed files):** <COV_RESULT>% (threshold: <COV_THRESHOLD>%) — or "skipped"
+- **Coverage (changed files):** <COV_LINE>
 - **Tests generated:** <TESTS_GEN>
 - **E2E tests:** <E2E_PAGES> pages tested, <E2E_RESULT> — or "skipped — no web components" / "skipped — MCP unavailable"
 - **CI:** green

--- a/plugins/go-workflow/skills/coverage/coverage-verification.md
+++ b/plugins/go-workflow/skills/coverage/coverage-verification.md
@@ -48,6 +48,32 @@ CHANGED_SRC=$(echo "$CHANGED_FILES" | grep '\.go$' \
   || true)
 ```
 
+Then partition `CHANGED_SRC` into **gated** files (counted toward the aggregate and the threshold) and **info** files (`package main` — shown in the report but excluded from the gate):
+
+```bash
+CHANGED_SRC_GATED=""
+CHANGED_SRC_INFO=""
+for f in $CHANGED_SRC; do
+  # Detection is by package clause, NOT filename.
+  # Any .go file declaring `package main` (cmd/foo/main.go, cmd/foo/server.go,
+  # cmd/foo/wire.go, internal/tools/run.go, ...) is excluded from the gate.
+  # Scan first 50 lines so leading copyright headers / //go:build tags don't
+  # hide the package clause. Deleted files (no longer on disk) fall through to
+  # the gated bucket where Step D's existing "N/A (no statements)" path handles them.
+  if [ -f "$f" ] && head -n 50 "$f" 2>/dev/null | grep -qE '^package[[:space:]]+main([[:space:]]|$)'; then
+    CHANGED_SRC_INFO="${CHANGED_SRC_INFO}${f}
+"
+  else
+    CHANGED_SRC_GATED="${CHANGED_SRC_GATED}${f}
+"
+  fi
+done
+CHANGED_SRC_GATED=$(printf '%s' "$CHANGED_SRC_GATED" | sed '/^$/d')
+CHANGED_SRC_INFO=$(printf '%s'  "$CHANGED_SRC_INFO"  | sed '/^$/d')
+```
+
+**Why exclude `package main`?** Idiomatic Go keeps `func main()` to a thin shim — argument parsing, dependency wiring, and a call into a testable package. There's little to assert against, and what's left (e.g. `os.Exit` paths) is awkward to test without refactoring purely to satisfy the metric. This is a **`package main`-only** carve-out — touching a hard-to-test middleware or handler file still trips the gate (the "if you touch it, you own it" rule is unchanged). See [#143](https://github.com/gopherguides/gopher-ai/issues/143) for full rationale and external references.
+
 **Node/TypeScript** (package.json exists):
 ```bash
 CHANGED_SRC=$(echo "$CHANGED_FILES" | grep -E '\.(ts|tsx|js|jsx)$' \
@@ -143,7 +169,7 @@ Parse the coverage output and compute per-file coverage for changed files only:
 
 1. For each file in `CHANGED_SRC`, extract its line or function coverage percentage
 2. Identify specific uncovered functions/methods in changed files
-3. Calculate the aggregate coverage percentage across all changed source files
+3. Calculate the aggregate coverage percentage across changed source files (Go: gated files only — `CHANGED_SRC_GATED`, excluding `package main`; other languages: all of `CHANGED_SRC`)
 
 For Go, parse the raw coverprofile to compute **statement-weighted** coverage (not function-average). The coverprofile format is:
 ```
@@ -151,7 +177,7 @@ mode: set
 file.go:startLine.startCol,endLine.endCol numStatements hitCount
 ```
 
-Use statement counts weighted by whether they were hit:
+Use statement counts weighted by whether they were hit. The loop runs twice: first over `CHANGED_SRC_GATED` (counted toward the aggregate), then over `CHANGED_SRC_INFO` (`package main` files — displayed but excluded from totals). Per-file row generation, uncovered-function extraction, and the `N/A (no statements)` short-circuit are identical in both passes; only the totals accumulation differs. The `Notes` column distinguishes the two: blank for gated rows, `excluded from gate (package main)` for info rows.
 
 ```bash
 COVERAGE_FUNC=$(go tool cover -func=.local/state/coverage.out 2>/dev/null)
@@ -160,8 +186,10 @@ FILE_REPORT=""
 UNCOVERED_FUNCS=""
 TOTAL_STMTS=0
 TOTAL_COVERED=0
+INFO_COUNT=0
 
-for f in $CHANGED_SRC; do
+# Pass 1: gated files — count toward TOTAL_STMTS / TOTAL_COVERED.
+for f in $CHANGED_SRC_GATED; do
   FILE_STMTS=$(grep "^${f}:" .local/state/coverage.out 2>/dev/null | awk '{
     split($2, a, " "); stmts=$2; hit=$3
     total+=stmts; if(hit>0) covered+=stmts
@@ -170,7 +198,7 @@ for f in $CHANGED_SRC; do
   FILE_COVERED=$(echo "$FILE_STMTS" | awk '{print $2}')
 
   if [ "$FILE_TOTAL" -eq 0 ] 2>/dev/null; then
-    FILE_REPORT="${FILE_REPORT}\n| ${f} | N/A (no statements) | — |"
+    FILE_REPORT="${FILE_REPORT}\n| ${f} | N/A (no statements) | — |  |"
     continue
   fi
 
@@ -181,15 +209,45 @@ for f in $CHANGED_SRC; do
   FILE_FUNC_LINES=$(echo "$COVERAGE_FUNC" | grep "^${f}:" | grep -v "^total:")
   UNCOV=$(echo "$FILE_FUNC_LINES" | awk '$NF == "0.0%" {print $2}' | paste -sd ", " -)
   UNCOV_DISPLAY="${UNCOV:-—}"
-  FILE_REPORT="${FILE_REPORT}\n| ${f} | ${FILE_COV}% | ${UNCOV_DISPLAY} |"
+  FILE_REPORT="${FILE_REPORT}\n| ${f} | ${FILE_COV}% | ${UNCOV_DISPLAY} |  |"
 
   if [ -n "$UNCOV" ]; then
     UNCOVERED_FUNCS="${UNCOVERED_FUNCS}\n${f}:${UNCOV}"
   fi
 done
 
+# Pass 2: info files (package main) — display only, do NOT touch totals.
+for f in $CHANGED_SRC_INFO; do
+  INFO_COUNT=$((INFO_COUNT + 1))
+  FILE_STMTS=$(grep "^${f}:" .local/state/coverage.out 2>/dev/null | awk '{
+    split($2, a, " "); stmts=$2; hit=$3
+    total+=stmts; if(hit>0) covered+=stmts
+  } END {printf "%d %d", total, covered}')
+  FILE_TOTAL=$(echo "$FILE_STMTS" | awk '{print $1}')
+  FILE_COVERED=$(echo "$FILE_STMTS" | awk '{print $2}')
+
+  NOTE="excluded from gate (package main)"
+
+  if [ "$FILE_TOTAL" -eq 0 ] 2>/dev/null; then
+    FILE_REPORT="${FILE_REPORT}\n| ${f} | N/A (no statements) | — | ${NOTE} |"
+    continue
+  fi
+
+  FILE_COV=$(awk "BEGIN {printf \"%.1f\", ($FILE_COVERED/$FILE_TOTAL)*100}")
+  FILE_FUNC_LINES=$(echo "$COVERAGE_FUNC" | grep "^${f}:" | grep -v "^total:")
+  UNCOV=$(echo "$FILE_FUNC_LINES" | awk '$NF == "0.0%" {print $2}' | paste -sd ", " -)
+  UNCOV_DISPLAY="${UNCOV:-—}"
+  FILE_REPORT="${FILE_REPORT}\n| ${f} | ${FILE_COV}% | ${UNCOV_DISPLAY} | ${NOTE} |"
+done
+
+# Aggregate is computed from gated files only. ALL_MAIN signals "every changed
+# file was package main" — Step E.2 emits a warning instead of running the gate.
+ALL_MAIN=false
 if [ "$TOTAL_STMTS" -gt 0 ]; then
   AGGREGATE_COVERAGE=$(awk "BEGIN {printf \"%.1f\", ($TOTAL_COVERED/$TOTAL_STMTS)*100}")
+elif [ -z "$CHANGED_SRC_GATED" ] && [ -n "$CHANGED_SRC_INFO" ]; then
+  AGGREGATE_COVERAGE="N/A"
+  ALL_MAIN=true
 else
   AGGREGATE_COVERAGE="0.0"
 fi
@@ -216,25 +274,37 @@ When coverage is below `COVERAGE_THRESHOLD`, you MUST call `AskUserQuestion` to 
 
 **Design philosophy: "if you touch it, you own it."** The entire file's coverage counts, regardless of which lines you changed or whether uncovered code existed before your changes. This is intentional. The purpose of this gate is to **improve coverage in the codebase over time** — every touched file is an opportunity. Only the USER can decide to proceed with low coverage. You cannot make that decision.
 
+**One narrow carve-out (Go only): `package main` files are excluded from the aggregate** because `func main()` is idiomatically a thin shim and not unit-testable in practice. The carve-out is detected by the package clause, not the filename — see Step B and issue #143. Hard-to-test middleware, handlers, and other non-main code still trip the gate as before.
+
 **If coverage < `COVERAGE_THRESHOLD`: your ONLY permitted action is to display the report (Step E.1) and then IMMEDIATELY call `AskUserQuestion` (Step E.2). Any other action is a violation of this workflow.**
 
 ### Step E.1: Display Coverage Report
 
 Output ONLY the coverage table and aggregate line. Do NOT add any analysis, explanation, or commentary. Do NOT discuss why coverage is low or whether the low coverage is justified.
 
+**Go format** — 4 columns; rows for `package main` files carry a Notes value of `excluded from gate (package main)`. The footer's "N file(s) shown for info only" suffix appears only when `INFO_COUNT > 0`. If `ALL_MAIN=true`, the footer reads `Changed-file coverage: N/A — all changed files are package main; gate skipped (see Step E.2 warning)`.
+
 ```
 ## Coverage Report (Changed Files)
 
-| File | Coverage | Uncovered Functions |
-|------|----------|-------------------|
-<one row per file from CHANGED_SRC, using FILE_REPORT from Step D>
+| File | Coverage | Uncovered Functions | Notes |
+|------|----------|--------------------|-------|
+<one row per file from CHANGED_SRC_GATED, then CHANGED_SRC_INFO, using FILE_REPORT from Step D>
 
-**Changed-file coverage: {AGGREGATE_COVERAGE}% (threshold: {COVERAGE_THRESHOLD}%)**
+**Changed-file coverage: {AGGREGATE_COVERAGE}% (threshold: {COVERAGE_THRESHOLD}%)** [— {INFO_COUNT} file(s) shown for info only]
 ```
+
+**Non-Go formats** — keep the existing 3-column table (`File | Coverage | Uncovered Functions`); the `package main` carve-out is Go-specific and does not apply to Node/TS, Rust, or Python paths.
 
 ### Step E.2: Gate Decision
 
 Apply IMMEDIATELY after displaying the report — no intervening text or analysis:
+
+- **Go path, `ALL_MAIN=true`** (every changed file is `package main`) → emit this exact one-line warning, then return to the calling command's next step. Do NOT call `AskUserQuestion`; there is no signal to act on, and silently passing would hide the fact that no gate ran.
+
+  ```
+  ⚠️  Coverage gate skipped: all changed files are in `package main` (typically bootstrap/wiring code that's untestable in practice). See issue #143 for rationale.
+  ```
 
 - **Coverage >= `COVERAGE_THRESHOLD`** → pass. Return to calling command's next step.
 - **Coverage < `COVERAGE_THRESHOLD`** → you MUST call `AskUserQuestion` with this exact question and options:

--- a/plugins/go-workflow/skills/coverage/coverage-verification.md
+++ b/plugins/go-workflow/skills/coverage/coverage-verification.md
@@ -62,7 +62,10 @@ get_pkg() {
     {
       line = $0
       if (in_block) { if (sub(/.*\*\//, "", line)) in_block=0; else next }
-      sub(/[[:space:]]*\/\/.*$/, "", line)
+      # Strip block comments BEFORE line comments — otherwise a one-line
+      # block comment containing a URL like `/* See https://example.com */`
+      # has its `//` stripped first, leaving `/* See https:` and opening an
+      # unterminated block that swallows the real package clause.
       while (match(line, /\/\*/)) {
         pre  = substr(line, 1, RSTART-1)
         rest = substr(line, RSTART+RLENGTH)
@@ -72,6 +75,7 @@ get_pkg() {
           line = pre; in_block = 1; break
         }
       }
+      sub(/[[:space:]]*\/\/.*$/, "", line)
       sub(/^[[:space:]]+/, "", line)
       if (line == "") next
       if (line ~ /^package[[:space:]]+[A-Za-z_]/) {

--- a/plugins/go-workflow/skills/coverage/coverage-verification.md
+++ b/plugins/go-workflow/skills/coverage/coverage-verification.md
@@ -51,16 +51,51 @@ CHANGED_SRC=$(echo "$CHANGED_FILES" | grep '\.go$' \
 Then partition `CHANGED_SRC` into **gated** files (counted toward the aggregate and the threshold) and **info** files (`package main` — shown in the report but excluded from the gate):
 
 ```bash
+# Comment-aware extractor: prints the actual Go package name (or empty).
+# Strips //-line-comments and /*..*/ block comments (handling unterminated
+# blocks across lines and inline blocks on the same line), then matches the
+# first non-blank `^package <name>` line. This avoids false positives from
+# `package main` text appearing inside doc comments.
+get_pkg() {
+  awk '
+    BEGIN { in_block=0 }
+    {
+      line = $0
+      if (in_block) { if (sub(/.*\*\//, "", line)) in_block=0; else next }
+      sub(/[[:space:]]*\/\/.*$/, "", line)
+      while (match(line, /\/\*/)) {
+        pre  = substr(line, 1, RSTART-1)
+        rest = substr(line, RSTART+RLENGTH)
+        if (match(rest, /\*\//)) {
+          line = pre substr(rest, RSTART+RLENGTH)
+        } else {
+          line = pre; in_block = 1; break
+        }
+      }
+      sub(/^[[:space:]]+/, "", line)
+      if (line == "") next
+      if (line ~ /^package[[:space:]]+[A-Za-z_]/) {
+        split(line, a, /[[:space:]]+/); print a[2]; exit
+      }
+    }
+  '
+}
+
 CHANGED_SRC_GATED=""
 CHANGED_SRC_INFO=""
 for f in $CHANGED_SRC; do
-  # Detection is by package clause, NOT filename.
-  # Any .go file declaring `package main` (cmd/foo/main.go, cmd/foo/server.go,
-  # cmd/foo/wire.go, internal/tools/run.go, ...) is excluded from the gate.
-  # Scan first 50 lines so leading copyright headers / //go:build tags don't
-  # hide the package clause. Deleted files (no longer on disk) fall through to
-  # the gated bucket where Step D's existing "N/A (no statements)" path handles them.
-  if [ -f "$f" ] && head -n 50 "$f" 2>/dev/null | grep -qE '^package[[:space:]]+main([[:space:]]|$)'; then
+  # Detection is by the file's package clause, NOT filename. Any .go file
+  # declaring `package main` (cmd/foo/main.go, cmd/foo/server.go, cmd/foo/wire.go,
+  # internal/tools/run.go, ...) is excluded from the gate. For deleted files
+  # (no longer on disk), read the blob from the base branch via `git show` so
+  # a diff that deletes only `cmd/foo/main.go` still triggers the all-main
+  # path in Step E.2 instead of producing a 0% gate prompt.
+  if [ -f "$f" ]; then
+    pkg=$(get_pkg < "$f" 2>/dev/null)
+  else
+    pkg=$(git show "${BASE_BRANCH}:${f}" 2>/dev/null | get_pkg)
+  fi
+  if [ "$pkg" = "main" ]; then
     CHANGED_SRC_INFO="${CHANGED_SRC_INFO}${f}
 "
   else
@@ -282,7 +317,7 @@ When coverage is below `COVERAGE_THRESHOLD`, you MUST call `AskUserQuestion` to 
 
 Output ONLY the coverage table and aggregate line. Do NOT add any analysis, explanation, or commentary. Do NOT discuss why coverage is low or whether the low coverage is justified.
 
-**Go format** — 4 columns; rows for `package main` files carry a Notes value of `excluded from gate (package main)`. The footer's "N file(s) shown for info only" suffix appears only when `INFO_COUNT > 0`. If `ALL_MAIN=true`, the footer reads `Changed-file coverage: N/A — all changed files are package main; gate skipped (see Step E.2 warning)`.
+**Go format** — 4 columns; rows for `package main` files carry a Notes value of `excluded from gate (package main)`. The footer is selected by the `ALL_MAIN` flag from Step D — never substitute `{AGGREGATE_COVERAGE}` directly into the gated-form footer when `ALL_MAIN=true`, or you'll render `N/A%`.
 
 ```
 ## Coverage Report (Changed Files)
@@ -291,8 +326,14 @@ Output ONLY the coverage table and aggregate line. Do NOT add any analysis, expl
 |------|----------|--------------------|-------|
 <one row per file from CHANGED_SRC_GATED, then CHANGED_SRC_INFO, using FILE_REPORT from Step D>
 
+# If ALL_MAIN=true:
+**Changed-file coverage: N/A — all changed files are `package main`; gate skipped (see Step E.2 warning)**
+
+# Else (ALL_MAIN=false):
 **Changed-file coverage: {AGGREGATE_COVERAGE}% (threshold: {COVERAGE_THRESHOLD}%)** [— {INFO_COUNT} file(s) shown for info only]
 ```
+
+Pick exactly one footer line; do not emit both. The `# If ... # Else` comments are for this skill's reader — they must not appear in the rendered report.
 
 **Non-Go formats** — keep the existing 3-column table (`File | Coverage | Uncovered Functions`); the `package main` carve-out is Go-specific and does not apply to Node/TS, Rust, or Python paths.
 

--- a/plugins/go-workflow/skills/coverage/coverage-verification.md
+++ b/plugins/go-workflow/skills/coverage/coverage-verification.md
@@ -357,18 +357,20 @@ Apply IMMEDIATELY after displaying the report — no intervening text or analysi
   **Question:** "Changed files have {AGGREGATE_COVERAGE}% coverage (threshold: {COVERAGE_THRESHOLD}%). What would you like to do?"
 
   **Options (Go projects):**
-  1. "Generate tests for all uncovered functions in changed files"
-  2. "Generate tests only for functions I added or modified"
+  1. "Generate tests for all uncovered functions in changed files (excludes `package main`)"
+  2. "Generate tests only for functions I added or modified (excludes `package main`)"
   3. "Proceed without additional tests"
   4. "Show me the uncovered functions so I can decide"
 
   **Options (non-Go projects):** Omit options 2 and 4 — changed-function detection and per-function uncovered listings are only supported for Go (Step D only populates `UNCOVERED_FUNCS` for Go). Present options 1 and 3 only.
 
+  **Scope of test generation (Go path):** Options 1, 2, and 4 only consider gated files (`CHANGED_SRC_GATED`). Uncovered functions in `package main` files are shown in the report's row for transparency but `UNCOVERED_FUNCS` only contains gated entries — Step F never generates tests for `func main()`-style code. This matches the rationale of issue #143 (main is intentionally untested).
+
   Handle the user's choice:
-  - Option 1 → proceed to Step F in **all uncovered functions** mode
-  - Option 2 (Go only) → proceed to Step F in **changed functions only** mode
+  - Option 1 → proceed to Step F in **all uncovered functions** mode (gated files only)
+  - Option 2 (Go only) → proceed to Step F in **changed functions only** mode (gated files only)
   - Option 3 → return to calling command's next step
-  - Option 4 (Go only) → display the full `UNCOVERED_FUNCS` list with file locations, then re-ask with options 1-3
+  - Option 4 (Go only) → display the gated-files `UNCOVERED_FUNCS` list with file locations, then re-ask with options 1-3
 
 - **No test files exist at all** (coverage output is empty or all functions show 0%) → you MUST call `AskUserQuestion` with:
   "No test files found for changed packages. Changed files have 0% coverage (threshold: {COVERAGE_THRESHOLD}%). What would you like to do?"
@@ -382,12 +384,27 @@ Apply IMMEDIATELY after displaying the report — no intervening text or analysi
 
 ### Step E.3: Persist Result
 
-Persist `coverage_result` in state file:
+Persist `coverage_result` in the state file. Two fields are written: a numeric
+`coverage_result` (when a real aggregate exists) and a `coverage_skip_reason`
+that explains why the gate did not run, so callers can render a sensible
+summary line without producing `N/A%`-style output.
 
 ```bash
 TMP="${STATE_FILE}.tmp"
-jq --arg cr "$AGGREGATE_COVERAGE" '.coverage_result = $cr' "$STATE_FILE" > "$TMP" && mv "$TMP" "$STATE_FILE"
+if [ "$ALL_MAIN" = "true" ]; then
+  jq --arg reason "all-main" '.coverage_result = "" | .coverage_skip_reason = $reason' \
+    "$STATE_FILE" > "$TMP" && mv "$TMP" "$STATE_FILE"
+else
+  jq --arg cr "$AGGREGATE_COVERAGE" '.coverage_result = $cr | .coverage_skip_reason = ""' \
+    "$STATE_FILE" > "$TMP" && mv "$TMP" "$STATE_FILE"
+fi
 ```
+
+**Caller contract:** Callers that render a summary line (e.g. `/ship` Step 13f)
+must check `coverage_skip_reason` before formatting `coverage_result` with a
+percent sign. If `coverage_skip_reason` is non-empty, render a textual reason
+(e.g. `skipped — all changed files are package main`) instead of
+`<COV_RESULT>%`.
 
 ## Step F: Test Generation for Uncovered Code
 

--- a/plugins/go-workflow/skills/coverage/coverage-verification.md
+++ b/plugins/go-workflow/skills/coverage/coverage-verification.md
@@ -345,7 +345,7 @@ Pick exactly one footer line; do not emit both. The `# If ... # Else` comments a
 
 Apply IMMEDIATELY after displaying the report — no intervening text or analysis:
 
-- **Go path, `ALL_MAIN=true`** (every changed file is `package main`) → emit this exact one-line warning, then return to the calling command's next step. Do NOT call `AskUserQuestion`; there is no signal to act on, and silently passing would hide the fact that no gate ran.
+- **Go path, `ALL_MAIN=true`** (every changed file is `package main`) → emit this exact one-line warning, **then run Step E.3 to persist the skip reason** (`coverage_skip_reason = "all-main"`, `coverage_result = ""`), and return to the calling command's next step. Do NOT call `AskUserQuestion`; there is no signal to act on, and silently passing would hide the fact that no gate ran. Skipping Step E.3 here would leave the calling command (e.g. `/ship`) unable to render the correct summary line.
 
   ```
   ⚠️  Coverage gate skipped: all changed files are in `package main` (typically bootstrap/wiring code that's untestable in practice). See issue #143 for rationale.

--- a/plugins/go-workflow/skills/coverage/coverage-verification.md
+++ b/plugins/go-workflow/skills/coverage/coverage-verification.md
@@ -410,8 +410,8 @@ percent sign. If `coverage_skip_reason` is non-empty, render a textual reason
 
 **Mode selection** (set by Step E.2 user choice):
 
-- **All uncovered functions mode** (option 1): Generate tests for every uncovered function in `CHANGED_SRC`, as listed in `UNCOVERED_FUNCS` from Step D.
-- **No-test-files path** (from Step E.2 "Generate initial tests"): `UNCOVERED_FUNCS` may be empty because Step D short-circuits when coverage data is missing. In this case, read each file in `CHANGED_SRC` directly and extract all exported function/method signatures as test targets.
+- **All uncovered functions mode** (option 1): Generate tests for every uncovered function in `CHANGED_SRC` (Go: `CHANGED_SRC_GATED`), as listed in `UNCOVERED_FUNCS` from Step D.
+- **No-test-files path** (from Step E.2 "Generate initial tests"): `UNCOVERED_FUNCS` may be empty because Step D short-circuits when coverage data is missing. In this case, read each file in `CHANGED_SRC` (Go: `CHANGED_SRC_GATED` — `package main` files are excluded so Step F never generates tests for `func main()`-style code) directly and extract all exported function/method signatures as test targets.
 - **Changed functions only mode** (option 2, Go only): Restrict test generation to Go functions whose bodies were added or modified. Identify changed functions by mapping diff hunks to their enclosing function using committed, staged, unstaged, and untracked changes (matching Step B's file detection):
   ```bash
   # Combine committed + staged + unstaged diffs


### PR DESCRIPTION
## Summary

- The Go path of the shared coverage workflow now partitions `CHANGED_SRC` into **gated** files (count toward the aggregate and the threshold) and **info** files (`package main`, displayed with an `excluded from gate (package main)` note but excluded from totals).
- Detection is by the file's `package main` clause — scanned across the first 50 lines so build tags and copyright headers don't hide it — **not** by filename. `cmd/foo/main.go`, `cmd/foo/server.go`, `cmd/foo/wire.go`, and `internal/tools/run.go` all qualify if and only if their package clause says `main`.
- When every changed file is `package main`, the gate is **skipped with an explicit one-line warning** rather than silently passing.
- Both `/ship` and `/start-issue` call this same skill, so this fix flows through both. No `shared/` copy of the file exists; no other plugin has parallel coverage logic.

Fixes #143

## Test Plan

- [x] Smoke-tested the new partition snippet under bash against a synthetic file set covering: `package main` in a non-`main.go` file (`cmd/cli/server.go`), `package main` behind a `//go:build` tag and copyright header (`cmd/cli/wire.go`), a non-main file whose path contains the word "main" (`internal/main_helpers.go`), a non-main library file (`service/auth.go`), and a deleted file. Files landed in the correct buckets in every case.
- [x] Spec review: updated step intros (Step D bullet, Step E.1 narration, Step E mandatory-rule carve-out) reference the new variables consistently. Non-Go paths (Node/TS, Rust, Python) are untouched and explicitly called out as keeping the original 3-column table.
- [ ] End-to-end exercise on a real Go diff: pending — best validated on a downstream PR that touches both a non-main file and a `cmd/*/main.go`.

## References (from issue body)

- [vladopajic/go-test-coverage](https://github.com/vladopajic/go-test-coverage) — supports regexp file/package exclusion
- [Excluding files from code coverage in Go (DEV)](https://dev.to/talalyousif/excluding-files-from-code-coverage-in-go-291f)
- [golangbridge: skip a go file in coverage](https://forum.golangbridge.org/t/while-running-the-go-test-under-a-package-how-to-skip-a-go-file-in-test-as-well-as-in-the-coverage-report/8644)
- [golang/go#53271 — //go:cover ignore proposal](https://github.com/golang/go/issues/53271)

🤖 Generated with [Claude Code](https://claude.com/claude-code)