### PR TITLE
fix(codex): drop flat skills layout, dedupe, and trim descriptions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -62,34 +62,23 @@ To add these plugins to **your own repo**:
 ./scripts/install-codex.sh --repo /path/to/your-repo
 ```
 
-### Global (Personal) Installation and Update
+### Global (Personal) Use
 
-To make plugins available across all your repos:
+For Codex, "global" means cloning this repo and running Codex inside it — Codex auto-discovers `.agents/plugins/marketplace.json` and offers the plugins through `/plugins`. There is no flat-skills install path; the previous `--user` mode has been removed because it double-loaded skills alongside the marketplace and overflowed Codex's skill metadata budget.
+
+If you previously ran `--user`, clean up the legacy entries once:
 
 ```bash
-./scripts/build-universal.sh
-./scripts/install-codex.sh --user
+./scripts/install-codex.sh --cleanup
 ```
 
-Or as a one-liner from GitHub (installs for all detected platforms):
+The universal installer handles every detected platform in one step:
 
 ```bash
 bash -c "$(curl -fsSL https://raw.githubusercontent.com/gopherguides/gopher-ai/main/scripts/install-all.sh)"
 ```
 
-This downloads the repo to a temp directory, builds, installs for every platform it detects (Claude Code, Codex, Gemini), and cleans up.
-
-Restart Codex after installation or update. Use `/plugins` to verify they appear.
-
-### Flat Skills (Legacy)
-
-Individual skills can also be installed without the plugin system:
-
-```bash
-cp -r dist/codex/skills/* ~/.codex/skills/
-```
-
-Or use the built-in `$skill-installer` for curated skills.
+It builds, installs Claude Code and Gemini, runs the Codex `--cleanup`, and cleans up after itself. Restart Codex after running it; use `/plugins` to verify.
 
 ## Architecture
 

--- a/README.md
+++ b/README.md
@@ -283,7 +283,7 @@ Plugins are distributed via the [Codex plugin system](https://developers.openai.
 
 **Install into another repo:** `./scripts/install-codex.sh --repo /path/to/your-repo` copies the current plugin set and merges entries into that repo's `.agents/plugins/marketplace.json` without removing unrelated plugin entries.
 
-**GitHub one-liner:** `bash -c "$(curl -fsSL https://raw.githubusercontent.com/gopherguides/gopher-ai/main/scripts/install-all.sh)"` auto-detects all platforms and installs everything.
+**GitHub one-liner:** `bash -c "$(curl -fsSL https://raw.githubusercontent.com/gopherguides/gopher-ai/main/scripts/install-all.sh)"` auto-detects all platforms — installs Claude Code and Gemini, and runs the Codex `--cleanup --yes` migration. It does **not** install Codex plugins, since Codex now discovers gopher-ai through the in-repo marketplace. Either clone this repo and run Codex inside it, or use `--repo` to add the marketplace to another repo.
 
 **Migration from older versions:** Older releases offered a `--user` mode that copied flat skills into `~/.codex/skills/`. That conflicted with the plugin marketplace — Codex saw every gopher-ai skill twice and the duplicated metadata overflowed Codex's [skill metadata budget](https://developers.openai.com/codex/skills) (~2% of the context window). The flat layout is gone; run `./scripts/install-codex.sh --cleanup` once on machines that used `--user` previously. The marketplace is the only delivery path now.
 

--- a/README.md
+++ b/README.md
@@ -69,13 +69,14 @@ cd gopher-ai
 codex   # Plugins load automatically from .agents/plugins/marketplace.json
 # Use /plugins to browse, $start-issue 42 to invoke workflow skills
 
-# Global install or update (all repos)
-./scripts/build-universal.sh
-./scripts/install-codex.sh --user
-# Restart Codex — use /plugins to verify
+# Add to another repo (so its Codex sessions discover gopher-ai too)
+./scripts/install-codex.sh --repo /path/to/your-repo
 
-# Or one-liner install from GitHub (Codex only)
-bash -c "$(curl -fsSL https://raw.githubusercontent.com/gopherguides/gopher-ai/main/scripts/install-codex.sh)" -- --user
+# Migrating from older versions: clean up legacy ~/.codex/skills/ entries
+./scripts/install-codex.sh --cleanup
+# Older versions installed flat skills into ~/.codex/skills/ via --user mode.
+# That double-loaded skills alongside the marketplace and overflowed Codex's
+# skill metadata budget. The marketplace is the only delivery path now.
 ```
 
 #### Google Gemini CLI
@@ -280,13 +281,11 @@ Plugins are distributed via the [Codex plugin system](https://developers.openai.
 
 **Repo-local discovery:** Codex reads `.agents/plugins/marketplace.json` on startup and syncs plugins automatically. Use `/plugins` to browse and manage installed plugins. Plugins with `.codex-plugin/plugin.json` are packaged for Codex. Today that set is `go-workflow`, `go-dev`, `gopher-guides`, `llm-tools`, `go-web`, and `tailwind`. The repo's `productivity` module remains Claude-only.
 
-**Global install or update:** Build the distribution and run `./scripts/install-codex.sh --user`. The installer replaces the current gopher-ai plugins in `~/.codex/plugins/` and merges the marketplace entries into `~/.agents/plugins/marketplace.json` without removing unrelated plugin entries.
+**Install into another repo:** `./scripts/install-codex.sh --repo /path/to/your-repo` copies the current plugin set and merges entries into that repo's `.agents/plugins/marketplace.json` without removing unrelated plugin entries.
 
-**GitHub one-liner:** `bash -c "$(curl -fsSL https://raw.githubusercontent.com/gopherguides/gopher-ai/main/scripts/install-all.sh)"` auto-detects all platforms and installs everything. For Codex-only: `bash -c "$(curl -fsSL https://raw.githubusercontent.com/gopherguides/gopher-ai/main/scripts/install-codex.sh)" -- --user`.
+**GitHub one-liner:** `bash -c "$(curl -fsSL https://raw.githubusercontent.com/gopherguides/gopher-ai/main/scripts/install-all.sh)"` auto-detects all platforms and installs everything.
 
-**Install into another repo:** Use `./scripts/install-codex.sh --repo /path/to/your-repo` to copy the current plugin set into another repository and update that repo's `.agents/plugins/marketplace.json`.
-
-**Manual install:** Copy `dist/codex/plugins/` to `~/.codex/plugins/` and `marketplace.json` to `~/.agents/plugins/` if you prefer manual steps.
+**Migration from older versions:** Older releases offered a `--user` mode that copied flat skills into `~/.codex/skills/`. That conflicted with the plugin marketplace — Codex saw every gopher-ai skill twice and the duplicated metadata overflowed Codex's [skill metadata budget](https://developers.openai.com/codex/skills) (~2% of the context window). The flat layout is gone; run `./scripts/install-codex.sh --cleanup` once on machines that used `--user` previously. The marketplace is the only delivery path now.
 
 **Workflow skills** (from `go-workflow` plugin):
 
@@ -300,8 +299,6 @@ $ship              # Verify, push, CI watch, merge
 $remove-worktree   # Remove a single worktree
 $prune-worktree    # Batch cleanup completed worktrees
 ```
-
-**Flat skills (legacy):** Individual skills can also be installed to `~/.codex/skills/` or via `$skill-installer`.
 
 ### Google Gemini CLI
 
@@ -420,7 +417,6 @@ Or build only (without installing):
 
 This generates:
 - `dist/codex/plugins/` - Codex plugin packages
-- `dist/codex/skills/` - Flat skills (legacy/backward-compatible)
 - `dist/gemini/` - Gemini extensions
 - `dist/*.tar.gz` - Release archives
 

--- a/plugins/go-dev/skills/go-best-practices/SKILL.md
+++ b/plugins/go-dev/skills/go-best-practices/SKILL.md
@@ -1,11 +1,6 @@
 ---
 name: go-best-practices
-description: |
-  WHEN: User is writing Go code, asking about Go patterns, reviewing Go code, asking
-  "what's the best way to...", "how should I structure...", "is this idiomatic?",
-  or any general Go development question. Trigger this skill liberally for ANY Go-related
-  development work as a routing hub to specialized skills.
-  WHEN NOT: Non-Go languages, questions entirely unrelated to programming
+description: Idiomatic Go patterns and routing hub to specialized Go skills (interfaces, concurrency, testing, errors, profiling, organization).
 allowed-tools: Read Edit Write Glob Grep Bash(go:*) Bash(golangci-lint:*) Bash(git:*) Agent
 ---
 

--- a/plugins/go-dev/skills/go-best-practices/SKILL.md
+++ b/plugins/go-dev/skills/go-best-practices/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: go-best-practices
-description: Idiomatic Go patterns and routing hub to specialized Go skills (interfaces, concurrency, testing, errors, profiling, organization).
+description: "Idiomatic Go patterns and routing hub to specialized Go skills (interfaces, concurrency, testing, errors, profiling, organization)."
 allowed-tools: Read Edit Write Glob Grep Bash(go:*) Bash(golangci-lint:*) Bash(git:*) Agent
 ---
 

--- a/plugins/go-dev/skills/go-code-organization/SKILL.md
+++ b/plugins/go-dev/skills/go-code-organization/SKILL.md
@@ -1,12 +1,6 @@
 ---
 name: go-code-organization
-description: |
-  WHEN: User is organizing Go code, asking about package structure, naming conventions,
-  project layout, import organization, file organization, or asking "where should I put this?",
-  "how should I name this package?", "should I split this file?". Also when reviewing
-  code organization in PRs or refactoring package boundaries.
-  WHEN NOT: Non-Go languages. Interface design specifics (use go-interfaces).
-  Concurrency patterns (use go-concurrency).
+description: Organize Go code: package structure, naming, project layout, import grouping, file splitting. Use when deciding 'where should I put this?'.
 allowed-tools: Read Edit Write Glob Grep Bash(go:*) Bash(golangci-lint:*) Bash(git:*) Agent
 ---
 

--- a/plugins/go-dev/skills/go-code-organization/SKILL.md
+++ b/plugins/go-dev/skills/go-code-organization/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: go-code-organization
-description: Organize Go code: package structure, naming, project layout, import grouping, file splitting. Use when deciding 'where should I put this?'.
+description: "Organize Go code: package structure, naming, project layout, import grouping, file splitting. Use when deciding 'where should I put this?'."
 allowed-tools: Read Edit Write Glob Grep Bash(go:*) Bash(golangci-lint:*) Bash(git:*) Agent
 ---
 

--- a/plugins/go-dev/skills/go-concurrency/SKILL.md
+++ b/plugins/go-dev/skills/go-concurrency/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: go-concurrency
-description: Write/review concurrent Go: goroutines, channels, select, locks, sync, errgroup, singleflight, worker pools, fan-out/in. Catch leaks, races, channel ownership.
+description: "Write/review concurrent Go: goroutines, channels, select, locks, sync, errgroup, singleflight, worker pools, fan-out/in. Catch leaks, races, channel ownership."
 allowed-tools: Read Edit Write Glob Grep Bash(go:*) Bash(golangci-lint:*) Bash(git:*) Agent
 ---
 

--- a/plugins/go-dev/skills/go-concurrency/SKILL.md
+++ b/plugins/go-dev/skills/go-concurrency/SKILL.md
@@ -1,12 +1,6 @@
 ---
 name: go-concurrency
-description: |
-  WHEN: User is writing or reviewing concurrent Go code involving goroutines, channels, select,
-  locks, sync primitives, errgroup, singleflight, worker pools, or fan-out/fan-in pipelines.
-  Also when detecting goroutine leaks, race conditions, channel ownership issues, or choosing
-  between channels and mutexes.
-  WHEN NOT: Non-Go languages. Sequential code with no concurrency needs.
-  Performance profiling (use go-profiling-optimization). Debugging race conditions (use systematic-debugging).
+description: Write/review concurrent Go: goroutines, channels, select, locks, sync, errgroup, singleflight, worker pools, fan-out/in. Catch leaks, races, channel ownership.
 allowed-tools: Read Edit Write Glob Grep Bash(go:*) Bash(golangci-lint:*) Bash(git:*) Agent
 ---
 

--- a/plugins/go-dev/skills/go-error-handling/SKILL.md
+++ b/plugins/go-dev/skills/go-error-handling/SKILL.md
@@ -1,11 +1,6 @@
 ---
 name: go-error-handling
-description: |
-  WHEN: User is creating, wrapping, inspecting, or logging errors in Go code. Also when
-  reviewing error handling in PRs, asking about error patterns, using fmt.Errorf, errors.Is,
-  errors.As, errors.Join, sentinel errors, custom error types, or panic/recover.
-  WHEN NOT: Non-Go languages. Performance profiling (use go-profiling-optimization).
-  General debugging (use systematic-debugging).
+description: Go error handling: fmt.Errorf, errors.Is/As/Join, sentinels, custom error types, panic/recover, wrapping, logging.
 allowed-tools: Read Edit Write Glob Grep Bash(go:*) Bash(golangci-lint:*) Bash(git:*) Agent
 ---
 

--- a/plugins/go-dev/skills/go-error-handling/SKILL.md
+++ b/plugins/go-dev/skills/go-error-handling/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: go-error-handling
-description: Go error handling: fmt.Errorf, errors.Is/As/Join, sentinels, custom error types, panic/recover, wrapping, logging.
+description: "Go error handling: fmt.Errorf, errors.Is/As/Join, sentinels, custom error types, panic/recover, wrapping, logging."
 allowed-tools: Read Edit Write Glob Grep Bash(go:*) Bash(golangci-lint:*) Bash(git:*) Agent
 ---
 

--- a/plugins/go-dev/skills/go-interfaces/SKILL.md
+++ b/plugins/go-dev/skills/go-interfaces/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: go-interfaces
-description: Design and review Go interfaces: composition, embedding, type assertions/switches, io.Reader/Writer, implicit satisfaction, decorator/middleware patterns.
+description: "Design and review Go interfaces: composition, embedding, type assertions/switches, io.Reader/Writer, implicit satisfaction, decorator/middleware patterns."
 allowed-tools: Read Edit Write Glob Grep Bash(go:*) Bash(golangci-lint:*) Bash(git:*) Agent
 ---
 

--- a/plugins/go-dev/skills/go-interfaces/SKILL.md
+++ b/plugins/go-dev/skills/go-interfaces/SKILL.md
@@ -1,16 +1,6 @@
 ---
 name: go-interfaces
-description: |
-  WHEN: User is designing interfaces, asking about interface patterns, implementing interfaces,
-  working with type assertions, type switches, embedding, or asking "should this be an interface?",
-  "where should I define this interface?", "how many methods should my interface have?".
-  Also activate when reviewing interface design in PRs or refactoring toward interfaces.
-  Trigger when user mentions io.Reader, io.Writer, fmt.Stringer, sort.Interface, interface
-  composition, interface embedding, type assertion, type switch, implicit satisfaction,
-  decorator pattern, middleware pattern, or any question about Go interface design.
-  Trigger this skill liberally for ANY Go interface-related work.
-  WHEN NOT: Non-Go languages. Concurrency primitives (use go-concurrency).
-  Error handling specifics (use go-error-handling).
+description: Design and review Go interfaces: composition, embedding, type assertions/switches, io.Reader/Writer, implicit satisfaction, decorator/middleware patterns.
 allowed-tools: Read Edit Write Glob Grep Bash(go:*) Bash(golangci-lint:*) Bash(git:*) Agent
 ---
 

--- a/plugins/go-dev/skills/go-profiling-optimization/SKILL.md
+++ b/plugins/go-dev/skills/go-profiling-optimization/SKILL.md
@@ -1,17 +1,6 @@
 ---
 name: go-profiling-optimization
-description: |
-  WHEN: User is analyzing Go performance, asking about profiling, optimization, benchmarking
-  strategy, memory allocations, CPU hotspots, pprof, flame graphs, escape analysis, or
-  "why is this slow". Also activate when user mentions PGO, GOGC, GOMEMLIMIT, runtime/trace,
-  net/http/pprof, gcflags, benchstat, sync.Pool, buffer pooling, preallocation, or is
-  interpreting benchmark results, profiling output, or trace data. Trigger when user asks
-  "how do I profile", "where is the bottleneck", "how to reduce allocations", "is this
-  allocation on heap or stack", or any question about Go runtime performance tuning.
-  Trigger this skill liberally for ANY Go performance-related work.
-  WHEN NOT: Non-Go languages, general debugging without performance focus (use
-  systematic-debugging instead), writing new benchmarks from scratch (suggest /bench command),
-  questions entirely unrelated to performance or optimization
+description: Profile and optimize Go performance: pprof, allocations, escape analysis, sync.Pool, GOGC, benchmarks. Trigger for any Go perf, profiling, or runtime tuning question.
 allowed-tools: Read Edit Write Glob Grep Bash(go:*) Bash(golangci-lint:*) Bash(git:*) Agent
 ---
 

--- a/plugins/go-dev/skills/go-profiling-optimization/SKILL.md
+++ b/plugins/go-dev/skills/go-profiling-optimization/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: go-profiling-optimization
-description: Profile and optimize Go performance: pprof, allocations, escape analysis, sync.Pool, GOGC, benchmarks. Trigger for any Go perf, profiling, or runtime tuning question.
+description: "Profile and optimize Go performance: pprof, allocations, escape analysis, sync.Pool, GOGC, benchmarks. Trigger for any Go perf, profiling, or runtime tuning question."
 allowed-tools: Read Edit Write Glob Grep Bash(go:*) Bash(golangci-lint:*) Bash(git:*) Agent
 ---
 

--- a/plugins/go-dev/skills/go-testing/SKILL.md
+++ b/plugins/go-dev/skills/go-testing/SKILL.md
@@ -1,12 +1,6 @@
 ---
 name: go-testing
-description: |
-  WHEN: User is writing tests, asking about testing patterns, using table-driven tests,
-  subtests, t.Parallel, t.Helper, t.Cleanup, testify, mocks, stubs, integration tests,
-  benchmarks, fuzzing, or test organization. Also when reviewing test code in PRs or
-  asking "how should I test this?", "what should I test?", or "is this test good enough?".
-  WHEN NOT: Non-Go languages. Debugging test failures (use systematic-debugging).
-  Performance benchmarking methodology (use go-profiling-optimization).
+description: Write Go tests: table-driven patterns, subtests, t.Parallel/Helper/Cleanup, testify, mocks, integration tests, benchmarks, fuzzing.
 allowed-tools: Read Edit Write Glob Grep Bash(go:*) Bash(golangci-lint:*) Bash(git:*) Agent
 ---
 

--- a/plugins/go-dev/skills/go-testing/SKILL.md
+++ b/plugins/go-dev/skills/go-testing/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: go-testing
-description: Write Go tests: table-driven patterns, subtests, t.Parallel/Helper/Cleanup, testify, mocks, integration tests, benchmarks, fuzzing.
+description: "Write Go tests: table-driven patterns, subtests, t.Parallel/Helper/Cleanup, testify, mocks, integration tests, benchmarks, fuzzing."
 allowed-tools: Read Edit Write Glob Grep Bash(go:*) Bash(golangci-lint:*) Bash(git:*) Agent
 ---
 

--- a/plugins/go-dev/skills/systematic-debugging/SKILL.md
+++ b/plugins/go-dev/skills/systematic-debugging/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: systematic-debugging
-description: Debug Go code: investigate bugs, analyze test failures, race conditions, panics, deadlocks, stack traces. Trigger for 'why is this broken', 'test failing', 'getting an error'.
+description: "Debug Go code: investigate bugs, analyze test failures, race conditions, panics, deadlocks, stack traces. Trigger for 'why is this broken', 'test failing', 'getting an error'."
 allowed-tools: Read Edit Write Glob Grep Bash(go:*) Bash(golangci-lint:*) Bash(git:*) Bash(dlv:*) Agent
 ---
 

--- a/plugins/go-dev/skills/systematic-debugging/SKILL.md
+++ b/plugins/go-dev/skills/systematic-debugging/SKILL.md
@@ -1,14 +1,6 @@
 ---
 name: systematic-debugging
-description: |
-  WHEN: User is debugging Go code, investigating bugs, analyzing test failures, encountering
-  unexpected behavior, reading stack traces, diagnosing race conditions, fixing flaky tests,
-  or saying "why is this broken", "this doesn't work", "test is failing", "getting an error".
-  Also activate when investigating panics, goroutine deadlocks, data corruption, or any
-  situation where the root cause is not immediately obvious.
-  Trigger this skill liberally for ANY debugging or bug investigation work in Go.
-  WHEN NOT: Writing new features from scratch, code review without a specific bug,
-  questions entirely unrelated to debugging or troubleshooting
+description: Debug Go code: investigate bugs, analyze test failures, race conditions, panics, deadlocks, stack traces. Trigger for 'why is this broken', 'test failing', 'getting an error'.
 allowed-tools: Read Edit Write Glob Grep Bash(go:*) Bash(golangci-lint:*) Bash(git:*) Bash(dlv:*) Agent
 ---
 

--- a/plugins/go-dev/skills/validate-skills/SKILL.md
+++ b/plugins/go-dev/skills/validate-skills/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: validate-skills
-description: Validate bash/shell code blocks in plugin commands and skills .md files. Trigger when editing markdown plugin files or new commands/skills.
-
+description: "Validate bash/shell code blocks in plugin commands and skills .md files. Trigger when editing markdown plugin files or new commands/skills."
 ---
 
 # Validate Skills

--- a/plugins/go-dev/skills/validate-skills/SKILL.md
+++ b/plugins/go-dev/skills/validate-skills/SKILL.md
@@ -1,13 +1,7 @@
 ---
 name: validate-skills
-description: |
-  WHEN: User is editing .md files in commands/ or skills/ directories, creating new slash commands
-  or skills, modifying fenced bash/shell code blocks in markdown plugin files, asking about
-  validating command files, or discussing shell code correctness in plugin markdown.
-  Also activate when user mentions "shellcheck", "bash -n", "code block validation",
-  "portability check", or has just finished writing/editing a command or skill markdown file.
-  WHEN NOT: Editing Go source code, working with non-markdown files, writing general
-  documentation or README files, questions unrelated to plugin command/skill development
+description: Validate bash/shell code blocks in plugin commands and skills .md files. Trigger when editing markdown plugin files or new commands/skills.
+
 ---
 
 # Validate Skills

--- a/plugins/go-web/skills/htmx/SKILL.md
+++ b/plugins/go-web/skills/htmx/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: htmx
-description: htmx for Go/templ apps: hx-* attributes, swap strategies, triggers, OOB updates, SSE, WebSockets, forms, redirects, debounce, server integration.
-
+description: "htmx for Go/templ apps: hx-* attributes, swap strategies, triggers, OOB updates, SSE, WebSockets, forms, redirects, debounce, server integration."
 ---
 
 # htmx Best Practices & Go/Templ Integration

--- a/plugins/go-web/skills/htmx/SKILL.md
+++ b/plugins/go-web/skills/htmx/SKILL.md
@@ -1,15 +1,7 @@
 ---
 name: htmx
-description: |
-  Use for htmx. If the user's message contains "htmx" or any "hx-" prefixed attribute,
-  activate this skill — no exceptions. Also activate whenever htmx is in the project
-  dependencies or HTML/templ templates contain hx-* attributes, even for follow-up questions
-  that don't explicitly mention htmx (e.g., "why does this swap return 422?", "should this
-  handler return HX-Redirect?"). Provides htmx patterns, Go/templ server integration, swap
-  strategies, triggers, OOB updates, SSE, WebSockets, forms, error handling, redirects,
-  debounce, inline editing, and extensions. Works with html/template + htmx and hybrid
-  SPA setups that use hx-* attributes.
-  WHEN NOT: Pure client-side SPA frameworks (React/Vue/Svelte) without any htmx involvement
+description: htmx for Go/templ apps: hx-* attributes, swap strategies, triggers, OOB updates, SSE, WebSockets, forms, redirects, debounce, server integration.
+
 ---
 
 # htmx Best Practices & Go/Templ Integration

--- a/plugins/go-web/skills/templui/SKILL.md
+++ b/plugins/go-web/skills/templui/SKILL.md
@@ -1,15 +1,7 @@
 ---
 name: templui
-description: |
-  templUI component library for Go templ apps. Invoke for queries mentioning "templUI",
-  ".templ files", or "templ generate". Also activate whenever .templ files are present in
-  the project or templUI is in dependencies — even for implicit questions like "why doesn't
-  this dialog open?" or "how should I build tabs in this Go web app?". Covers: templUI
-  component setup (dropdown, dialog, modal, tabs, toast), Script() template configuration,
-  fixing non-responsive components, Go variable interpolation in JavaScript/onclick handlers
-  within templ files (curly braces as literal text or %7B encoding), HTML-to-templ conversion,
-  and HTMX/Alpine.js integration in templ-based apps.
-  Do NOT use for: React/Vue/Angular/Svelte, standard Go html/template, or non-Go frontend work.
+description: templUI component library for Go templ apps. Use for templUI components, Script() setup, Go variable interpolation in JS, HTML-to-templ conversion, HTMX/Alpine integration.
+
 ---
 
 # templUI & HTMX/Alpine Best Practices

--- a/plugins/go-web/skills/templui/SKILL.md
+++ b/plugins/go-web/skills/templui/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: templui
-description: templUI component library for Go templ apps. Use for templUI components, Script() setup, Go variable interpolation in JS, HTML-to-templ conversion, HTMX/Alpine integration.
-
+description: "templUI component library for Go templ apps. Use for templUI components, Script() setup, Go variable interpolation in JS, HTML-to-templ conversion, HTMX/Alpine integration."
 ---
 
 # templUI & HTMX/Alpine Best Practices

--- a/plugins/go-workflow/skills/address-review/SKILL.md
+++ b/plugins/go-workflow/skills/address-review/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: address-review
-description: Address PR review feedback: fetch comments, fix in code, verify, push, resolve threads, request re-review. Use when reviewers/bots left feedback to apply.
+description: "Address PR review feedback: fetch comments, fix in code, verify, push, resolve threads, request re-review. Use when reviewers/bots left feedback to apply."
 argument-hint: "[PR-number] [--no-watch]"
 allowed-tools: ["Bash", "Read", "Glob", "Grep", "Edit", "Write", "Task", "AskUserQuestion", "Agent"]
 ---

--- a/plugins/go-workflow/skills/address-review/SKILL.md
+++ b/plugins/go-workflow/skills/address-review/SKILL.md
@@ -1,13 +1,6 @@
 ---
 name: address-review
-description: |
-  PR got review comments that need fixing? Use this. Whenever a reviewer or bot left feedback
-  on the user's pull request — comments to address, change requests, unresolved threads — and
-  the user wants those fixed in code, this is the skill. Runs the full response workflow: fetch
-  all review feedback (from teammates, leads, CodeRabbit, Copilot, Greptile, Claude, Codex, or
-  any other reviewer), apply code fixes, verify, push, resolve threads, request re-review.
-  Do NOT use for: creating new PRs, merging or closing PRs, writing your own review of
-  someone's code, or fixing CI/lint errors unrelated to review feedback.
+description: Address PR review feedback: fetch comments, fix in code, verify, push, resolve threads, request re-review. Use when reviewers/bots left feedback to apply.
 argument-hint: "[PR-number] [--no-watch]"
 allowed-tools: ["Bash", "Read", "Glob", "Grep", "Edit", "Write", "Task", "AskUserQuestion", "Agent"]
 ---

--- a/plugins/go-workflow/skills/commit/SKILL.md
+++ b/plugins/go-workflow/skills/commit/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: commit
-description: Create a git commit with auto-generated conventional message. Trigger on 'commit', 'save my work'.
-
+description: "Create a git commit with auto-generated conventional message. Trigger on 'commit', 'save my work'."
 ---
 
 # Commit

--- a/plugins/go-workflow/skills/commit/SKILL.md
+++ b/plugins/go-workflow/skills/commit/SKILL.md
@@ -1,11 +1,7 @@
 ---
 name: commit
-description: |
-  WHEN: User wants to create a git commit with an auto-generated message, says "commit",
-  "commit changes", "save my work", or invokes $commit. Also when finishing a task and
-  needing to commit before pushing.
-  WHEN NOT: User wants to push, create a PR, or do the full ship workflow.
-  Use $create-pr or $ship for those.
+description: Create a git commit with auto-generated conventional message. Trigger on 'commit', 'save my work'.
+
 ---
 
 # Commit

--- a/plugins/go-workflow/skills/complete-issue/SKILL.md
+++ b/plugins/go-workflow/skills/complete-issue/SKILL.md
@@ -1,11 +1,6 @@
 ---
 name: complete-issue
-description: |
-  WHEN: User wants to go from issue to merged PR fully autonomously. Trigger on "complete issue",
-  "do issue #N end to end", "implement and ship issue", "take issue N to completion", or
-  $complete-issue invocation. This is the ultimate pipeline: issue number in → merged PR out.
-  WHEN NOT: User wants to start an issue without shipping ($start-issue), only ship ($ship),
-  only verify ($e2e-verify), or only address review comments ($address-review).
+description: Take a GitHub issue end-to-end: implement, review, e2e verify, merge. Issue number in -> merged PR out.
 argument-hint: "<issue-number> [--skip-coverage] [--coverage-threshold <n>] [--no-agents]"
 allowed-tools: ["Bash", "Read", "Glob", "Grep", "Edit", "Write", "AskUserQuestion", "Agent", "EnterPlanMode", "mcp__chrome-devtools-mcp__navigate_page", "mcp__chrome-devtools-mcp__take_screenshot", "mcp__chrome-devtools-mcp__list_console_messages", "mcp__chrome-devtools-mcp__list_network_requests", "mcp__chrome-devtools-mcp__fill", "mcp__chrome-devtools-mcp__click", "mcp__chrome-devtools-mcp__new_page", "mcp__chrome-devtools-mcp__fill_form", "mcp__chrome-devtools-mcp__wait_for", "mcp__chrome-devtools-mcp__evaluate_script"]
 ---

--- a/plugins/go-workflow/skills/complete-issue/SKILL.md
+++ b/plugins/go-workflow/skills/complete-issue/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: complete-issue
-description: Take a GitHub issue end-to-end: implement, review, e2e verify, merge. Issue number in -> merged PR out.
+description: "Take a GitHub issue end-to-end: implement, review, e2e verify, merge. Issue number in -> merged PR out."
 argument-hint: "<issue-number> [--skip-coverage] [--coverage-threshold <n>] [--no-agents]"
 allowed-tools: ["Bash", "Read", "Glob", "Grep", "Edit", "Write", "AskUserQuestion", "Agent", "EnterPlanMode", "mcp__chrome-devtools-mcp__navigate_page", "mcp__chrome-devtools-mcp__take_screenshot", "mcp__chrome-devtools-mcp__list_console_messages", "mcp__chrome-devtools-mcp__list_network_requests", "mcp__chrome-devtools-mcp__fill", "mcp__chrome-devtools-mcp__click", "mcp__chrome-devtools-mcp__new_page", "mcp__chrome-devtools-mcp__fill_form", "mcp__chrome-devtools-mcp__wait_for", "mcp__chrome-devtools-mcp__evaluate_script"]
 ---

--- a/plugins/go-workflow/skills/create-pr/SKILL.md
+++ b/plugins/go-workflow/skills/create-pr/SKILL.md
@@ -1,10 +1,7 @@
 ---
 name: create-pr
-description: |
-  WHEN: User wants to create a pull request, says "create PR", "open PR", "make a pull request",
-  "submit PR", or invokes $create-pr. Also when finishing implementation and ready to submit
-  for review.
-  WHEN NOT: User wants the full ship workflow with CI watching and merge. Use $ship for that.
+description: Create a pull request following the repo's PR template. Trigger on 'create PR', 'open PR', 'submit PR'.
+
 ---
 
 # Create PR

--- a/plugins/go-workflow/skills/create-pr/SKILL.md
+++ b/plugins/go-workflow/skills/create-pr/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: create-pr
-description: Create a pull request following the repo's PR template. Trigger on 'create PR', 'open PR', 'submit PR'.
-
+description: "Create a pull request following the repo's PR template. Trigger on 'create PR', 'open PR', 'submit PR'."
 ---
 
 # Create PR

--- a/plugins/go-workflow/skills/create-worktree/SKILL.md
+++ b/plugins/go-workflow/skills/create-worktree/SKILL.md
@@ -1,10 +1,7 @@
 ---
 name: create-worktree
-description: |
-  WHEN: User wants to create a git worktree for isolated work on a GitHub issue or PR,
-  says "create worktree", "new worktree", "worktree for issue #N", or invokes
-  $create-worktree with an issue or PR number.
-  WHEN NOT: User wants to remove or clean up worktrees (use $remove-worktree or $prune-worktree).
+description: Create a git worktree for an issue or PR. Trigger on 'create worktree', 'worktree for issue #N'.
+
 ---
 
 # Create Worktree

--- a/plugins/go-workflow/skills/create-worktree/SKILL.md
+++ b/plugins/go-workflow/skills/create-worktree/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: create-worktree
-description: Create a git worktree for an issue or PR. Trigger on 'create worktree', 'worktree for issue #N'.
-
+description: "Create a git worktree for an issue or PR. Trigger on 'create worktree', 'worktree for issue #N'."
 ---
 
 # Create Worktree

--- a/plugins/go-workflow/skills/e2e-verify/SKILL.md
+++ b/plugins/go-workflow/skills/e2e-verify/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: e2e-verify
-description: End-to-end PR verification: rebase, build, browser test, post results. Use to verify a PR before merging or to fix and ship.
+description: "End-to-end PR verification: rebase, build, browser test, post results. Use to verify a PR before merging or to fix and ship."
 argument-hint: "[PR-number] [verify|fix-and-verify|investigate|ship-prep|ship|fix-and-ship]"
 allowed-tools: ["Bash", "Read", "Glob", "Grep", "Edit", "Write", "AskUserQuestion", "Agent", "mcp__chrome-devtools-mcp__navigate_page", "mcp__chrome-devtools-mcp__take_screenshot", "mcp__chrome-devtools-mcp__list_console_messages", "mcp__chrome-devtools-mcp__list_network_requests", "mcp__chrome-devtools-mcp__fill", "mcp__chrome-devtools-mcp__click", "mcp__chrome-devtools-mcp__new_page", "mcp__chrome-devtools-mcp__fill_form", "mcp__chrome-devtools-mcp__wait_for", "mcp__chrome-devtools-mcp__evaluate_script"]
 ---

--- a/plugins/go-workflow/skills/e2e-verify/SKILL.md
+++ b/plugins/go-workflow/skills/e2e-verify/SKILL.md
@@ -1,11 +1,6 @@
 ---
 name: e2e-verify
-description: |
-  WHEN: User wants to verify a PR end-to-end before merging, run E2E browser tests on a PR,
-  investigate implementation gaps, or fix review comments and verify. Trigger on "e2e verify",
-  "verify PR", "e2e test", "fix and verify", "fix and ship", "ship prep", or $e2e-verify invocation.
-  WHEN NOT: User only wants to run unit tests ($verify), only ship without verification ($ship),
-  only address review comments ($address-review), or only run coverage ($coverage).
+description: End-to-end PR verification: rebase, build, browser test, post results. Use to verify a PR before merging or to fix and ship.
 argument-hint: "[PR-number] [verify|fix-and-verify|investigate|ship-prep|ship|fix-and-ship]"
 allowed-tools: ["Bash", "Read", "Glob", "Grep", "Edit", "Write", "AskUserQuestion", "Agent", "mcp__chrome-devtools-mcp__navigate_page", "mcp__chrome-devtools-mcp__take_screenshot", "mcp__chrome-devtools-mcp__list_console_messages", "mcp__chrome-devtools-mcp__list_network_requests", "mcp__chrome-devtools-mcp__fill", "mcp__chrome-devtools-mcp__click", "mcp__chrome-devtools-mcp__new_page", "mcp__chrome-devtools-mcp__fill_form", "mcp__chrome-devtools-mcp__wait_for", "mcp__chrome-devtools-mcp__evaluate_script"]
 ---

--- a/plugins/go-workflow/skills/prune-worktree/SKILL.md
+++ b/plugins/go-workflow/skills/prune-worktree/SKILL.md
@@ -1,10 +1,7 @@
 ---
 name: prune-worktree
-description: |
-  WHEN: User wants to batch-clean all completed git worktrees, says "prune worktrees",
-  "clean up worktrees", "remove old worktrees", or invokes $prune-worktree.
-  WHEN NOT: User wants to remove a single specific worktree (use $remove-worktree) or
-  create a new worktree (use $create-worktree).
+description: Batch-clean all completed git worktrees. Trigger on 'prune worktrees', 'clean up worktrees'.
+
 ---
 
 # Prune Worktrees

--- a/plugins/go-workflow/skills/prune-worktree/SKILL.md
+++ b/plugins/go-workflow/skills/prune-worktree/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: prune-worktree
-description: Batch-clean all completed git worktrees. Trigger on 'prune worktrees', 'clean up worktrees'.
-
+description: "Batch-clean all completed git worktrees. Trigger on 'prune worktrees', 'clean up worktrees'."
 ---
 
 # Prune Worktrees

--- a/plugins/go-workflow/skills/remove-worktree/SKILL.md
+++ b/plugins/go-workflow/skills/remove-worktree/SKILL.md
@@ -1,10 +1,7 @@
 ---
 name: remove-worktree
-description: |
-  WHEN: User wants to remove a specific git worktree, says "remove worktree", "delete worktree",
-  "clean up worktree", or invokes $remove-worktree.
-  WHEN NOT: User wants to batch-remove all completed worktrees (use $prune-worktree) or
-  create a new worktree (use $create-worktree).
+description: Remove a specific git worktree interactively. Trigger on 'remove worktree', 'delete worktree'.
+
 ---
 
 # Remove Worktree

--- a/plugins/go-workflow/skills/remove-worktree/SKILL.md
+++ b/plugins/go-workflow/skills/remove-worktree/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: remove-worktree
-description: Remove a specific git worktree interactively. Trigger on 'remove worktree', 'delete worktree'.
-
+description: "Remove a specific git worktree interactively. Trigger on 'remove worktree', 'delete worktree'."
 ---
 
 # Remove Worktree

--- a/plugins/go-workflow/skills/review-deep/SKILL.md
+++ b/plugins/go-workflow/skills/review-deep/SKILL.md
@@ -1,15 +1,6 @@
 ---
 name: review-deep
-description: |
-  WHEN: User wants a thorough code review with full PR/issue context. Trigger on "review",
-  "deep review", "review my changes", "review this PR", "review from issue", "code review",
-  "check my changes", "what do you think of this code?", or $review-deep invocation. Also
-  auto-trigger when user finishes implementing a feature or bug fix and wants feedback before
-  shipping.
-  WHEN NOT: User wants to address/fix existing review comments from reviewers (use $address-review).
-  User wants to delegate review to another LLM ($codex, /review-loop). User only wants linting
-  ($verify, $lint-fix). User wants to review someone else's PR. User is already mid-fix from
-  a previous review-deep run.
+description: Deep code review with full PR/issue context, then fix findings. Trigger for 'review', 'review my changes', 'check this PR', or after finishing a feature/fix.
 argument-hint: "[PR-number|--issue <N>] [--post] [--scope <hint>]"
 allowed-tools: ["Bash", "Read", "Glob", "Grep", "Edit", "Write", "AskUserQuestion", "Agent"]
 ---

--- a/plugins/go-workflow/skills/review-deep/SKILL.md
+++ b/plugins/go-workflow/skills/review-deep/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: review-deep
-description: Deep code review with full PR/issue context, then fix findings. Trigger for 'review', 'review my changes', 'check this PR', or after finishing a feature/fix.
+description: "Deep code review with full PR/issue context, then fix findings. Trigger for 'review', 'review my changes', 'check this PR', or after finishing a feature/fix."
 argument-hint: "[PR-number|--issue <N>] [--post] [--scope <hint>]"
 allowed-tools: ["Bash", "Read", "Glob", "Grep", "Edit", "Write", "AskUserQuestion", "Agent"]
 ---

--- a/plugins/go-workflow/skills/ship/SKILL.md
+++ b/plugins/go-workflow/skills/ship/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: ship
-description: Ship a PR end-to-end: verify, push, create PR, watch CI, merge. Trigger on 'ship', 'ship it', 'push and merge'.
-
+description: "Ship a PR end-to-end: verify, push, create PR, watch CI, merge. Trigger on 'ship', 'ship it', 'push and merge'."
 ---
 
 # Ship

--- a/plugins/go-workflow/skills/ship/SKILL.md
+++ b/plugins/go-workflow/skills/ship/SKILL.md
@@ -1,10 +1,7 @@
 ---
 name: ship
-description: |
-  WHEN: User wants to ship a PR end-to-end: verify, push, create PR, watch CI, and optionally
-  merge. Trigger on "ship", "ship it", "ship this PR", "push and merge", or $ship invocation.
-  WHEN NOT: User only wants to commit ($commit), only create a PR ($create-pr), or only
-  manage worktrees ($remove-worktree, $prune-worktree).
+description: Ship a PR end-to-end: verify, push, create PR, watch CI, merge. Trigger on 'ship', 'ship it', 'push and merge'.
+
 ---
 
 # Ship

--- a/plugins/go-workflow/skills/start-issue/SKILL.md
+++ b/plugins/go-workflow/skills/start-issue/SKILL.md
@@ -1,11 +1,7 @@
 ---
 name: start-issue
-description: |
-  WHEN: User wants to start working on a GitHub issue, says "start issue", "work on issue",
-  "pick up issue #N", "implement issue", "fix issue #N", "add feature #N", or invokes
-  $start-issue with an issue number. Also when user wants the full issue-to-PR workflow.
-  WHEN NOT: User is already mid-implementation and just wants to commit, create a PR, or
-  manage worktrees. Use $commit, $create-pr, or $ship for those.
+description: Start a GitHub issue end-to-end through PR: fetch, worktree, detect bug vs feature, implement with TDD, verify, submit.
+
 ---
 
 # Start Issue

--- a/plugins/go-workflow/skills/start-issue/SKILL.md
+++ b/plugins/go-workflow/skills/start-issue/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: start-issue
-description: Start a GitHub issue end-to-end through PR: fetch, worktree, detect bug vs feature, implement with TDD, verify, submit.
-
+description: "Start a GitHub issue end-to-end through PR: fetch, worktree, detect bug vs feature, implement with TDD, verify, submit."
 ---
 
 # Start Issue

--- a/plugins/go-workflow/skills/tmux-start/SKILL.md
+++ b/plugins/go-workflow/skills/tmux-start/SKILL.md
@@ -1,10 +1,7 @@
 ---
 name: tmux-start
-description: |
-  WHEN: User wants to start working on an issue in a new tmux window, says "tmux start",
-  "start issue in tmux", "kick off issue #N", or invokes $tmux-start with an issue number.
-  WHEN NOT: User wants to create a worktree without tmux ($create-worktree), or start
-  an issue in the current session ($start-issue).
+description: Start an issue in a new tmux window: create worktree, kick off /start-issue autonomously.
+
 ---
 
 # tmux Start

--- a/plugins/go-workflow/skills/tmux-start/SKILL.md
+++ b/plugins/go-workflow/skills/tmux-start/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: tmux-start
-description: Start an issue in a new tmux window: create worktree, kick off /start-issue autonomously.
-
+description: "Start an issue in a new tmux window: create worktree, kick off /start-issue autonomously."
 ---
 
 # tmux Start

--- a/plugins/gopher-guides/skills/gopher-guides/SKILL.md
+++ b/plugins/gopher-guides/skills/gopher-guides/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: gopher-guides
-description: Authoritative Gopher Guides Go training materials. Trigger when reviewing Go code, asking 'what's idiomatic?', 'how do professionals do this?', or learning Go conventions.
-
+description: "Authoritative Gopher Guides Go training materials. Trigger when reviewing Go code, asking 'what's idiomatic?', 'how do professionals do this?', or learning Go conventions."
 ---
 
 # Gopher Guides Professional Training

--- a/plugins/gopher-guides/skills/gopher-guides/SKILL.md
+++ b/plugins/gopher-guides/skills/gopher-guides/SKILL.md
@@ -1,14 +1,7 @@
 ---
 name: gopher-guides
-description: |
-  WHEN: User asks about Go best practices, idiomatic patterns, how to properly implement
-  something in Go, or wants authoritative training material. Trigger when reviewing Go code,
-  asking "what's the right way to...", "is this correct Go?", "how do professionals do this?",
-  or requesting Go training/learning resources. Also activate when user needs Go code review
-  feedback, wants to understand Go conventions, or is learning Go. This skill provides
-  official Gopher Guides training materials via API — use it whenever professional Go
-  guidance would improve the answer.
-  WHEN NOT: Questions entirely unrelated to Go programming
+description: Authoritative Gopher Guides Go training materials. Trigger when reviewing Go code, asking 'what's idiomatic?', 'how do professionals do this?', or learning Go conventions.
+
 ---
 
 # Gopher Guides Professional Training

--- a/plugins/llm-tools/skills/gemini-image/SKILL.md
+++ b/plugins/llm-tools/skills/gemini-image/SKILL.md
@@ -1,15 +1,7 @@
 ---
 name: gemini-image
-description: |
-  WHEN: User asks to "generate an image", "create an image", "make a picture",
-  "create a graphic", "generate artwork", "make an illustration", "create a visual",
-  "generate a photo", "make a banner", "create a hero image", "generate a thumbnail",
-  "make a logo", "create an icon", "I need an image", or similar image generation
-  requests. Also trigger when user says "use Gemini to make", "AI-generated image",
-  or "image for my blog/site/project".
-  WHEN NOT: User is discussing image formats, image processing code, or asking about
-  image generation conceptually. Do not trigger for screenshots, editing existing
-  images, or when the user explicitly wants DALL-E, Midjourney, or Stable Diffusion.
+description: Generate images via Google Gemini AI. Trigger for image/picture/graphic/illustration/banner/logo/icon generation requests.
+
 ---
 
 # Gemini Image Generation

--- a/plugins/llm-tools/skills/gemini-image/SKILL.md
+++ b/plugins/llm-tools/skills/gemini-image/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: gemini-image
-description: Generate images via Google Gemini AI. Trigger for image/picture/graphic/illustration/banner/logo/icon generation requests.
-
+description: "Generate images via Google Gemini AI. Trigger for image/picture/graphic/illustration/banner/logo/icon generation requests."
 ---
 
 # Gemini Image Generation

--- a/plugins/llm-tools/skills/second-opinion/SKILL.md
+++ b/plugins/llm-tools/skills/second-opinion/SKILL.md
@@ -1,14 +1,7 @@
 ---
 name: second-opinion
-description: |
-  WHEN: User faces complex architectural decisions, asks for "another perspective", "second opinion",
-  "sanity check", "what do you think", or "am I overthinking this". Also trigger when multiple
-  valid approaches exist and user seems uncertain, when reviewing critical/security-sensitive code,
-  evaluating design trade-offs, choosing between libraries/frameworks, debating patterns like
-  microservices vs monolith, or when the user asks "should I..." about a significant technical
-  decision. Proactively suggest getting a second opinion on complex changes even if not asked.
-  WHEN NOT: User has expressed a clear strong preference, explicitly declines other opinions,
-  or is making simple/routine changes
+description: Get a second LLM opinion on complex architectural decisions, design trade-offs, library/framework choices, or security-sensitive code. Trigger when uncertain or facing 'should I' calls.
+
 ---
 
 # Second Opinion Skill

--- a/plugins/llm-tools/skills/second-opinion/SKILL.md
+++ b/plugins/llm-tools/skills/second-opinion/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: second-opinion
-description: Get a second LLM opinion on complex architectural decisions, design trade-offs, library/framework choices, or security-sensitive code. Trigger when uncertain or facing 'should I' calls.
-
+description: "Get a second LLM opinion on complex architectural decisions, design trade-offs, library/framework choices, or security-sensitive code. Trigger when uncertain or facing 'should I' calls."
 ---
 
 # Second Opinion Skill

--- a/plugins/tailwind/skills/tailwind-best-practices/SKILL.md
+++ b/plugins/tailwind/skills/tailwind-best-practices/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: tailwind-best-practices
-description: Tailwind CSS guidance: utility-first patterns, theme/color config, dark mode, responsive design, v4 syntax, content/source paths. Trigger for any Tailwind-related styling question.
-
+description: "Tailwind CSS guidance: utility-first patterns, theme/color config, dark mode, responsive design, v4 syntax, content/source paths. Trigger for any Tailwind-related styling question."
 ---
 
 # Tailwind CSS v4 Best Practices

--- a/plugins/tailwind/skills/tailwind-best-practices/SKILL.md
+++ b/plugins/tailwind/skills/tailwind-best-practices/SKILL.md
@@ -1,16 +1,7 @@
 ---
 name: tailwind-best-practices
-description: |
-  TRIGGER when user mentions "Tailwind", "tailwind", "tw-", or "tailwindcss", or when working
-  in any project that uses Tailwind CSS (tailwind in dependencies, tailwind.config.* present,
-  @tailwind/@import "tailwindcss" directives in CSS files). Also activate for styling questions
-  in Tailwind projects even without explicit "Tailwind" keyword — e.g., "why isn't md:w-1/2
-  applying?", "my @source glob isn't picked up", "responsive design", "dark mode", "custom
-  colors", "spacing", "flex/grid layout". Covers: CSS-to-utility conversion, theme/color
-  configuration, dark mode, content/source path setup, class detection issues, responsive
-  breakpoints, focus-visible/ring accessibility, v3-to-v4 migration, component styling.
-  Must be loaded before using any Tailwind MCP tools.
-  DO NOT trigger for: Bootstrap, Bulma, plain CSS without Tailwind context, or non-styling topics.
+description: Tailwind CSS guidance: utility-first patterns, theme/color config, dark mode, responsive design, v4 syntax, content/source paths. Trigger for any Tailwind-related styling question.
+
 ---
 
 # Tailwind CSS v4 Best Practices

--- a/scripts/build-universal.sh
+++ b/scripts/build-universal.sh
@@ -19,7 +19,7 @@ build_codex() {
     echo "-------------------------"
 
     local codex_dir="$DIST_DIR/codex"
-    mkdir -p "$codex_dir/plugins" "$codex_dir/skills"
+    mkdir -p "$codex_dir/plugins"
 
     # Build Codex plugin packages for plugins with .codex-plugin/plugin.json
     for plugin_dir in "$ROOT_DIR"/plugins/*; do
@@ -36,17 +36,6 @@ build_codex() {
 
     echo "  - Generating marketplace.json"
     generate_codex_marketplace > "$codex_dir/plugins/marketplace.json"
-
-    for skill_dir in "$ROOT_DIR"/plugins/*/skills/*/; do
-        if [[ -f "${skill_dir}SKILL.md" ]]; then
-            skill_name=$(basename "$skill_dir")
-            mkdir -p "$codex_dir/skills/$skill_name"
-            cp "${skill_dir}"*.md "$codex_dir/skills/$skill_name/"
-            if [[ -d "${skill_dir}references" ]]; then
-                cp -R "${skill_dir}references" "$codex_dir/skills/$skill_name/"
-            fi
-        fi
-    done
 
     echo "  - Generating AGENTS.md"
     generate_agents_md > "$codex_dir/AGENTS.md"
@@ -164,16 +153,6 @@ bash <(curl -fsSL https://raw.githubusercontent.com/gopherguides/gopher-ai/main/
 ```
 
 Restart Codex after installation or update. Use `/plugins` to verify.
-
-### Flat Skills (Legacy)
-
-Individual skills can also be installed without the plugin system:
-
-```bash
-cp -r dist/codex/skills/* ~/.codex/skills/
-```
-
-Or use the built-in `$skill-installer` for curated skills.
 
 ## Architecture
 
@@ -421,14 +400,11 @@ print_summary() {
     echo ""
     echo "Installation instructions:"
     echo ""
-    echo "  Codex CLI (user-level plugins):"
-    echo "    ./scripts/install-codex.sh --user"
-    echo ""
     echo "  Codex CLI (repo-level plugins):"
     echo "    ./scripts/install-codex.sh --repo /path/to/your-repo"
     echo ""
-    echo "  Codex CLI (flat skills, legacy):"
-    echo "    cp -r dist/codex/skills/* ~/.codex/skills/"
+    echo "  Codex CLI (clean up legacy ~/.codex/skills/ entries):"
+    echo "    ./scripts/install-codex.sh --cleanup"
     echo ""
     echo "  Gemini CLI:"
     echo "    gemini extensions install ./dist/gemini/gopher-ai-<plugin>"

--- a/scripts/build-universal.sh
+++ b/scripts/build-universal.sh
@@ -137,22 +137,17 @@ To add these plugins to another repo:
 ./scripts/install-codex.sh --repo /path/to/your-repo
 ```
 
-### Global (Personal) Installation and Update
+### Global (Personal) Use
 
-To install or replace the current gopher-ai plugins in your personal Codex setup:
+For Codex, "global" means cloning this repo and running Codex inside it — Codex auto-discovers `.agents/plugins/marketplace.json` and offers the plugins through `/plugins`. There is no flat-skills install path; the previous `--user` mode was removed because it double-loaded skills alongside the marketplace and overflowed Codex's skill metadata budget.
 
-```bash
-./scripts/build-universal.sh
-./scripts/install-codex.sh --user
-```
-
-Or as a one-liner from GitHub:
+If you previously ran `--user`, clean up the legacy entries once:
 
 ```bash
-bash <(curl -fsSL https://raw.githubusercontent.com/gopherguides/gopher-ai/main/scripts/install-codex.sh) --user
+./scripts/install-codex.sh --cleanup
 ```
 
-Restart Codex after installation or update. Use `/plugins` to verify.
+Restart Codex after cleanup. Use `/plugins` to verify.
 
 ## Architecture
 

--- a/scripts/install-all.sh
+++ b/scripts/install-all.sh
@@ -7,7 +7,8 @@
 #
 # Platforms detected:
 #   - Claude Code: updates marketplace repo + plugin cache (requires ~/.claude/)
-#   - Codex CLI:   installs flat skills to ~/.codex/skills/ (requires jq)
+#   - Codex CLI:   cleans up legacy ~/.codex/skills/ entries; plugins are
+#                  discovered via .agents/plugins/marketplace.json (requires jq)
 #   - Gemini CLI:  installs extensions (requires gemini command)
 #
 # Remote install (no clone needed — downloads to tmp, installs, cleans up):
@@ -152,7 +153,10 @@ install_claude() {
 
 install_codex() {
     echo "=== Codex CLI ==="
-    "$ROOT_DIR/scripts/install-codex.sh" --user
+    "$ROOT_DIR/scripts/install-codex.sh" --cleanup
+    echo "  Plugins discovered automatically via .agents/plugins/marketplace.json"
+    echo "  in any repo that ships one. To add to another repo:"
+    echo "    ./scripts/install-codex.sh --repo /path/to/your-repo"
     echo ""
 }
 

--- a/scripts/install-all.sh
+++ b/scripts/install-all.sh
@@ -7,8 +7,9 @@
 #
 # Platforms detected:
 #   - Claude Code: updates marketplace repo + plugin cache (requires ~/.claude/)
-#   - Codex CLI:   cleans up legacy ~/.codex/skills/ entries; plugins are
-#                  discovered via .agents/plugins/marketplace.json (requires jq)
+#   - Codex CLI:   cleans up legacy ~/.codex/skills/ entries (migration only);
+#                  plugins are discovered via .agents/plugins/marketplace.json
+#                  in the repo. Cleanup runs without jq or git.
 #   - Gemini CLI:  installs extensions (requires gemini command)
 #
 # Remote install (no clone needed — downloads to tmp, installs, cleans up):
@@ -299,12 +300,18 @@ main() {
     echo "Done! Installed for: ${platforms[*]}"
     echo ""
     echo "Next steps:"
-    $HAVE_CLAUDE && echo "  Claude Code: Restart Claude Code to reload plugins"
-    $HAVE_CODEX && echo "  Codex CLI:   Migration only — no plugins were installed."
-    $HAVE_CODEX && echo "               To use gopher-ai with Codex: clone this repo and"
-    $HAVE_CODEX && echo "               run 'codex' inside it (auto-discovers the marketplace),"
-    $HAVE_CODEX && echo "               or run scripts/install-codex.sh --repo <target-repo>"
-    $HAVE_GEMINI && echo "  Gemini CLI:  Restart Gemini to load extensions"
+    if $HAVE_CLAUDE; then
+        echo "  Claude Code: Restart Claude Code to reload plugins"
+    fi
+    if $HAVE_CODEX; then
+        echo "  Codex CLI:   Migration only — no plugins were installed."
+        echo "               To use gopher-ai with Codex: clone this repo and"
+        echo "               run 'codex' inside it (auto-discovers the marketplace),"
+        echo "               or run scripts/install-codex.sh --repo <target-repo>"
+    fi
+    if $HAVE_GEMINI; then
+        echo "  Gemini CLI:  Restart Gemini to load extensions"
+    fi
 }
 
 main "$@"

--- a/scripts/install-all.sh
+++ b/scripts/install-all.sh
@@ -68,16 +68,24 @@ bootstrap_if_needed() {
     echo ""
 }
 
-# Check that required tools are available before building
+# Check that the tools required for the platforms we're actually installing
+# are available. Codex --cleanup needs neither jq nor git nor the build step,
+# so we don't gate cleanup-only flows on those.
 check_prerequisites() {
     local missing=()
 
-    if ! command -v jq >/dev/null 2>&1; then
-        missing+=("jq (brew install jq / apt install jq)")
+    # jq is needed by build-universal.sh, which only runs for Claude/Gemini.
+    if $HAVE_CLAUDE || $HAVE_GEMINI; then
+        if ! command -v jq >/dev/null 2>&1; then
+            missing+=("jq (brew install jq / apt install jq)")
+        fi
     fi
 
-    if ! command -v git >/dev/null 2>&1; then
-        missing+=("git")
+    # git is needed for Claude marketplace updates.
+    if $HAVE_CLAUDE; then
+        if ! command -v git >/dev/null 2>&1; then
+            missing+=("git")
+        fi
     fi
 
     if [[ ${#missing[@]} -gt 0 ]]; then
@@ -236,8 +244,8 @@ main() {
     echo ""
 
     bootstrap_if_needed
-    check_prerequisites
     detect_platforms
+    check_prerequisites
 
     if ! $HAVE_CLAUDE && ! $HAVE_CODEX && ! $HAVE_GEMINI; then
         echo "No supported platforms detected."
@@ -267,18 +275,21 @@ main() {
         echo ""
     fi
 
-    # Build once, install everywhere
-    echo "Building distribution..."
-    echo ""
-    if ! "$ROOT_DIR/scripts/build-universal.sh"; then
+    # Build is only needed for Claude and Gemini; Codex --cleanup walks
+    # plugins/*/skills/ directly and doesn't read dist/.
+    if $HAVE_CLAUDE || $HAVE_GEMINI; then
+        echo "Building distribution..."
         echo ""
-        echo "error: build failed." >&2
-        echo "Common fixes:" >&2
-        echo "  - Install jq: brew install jq (macOS) / sudo apt install jq (Linux)" >&2
-        echo "  - Ensure git is installed and available" >&2
-        exit 1
+        if ! "$ROOT_DIR/scripts/build-universal.sh"; then
+            echo ""
+            echo "error: build failed." >&2
+            echo "Common fixes:" >&2
+            echo "  - Install jq: brew install jq (macOS) / sudo apt install jq (Linux)" >&2
+            echo "  - Ensure git is installed and available" >&2
+            exit 1
+        fi
+        echo ""
     fi
-    echo ""
 
     $HAVE_CLAUDE && install_claude
     $HAVE_CODEX && install_codex

--- a/scripts/install-all.sh
+++ b/scripts/install-all.sh
@@ -153,10 +153,14 @@ install_claude() {
 
 install_codex() {
     echo "=== Codex CLI ==="
-    "$ROOT_DIR/scripts/install-codex.sh" --cleanup
-    echo "  Plugins discovered automatically via .agents/plugins/marketplace.json"
-    echo "  in any repo that ships one. To add to another repo:"
-    echo "    ./scripts/install-codex.sh --repo /path/to/your-repo"
+    echo "  Note: gopher-ai for Codex is delivered via the plugin marketplace,"
+    echo "  not via flat skills. This step only removes legacy ~/.codex/skills/"
+    echo "  entries from older --user installs. To use the plugins:"
+    echo "    - Run codex inside this repo (auto-discovered marketplace), OR"
+    echo "    - Run scripts/install-codex.sh --repo /path/to/your-repo to add"
+    echo "      the marketplace to another repo."
+    echo ""
+    "$ROOT_DIR/scripts/install-codex.sh" --cleanup --yes
     echo ""
 }
 

--- a/scripts/install-all.sh
+++ b/scripts/install-all.sh
@@ -99,8 +99,10 @@ detect_platforms() {
         HAVE_CLAUDE=true
     fi
 
-    # Codex needs jq for install-codex.sh (already checked in prerequisites)
-    if command -v jq >/dev/null 2>&1; then
+    # Codex --cleanup doesn't require jq; treat ~/.codex/ as the signal so
+    # the migration runs even on minimal machines. (--repo would require jq,
+    # but install-all.sh only invokes --cleanup.)
+    if [[ -d "$HOME/.codex" ]]; then
         HAVE_CODEX=true
     fi
 
@@ -118,9 +120,9 @@ print_detection() {
     fi
 
     if $HAVE_CODEX; then
-        echo "  Codex CLI ...... found (jq available for install)"
+        echo "  Codex CLI ...... found (~/.codex/ exists — will run cleanup migration only)"
     else
-        echo "  Codex CLI ...... skipped (jq not found — install with: brew install jq)"
+        echo "  Codex CLI ...... skipped (no ~/.codex/ directory)"
     fi
 
     if $HAVE_GEMINI; then
@@ -287,7 +289,10 @@ main() {
     echo ""
     echo "Next steps:"
     $HAVE_CLAUDE && echo "  Claude Code: Restart Claude Code to reload plugins"
-    $HAVE_CODEX && echo "  Codex CLI:   Restart Codex — use /plugins to verify"
+    $HAVE_CODEX && echo "  Codex CLI:   Migration only — no plugins were installed."
+    $HAVE_CODEX && echo "               To use gopher-ai with Codex: clone this repo and"
+    $HAVE_CODEX && echo "               run 'codex' inside it (auto-discovers the marketplace),"
+    $HAVE_CODEX && echo "               or run scripts/install-codex.sh --repo <target-repo>"
     $HAVE_GEMINI && echo "  Gemini CLI:  Restart Gemini to load extensions"
 }
 

--- a/scripts/install-codex.sh
+++ b/scripts/install-codex.sh
@@ -13,7 +13,7 @@ usage() {
     cat <<'EOF'
 Usage:
   scripts/install-codex.sh --repo /path/to/repo
-  scripts/install-codex.sh --cleanup
+  scripts/install-codex.sh --cleanup [--yes]
 
 gopher-ai is delivered to Codex as plugins. Codex discovers them automatically
 when you run inside a repo that has .agents/plugins/marketplace.json (this repo
@@ -22,10 +22,16 @@ ships one). To make them available in another repo, use --repo.
 Options:
   --repo PATH   Install plugins into PATH/plugins and merge entries into
                 PATH/.agents/plugins/marketplace.json. Auto-cleans legacy
-                ~/.codex/skills/ entries left over from older installs.
-  --cleanup     Remove legacy gopher-ai skills from ~/.codex/skills/ that were
-                installed by the old --user mode. Safe — only removes skill
-                directory names that match this repo's plugin skills.
+                ~/.codex/skills/ entries left over from older installs
+                (with --yes semantics — assumes the user wants the migration).
+  --cleanup     Remove legacy gopher-ai skills from ~/.codex/skills/ left over
+                from the old --user mode. Lists candidates and prompts before
+                deleting. A directory is only considered a candidate when its
+                SKILL.md frontmatter has `name: <dirname>` matching one of
+                this repo's skill names — that prevents nuking unrelated user
+                skills that happen to share a generic name like `commit`.
+  --yes         Skip the interactive confirmation in --cleanup (used by
+                install-all.sh and CI flows).
   --help        Show this help text
 
 Notes:
@@ -105,32 +111,95 @@ merge_marketplace() {
     fi
 }
 
+# Reads the SKILL.md frontmatter `name:` field. Returns empty if missing.
+# Tolerant of single quotes, double quotes, and unquoted values; does not
+# require a YAML parser.
+skill_md_name() {
+    local skill_md="$1"
+    [[ -f "$skill_md" ]] || { echo ""; return; }
+    awk '
+        /^---[[:space:]]*$/ { fm++; next }
+        fm == 1 && /^name:[[:space:]]*/ {
+            sub(/^name:[[:space:]]*/, "")
+            gsub(/^["'\'']|["'\'']$/, "")
+            print
+            exit
+        }
+        fm >= 2 { exit }
+    ' "$skill_md"
+}
+
 cleanup_legacy_user_skills() {
+    local assume_yes="${1:-false}"
     local skills_home="$HOME/.codex/skills"
     if [[ ! -d "$skills_home" ]]; then
         echo "no ~/.codex/skills/ directory — nothing to clean up"
         return 0
     fi
 
-    local removed=0
+    # Build candidate list: dirs in ~/.codex/skills/ whose name matches a
+    # gopher-ai skill AND whose SKILL.md frontmatter `name:` confirms it.
+    local candidates=()
+    local skipped_unowned=()
     local skill_dir
     for skill_dir in "$ROOT_DIR"/plugins/*/skills/*/; do
         [[ -d "$skill_dir" ]] || continue
-        local skill_name
+        local skill_name target
         skill_name="$(basename "$skill_dir")"
-        local target="$skills_home/$skill_name"
-        if [[ -d "$target" ]]; then
-            rm -rf "${target:?}"
-            echo "removed legacy skill: $target"
-            removed=$((removed + 1))
+        target="$skills_home/$skill_name"
+        [[ -d "$target" ]] || continue
+
+        local fm_name
+        fm_name="$(skill_md_name "$target/SKILL.md")"
+        if [[ "$fm_name" == "$skill_name" ]]; then
+            candidates+=("$target")
+        else
+            skipped_unowned+=("$target (frontmatter name: '${fm_name:-<missing>}')")
         fi
     done
 
-    if [[ "$removed" -eq 0 ]]; then
-        echo "no legacy gopher-ai skills found in $skills_home"
-    else
-        echo "cleaned up $removed legacy skill directories"
+    if [[ ${#skipped_unowned[@]} -gt 0 ]]; then
+        echo "skipping (not gopher-ai-installed — frontmatter name doesn't match dir):"
+        local entry
+        for entry in "${skipped_unowned[@]}"; do
+            echo "  $entry"
+        done
     fi
+
+    if [[ ${#candidates[@]} -eq 0 ]]; then
+        echo "no legacy gopher-ai skills found in $skills_home"
+        return 0
+    fi
+
+    echo "found ${#candidates[@]} legacy gopher-ai skill(s) to remove:"
+    local target
+    for target in "${candidates[@]}"; do
+        echo "  $target"
+    done
+
+    if [[ "$assume_yes" != "true" ]]; then
+        if [[ ! -t 0 ]]; then
+            echo ""
+            echo "stdin is not a terminal — re-run with --yes to confirm removal."
+            echo "(install-all.sh passes --yes automatically.)"
+            return 1
+        fi
+        local answer=""
+        printf "remove these directories? [y/N] "
+        read -r answer
+        case "$answer" in
+            [Yy]|[Yy][Ee][Ss]) ;;
+            *) echo "aborted — nothing removed."; return 0 ;;
+        esac
+    fi
+
+    local removed=0
+    for target in "${candidates[@]}"; do
+        rm -rf "${target:?}"
+        echo "removed: $target"
+        removed=$((removed + 1))
+    done
+    echo "cleaned up $removed legacy skill director$([ "$removed" -eq 1 ] && echo "y" || echo "ies")"
 }
 
 build_repo_marketplace() {
@@ -179,8 +248,6 @@ write_repo_marketplace() {
 }
 
 main() {
-    require_cmd jq
-
     case "${1:-}" in
         --help|-h)
             usage
@@ -202,19 +269,25 @@ EOF
             ;;
         --cleanup)
             bootstrap_repo
-            cleanup_legacy_user_skills
+            local assume_yes=false
+            if [[ "${2:-}" == "--yes" || "${2:-}" == "-y" ]]; then
+                assume_yes=true
+            fi
+            cleanup_legacy_user_skills "$assume_yes"
             ;;
         --repo)
             if [[ $# -lt 2 ]]; then
                 echo "error: --repo requires a target path" >&2
                 exit 1
             fi
+            require_cmd jq
             ensure_dist
             local target_repo
             target_repo="$(cd "$2" && pwd)"
             copy_repo_plugins "$target_repo"
             write_repo_marketplace "$target_repo"
-            cleanup_legacy_user_skills
+            # --repo is itself an explicit migration action; auto-confirm cleanup.
+            cleanup_legacy_user_skills "true"
             ;;
         *)
             usage >&2

--- a/scripts/install-codex.sh
+++ b/scripts/install-codex.sh
@@ -12,15 +12,27 @@ BOOTSTRAP_DIR=""
 usage() {
     cat <<'EOF'
 Usage:
-  scripts/install-codex.sh --user
   scripts/install-codex.sh --repo /path/to/repo
+  scripts/install-codex.sh --cleanup
 
-Installs or updates gopher-ai Codex plugins using the current plugin-based layout.
+gopher-ai is delivered to Codex as plugins. Codex discovers them automatically
+when you run inside a repo that has .agents/plugins/marketplace.json (this repo
+ships one). To make them available in another repo, use --repo.
 
 Options:
-  --user        Install skills into ~/.codex/skills/ for global availability
-  --repo PATH   Install into PATH/plugins and merge entries into PATH/.agents/plugins/marketplace.json
+  --repo PATH   Install plugins into PATH/plugins and merge entries into
+                PATH/.agents/plugins/marketplace.json. Auto-cleans legacy
+                ~/.codex/skills/ entries left over from older installs.
+  --cleanup     Remove legacy gopher-ai skills from ~/.codex/skills/ that were
+                installed by the old --user mode. Safe — only removes skill
+                directory names that match this repo's plugin skills.
   --help        Show this help text
+
+Notes:
+  --user has been removed. The old mode copied skills into ~/.codex/skills/,
+  which double-loaded them alongside the plugin marketplace and overflowed the
+  Codex skill metadata budget. Run --cleanup once on machines that used --user
+  before, then rely on the marketplace for skill discovery.
 EOF
 }
 
@@ -93,19 +105,32 @@ merge_marketplace() {
     fi
 }
 
-install_user_skills() {
+cleanup_legacy_user_skills() {
     local skills_home="$HOME/.codex/skills"
-    mkdir -p "$skills_home"
+    if [[ ! -d "$skills_home" ]]; then
+        echo "no ~/.codex/skills/ directory — nothing to clean up"
+        return 0
+    fi
 
+    local removed=0
     local skill_dir
-    for skill_dir in "$DIST_DIR"/skills/*; do
+    for skill_dir in "$ROOT_DIR"/plugins/*/skills/*/; do
         [[ -d "$skill_dir" ]] || continue
         local skill_name
         skill_name="$(basename "$skill_dir")"
-        rm -rf "${skills_home:?}/$skill_name"
-        cp -R "$skill_dir" "$skills_home/"
-        echo "installed skill: $skills_home/$skill_name"
+        local target="$skills_home/$skill_name"
+        if [[ -d "$target" ]]; then
+            rm -rf "${target:?}"
+            echo "removed legacy skill: $target"
+            removed=$((removed + 1))
+        fi
     done
+
+    if [[ "$removed" -eq 0 ]]; then
+        echo "no legacy gopher-ai skills found in $skills_home"
+    else
+        echo "cleaned up $removed legacy skill directories"
+    fi
 }
 
 build_repo_marketplace() {
@@ -161,8 +186,23 @@ main() {
             usage
             ;;
         --user)
-            ensure_dist
-            install_user_skills
+            cat >&2 <<'EOF'
+error: --user mode has been removed.
+
+The old --user mode copied skills into ~/.codex/skills/, which conflicted
+with the plugin marketplace and overflowed Codex's skill metadata budget.
+gopher-ai is now delivered as Codex plugins only.
+
+To migrate:
+  1. ./scripts/install-codex.sh --cleanup     # remove legacy ~/.codex/skills/ entries
+  2. Run codex inside a repo that has .agents/plugins/marketplace.json
+     (this repo ships one), or use --repo to add the marketplace to another repo.
+EOF
+            exit 1
+            ;;
+        --cleanup)
+            bootstrap_repo
+            cleanup_legacy_user_skills
             ;;
         --repo)
             if [[ $# -lt 2 ]]; then
@@ -174,6 +214,7 @@ main() {
             target_repo="$(cd "$2" && pwd)"
             copy_repo_plugins "$target_repo"
             write_repo_marketplace "$target_repo"
+            cleanup_legacy_user_skills
             ;;
         *)
             usage >&2

--- a/scripts/install-codex.sh
+++ b/scripts/install-codex.sh
@@ -26,10 +26,13 @@ Options:
                 (with --yes semantics — assumes the user wants the migration).
   --cleanup     Remove legacy gopher-ai skills from ~/.codex/skills/ left over
                 from the old --user mode. Lists candidates and prompts before
-                deleting. A directory is only considered a candidate when its
-                SKILL.md frontmatter has `name: <dirname>` matching one of
-                this repo's skill names — that prevents nuking unrelated user
-                skills that happen to share a generic name like `commit`.
+                deleting. Two ownership gates protect user-authored skills:
+                (1) the SKILL.md frontmatter must have `name: <dirname>`, and
+                (2) its content must hash-match a current or historical
+                gopher-ai-shipped version of that file (via git history when
+                this script runs from a clone, or just current sources in
+                bootstrap mode). A user-authored skill at a generic name like
+                `commit` or `ship` will fail the content check and be kept.
   --yes         Skip the interactive confirmation in --cleanup (used by
                 install-all.sh and CI flows).
   --help        Show this help text
@@ -129,6 +132,49 @@ skill_md_name() {
     ' "$skill_md"
 }
 
+# Returns 0 if the candidate file's content matches some historical or current
+# version of the corresponding gopher-ai SKILL.md. Uses git history when this
+# script is running from a real clone (with .git/), so old --user installs of
+# previous gopher-ai versions still match. In bootstrap mode (curl-piped tarball,
+# no .git/), falls back to comparing against just the current source.
+file_matches_known_skill_content() {
+    local skill_name="$1"
+    local candidate_file="$2"
+    [[ -f "$candidate_file" ]] || return 1
+
+    local candidate_hash
+    candidate_hash="$(sha256sum "$candidate_file" 2>/dev/null | awk '{print $1}')"
+    [[ -n "$candidate_hash" ]] || return 1
+
+    # Always include current files (covers bootstrap mode and avoids requiring git
+    # for users who installed the latest version).
+    local p
+    for p in "$ROOT_DIR"/plugins/*/skills/"$skill_name"/SKILL.md; do
+        [[ -f "$p" ]] || continue
+        local h
+        h="$(sha256sum "$p" 2>/dev/null | awk '{print $1}')"
+        [[ "$h" == "$candidate_hash" ]] && return 0
+    done
+
+    # If we have git history, also check every historical blob for any path
+    # matching plugins/*/skills/<name>/SKILL.md.
+    if (cd "$ROOT_DIR" && [[ -d .git ]]) 2>/dev/null; then
+        local blobs
+        blobs="$(cd "$ROOT_DIR" && git rev-list --objects --all 2>/dev/null \
+            | awk -v name="$skill_name" '$2 ~ "^plugins/[^/]+/skills/"name"/SKILL.md$" {print $1}' \
+            | sort -u)"
+        if [[ -n "$blobs" ]]; then
+            local blob blob_hash
+            while IFS= read -r blob; do
+                [[ -n "$blob" ]] || continue
+                blob_hash="$(cd "$ROOT_DIR" && git cat-file blob "$blob" 2>/dev/null | sha256sum 2>/dev/null | awk '{print $1}')"
+                [[ "$blob_hash" == "$candidate_hash" ]] && return 0
+            done <<<"$blobs"
+        fi
+    fi
+    return 1
+}
+
 cleanup_legacy_user_skills() {
     local assume_yes="${1:-false}"
     local skills_home="$HOME/.codex/skills"
@@ -137,33 +183,60 @@ cleanup_legacy_user_skills() {
         return 0
     fi
 
+    local has_git_history=false
+    if (cd "$ROOT_DIR" && [[ -d .git ]]) 2>/dev/null; then
+        has_git_history=true
+    fi
+
     # Build candidate list: dirs in ~/.codex/skills/ whose name matches a
-    # gopher-ai skill AND whose SKILL.md frontmatter `name:` confirms it.
+    # gopher-ai skill, whose SKILL.md frontmatter `name:` confirms it, AND
+    # whose SKILL.md content matches a historical or current gopher-ai shipped
+    # version. The content check is the hard ownership signal — without it,
+    # generic names like `commit` or `ship` would falsely match user-authored
+    # skills that happen to share a name and define `name:` matching the dir.
     local candidates=()
-    local skipped_unowned=()
+    local skipped_name_mismatch=()
+    local skipped_content_mismatch=()
     local skill_dir
     for skill_dir in "$ROOT_DIR"/plugins/*/skills/*/; do
         [[ -d "$skill_dir" ]] || continue
-        local skill_name target
+        local skill_name target skill_md
         skill_name="$(basename "$skill_dir")"
         target="$skills_home/$skill_name"
         [[ -d "$target" ]] || continue
+        skill_md="$target/SKILL.md"
 
         local fm_name
-        fm_name="$(skill_md_name "$target/SKILL.md")"
-        if [[ "$fm_name" == "$skill_name" ]]; then
+        fm_name="$(skill_md_name "$skill_md")"
+        if [[ "$fm_name" != "$skill_name" ]]; then
+            skipped_name_mismatch+=("$target (frontmatter name: '${fm_name:-<missing>}')")
+            continue
+        fi
+        if file_matches_known_skill_content "$skill_name" "$skill_md"; then
             candidates+=("$target")
         else
-            skipped_unowned+=("$target (frontmatter name: '${fm_name:-<missing>}')")
+            skipped_content_mismatch+=("$target")
         fi
     done
 
-    if [[ ${#skipped_unowned[@]} -gt 0 ]]; then
-        echo "skipping (not gopher-ai-installed — frontmatter name doesn't match dir):"
+    if [[ ${#skipped_name_mismatch[@]} -gt 0 ]]; then
+        echo "skipping (frontmatter name doesn't match directory — not gopher-ai-installed):"
         local entry
-        for entry in "${skipped_unowned[@]}"; do
+        for entry in "${skipped_name_mismatch[@]}"; do
             echo "  $entry"
         done
+    fi
+
+    if [[ ${#skipped_content_mismatch[@]} -gt 0 ]]; then
+        echo "skipping (SKILL.md content does not match any gopher-ai-shipped version — likely user-authored):"
+        local entry
+        for entry in "${skipped_content_mismatch[@]}"; do
+            echo "  $entry"
+        done
+        if [[ "$has_git_history" == "false" ]]; then
+            echo "  (note: running without git history; only current sources were checked."
+            echo "   to migrate stale --user installs, clone the repo and run --cleanup from there.)"
+        fi
     fi
 
     if [[ ${#candidates[@]} -eq 0 ]]; then

--- a/scripts/test-installation.sh
+++ b/scripts/test-installation.sh
@@ -160,27 +160,42 @@ else
 fi
 rm -rf "$TMP_REPO"
 
-echo -n "Codex installer --cleanup --yes removes only matching skills... "
+echo -n "Codex installer --cleanup --yes removes only owned skills... "
 TMP_HOME=$(mktemp -d)
 SKILLS_DIR="$TMP_HOME/.codex/skills"
 mkdir -p "$SKILLS_DIR"
-# Seed:
-#   1. A gopher-ai skill name with matching frontmatter — should be removed.
-#   2. A gopher-ai skill name with NON-matching frontmatter — should be kept
-#      (user redefined a skill that happens to share a generic name).
-#   3. A user-custom skill name — should be kept.
+# Seed four scenarios:
+#   1. SEEDED_OWNED         — gopher-ai name + matching content (gopher-ai SKILL.md verbatim)
+#                             → MUST be removed.
+#   2. SEEDED_NAME_DRIFT    — gopher-ai name + non-matching frontmatter name
+#                             → MUST be kept (frontmatter check is the first gate).
+#   3. SEEDED_CONTENT_DRIFT — gopher-ai name + matching frontmatter name + DIFFERENT content
+#                             → MUST be kept (content fingerprint catches user-authored
+#                             skills with generic names like `commit` or `ship`).
+#   4. user-custom-skill    — unrelated name
+#                             → MUST be kept.
 SEEDED_OWNED=""
-SEEDED_DISGUISED=""
+SEEDED_NAME_DRIFT=""
+SEEDED_CONTENT_DRIFT=""
+COUNT=0
 for skill_dir in "$ROOT_DIR"/plugins/*/skills/*/; do
   skill_name=$(basename "$skill_dir")
+  COUNT=$((COUNT + 1))
   if [ -z "$SEEDED_OWNED" ]; then
     SEEDED_OWNED="$skill_name"
     mkdir -p "$SKILLS_DIR/$skill_name"
-    printf -- "---\nname: %s\ndescription: legacy gopher-ai install\n---\n\nbody\n" "$skill_name" > "$SKILLS_DIR/$skill_name/SKILL.md"
-  elif [ -z "$SEEDED_DISGUISED" ]; then
-    SEEDED_DISGUISED="$skill_name"
+    # Copy verbatim so content matches a current shipped version.
+    cp "$skill_dir/SKILL.md" "$SKILLS_DIR/$skill_name/SKILL.md"
+  elif [ -z "$SEEDED_NAME_DRIFT" ]; then
+    SEEDED_NAME_DRIFT="$skill_name"
     mkdir -p "$SKILLS_DIR/$skill_name"
     printf -- "---\nname: my-personal-%s\ndescription: user override\n---\n\nbody\n" "$skill_name" > "$SKILLS_DIR/$skill_name/SKILL.md"
+  elif [ -z "$SEEDED_CONTENT_DRIFT" ]; then
+    SEEDED_CONTENT_DRIFT="$skill_name"
+    mkdir -p "$SKILLS_DIR/$skill_name"
+    # Frontmatter name matches dir name (a user could plausibly write this for
+    # a generic name like `commit`), but content is NOT any version we shipped.
+    printf -- "---\nname: %s\ndescription: my own custom skill\n---\n\n# My %s\n\nUnrelated body content.\n" "$skill_name" "$skill_name" > "$SKILLS_DIR/$skill_name/SKILL.md"
     break
   fi
 done
@@ -192,10 +207,14 @@ if ! HOME="$TMP_HOME" bash "$ROOT_DIR/scripts/install-codex.sh" --cleanup --yes 
   sed -n '1,120p' /tmp/gopher-ai-install-cleanup.log
   ERRORS=$((ERRORS + 1))
 elif [ -d "$SKILLS_DIR/$SEEDED_OWNED" ]; then
-  echo "FAIL (seeded gopher-ai skill not removed: $SEEDED_OWNED)"
+  echo "FAIL (owned gopher-ai skill not removed: $SEEDED_OWNED)"
+  sed -n '1,40p' /tmp/gopher-ai-install-cleanup.log
   ERRORS=$((ERRORS + 1))
-elif [ ! -d "$SKILLS_DIR/$SEEDED_DISGUISED" ]; then
-  echo "FAIL (cleanup wrongly removed disguised user skill: $SEEDED_DISGUISED)"
+elif [ ! -d "$SKILLS_DIR/$SEEDED_NAME_DRIFT" ]; then
+  echo "FAIL (cleanup wrongly removed name-drifted user skill: $SEEDED_NAME_DRIFT)"
+  ERRORS=$((ERRORS + 1))
+elif [ ! -d "$SKILLS_DIR/$SEEDED_CONTENT_DRIFT" ]; then
+  echo "FAIL (cleanup wrongly removed content-drifted user skill: $SEEDED_CONTENT_DRIFT)"
   ERRORS=$((ERRORS + 1))
 elif [ ! -d "$SKILLS_DIR/user-custom-skill" ]; then
   echo "FAIL (cleanup wrongly removed user-custom-skill)"
@@ -214,7 +233,8 @@ for skill_dir in "$ROOT_DIR"/plugins/*/skills/*/; do
   skill_name=$(basename "$skill_dir")
   SEEDED_OWNED="$skill_name"
   mkdir -p "$SKILLS_DIR/$skill_name"
-  printf -- "---\nname: %s\ndescription: legacy\n---\n" "$skill_name" > "$SKILLS_DIR/$skill_name/SKILL.md"
+  # Verbatim copy so content fingerprint check recognizes it as gopher-ai-owned.
+  cp "$skill_dir/SKILL.md" "$SKILLS_DIR/$skill_name/SKILL.md"
   break
 done
 # Pipe </dev/null so stdin is not a tty; expect non-zero exit and skill kept.
@@ -237,7 +257,8 @@ for skill_dir in "$ROOT_DIR"/plugins/*/skills/*/; do
   skill_name=$(basename "$skill_dir")
   SEEDED_OWNED="$skill_name"
   mkdir -p "$TMP_HOME/.codex/skills/$skill_name"
-  printf -- "---\nname: %s\ndescription: legacy\n---\n" "$skill_name" > "$TMP_HOME/.codex/skills/$skill_name/SKILL.md"
+  # Verbatim copy so content fingerprint check recognizes it as gopher-ai-owned.
+  cp "$skill_dir/SKILL.md" "$TMP_HOME/.codex/skills/$skill_name/SKILL.md"
   break
 done
 JQ_PATH="$(command -v jq 2>/dev/null || true)"
@@ -246,7 +267,10 @@ if [ -n "$JQ_PATH" ]; then
   # the test — no jq, no gemini — so the test result reflects installer
   # behavior rather than what else happens to be on the developer's PATH.
   TMP_BIN=$(mktemp -d)
-  for cmd in bash sh awk sed grep find mkdir rm cp mktemp printf cat dirname basename tr head tail xargs sleep date wc; do
+  # Note: jq and gemini are intentionally excluded to simulate a minimal
+  # Codex-only machine. sha256sum, git, and sort are needed for the new
+  # content-fingerprint cleanup logic.
+  for cmd in bash sh awk sed grep find mkdir rm cp mktemp printf cat dirname basename tr head tail xargs sleep date wc sha256sum git sort uniq stat ln readlink; do
     cmd_path="$(command -v "$cmd" 2>/dev/null || true)"
     [ -n "$cmd_path" ] && ln -s "$cmd_path" "$TMP_BIN/$cmd"
   done

--- a/scripts/test-installation.sh
+++ b/scripts/test-installation.sh
@@ -160,40 +160,57 @@ else
 fi
 rm -rf "$TMP_REPO"
 
-echo -n "Standalone Codex installer bootstraps correctly... "
+echo -n "Codex installer --cleanup removes legacy skills... "
 TMP_HOME=$(mktemp -d)
-TMP_SCRIPT_DIR=$(mktemp -d)
-TMP_ARCHIVE_DIR=$(mktemp -d)
-cp "$ROOT_DIR/scripts/install-codex.sh" "$TMP_SCRIPT_DIR/install-codex.sh"
-cp -R "$ROOT_DIR" "$TMP_ARCHIVE_DIR/gopher-ai-main"
-tar -czf "$TMP_ARCHIVE_DIR/gopher-ai-main.tar.gz" -C "$TMP_ARCHIVE_DIR" gopher-ai-main
-if ! HOME="$TMP_HOME" GOPHER_AI_ARCHIVE_URL="file://$TMP_ARCHIVE_DIR/gopher-ai-main.tar.gz" bash "$TMP_SCRIPT_DIR/install-codex.sh" --user >/tmp/gopher-ai-install-user.log 2>&1; then
+SKILLS_DIR="$TMP_HOME/.codex/skills"
+mkdir -p "$SKILLS_DIR"
+# Seed the fake home with one legacy skill name from the repo and one unrelated
+# skill that must NOT be removed.
+SEEDED_SKILL=""
+for skill_dir in "$ROOT_DIR"/plugins/*/skills/*/; do
+  skill_name=$(basename "$skill_dir")
+  mkdir -p "$SKILLS_DIR/$skill_name"
+  echo "stub" > "$SKILLS_DIR/$skill_name/SKILL.md"
+  SEEDED_SKILL="$skill_name"
+  break
+done
+mkdir -p "$SKILLS_DIR/user-custom-skill"
+echo "user content" > "$SKILLS_DIR/user-custom-skill/SKILL.md"
+
+if ! HOME="$TMP_HOME" bash "$ROOT_DIR/scripts/install-codex.sh" --cleanup >/tmp/gopher-ai-install-cleanup.log 2>&1; then
   echo "FAIL"
-  sed -n '1,120p' /tmp/gopher-ai-install-user.log
+  sed -n '1,120p' /tmp/gopher-ai-install-cleanup.log
+  ERRORS=$((ERRORS + 1))
+elif [ -d "$SKILLS_DIR/$SEEDED_SKILL" ]; then
+  echo "FAIL (seeded gopher-ai skill not removed: $SEEDED_SKILL)"
+  ERRORS=$((ERRORS + 1))
+elif [ ! -d "$SKILLS_DIR/user-custom-skill" ]; then
+  echo "FAIL (cleanup wrongly removed user-custom-skill)"
   ERRORS=$((ERRORS + 1))
 else
-  SKILLS_DIR="$TMP_HOME/.codex/skills"
-  CODEX_DIST_DIR="$ROOT_DIR/dist/codex"
-  # Check that dist skills were copied to ~/.codex/skills/
-  DIST_SKILL_COUNT=$(find "$CODEX_DIST_DIR/skills" -mindepth 1 -maxdepth 1 -type d 2>/dev/null | wc -l)
-  INSTALLED_SKILL_COUNT=$(find "$SKILLS_DIR" -mindepth 1 -maxdepth 1 -type d 2>/dev/null | wc -l)
-  MISSING_SKILLS=""
-  for skill_dir in "$CODEX_DIST_DIR"/skills/*/; do
-    skill_name=$(basename "$skill_dir")
-    if [ ! -f "$SKILLS_DIR/$skill_name/SKILL.md" ]; then
-      MISSING_SKILLS="$MISSING_SKILLS $skill_name"
-    fi
-  done
-  if [ "$INSTALLED_SKILL_COUNT" -lt "$DIST_SKILL_COUNT" ] || [ -n "$MISSING_SKILLS" ]; then
-    echo "FAIL"
-    [ "$INSTALLED_SKILL_COUNT" -lt "$DIST_SKILL_COUNT" ] && echo "expected $DIST_SKILL_COUNT skills, got $INSTALLED_SKILL_COUNT"
-    [ -n "$MISSING_SKILLS" ] && echo "missing skills:$MISSING_SKILLS"
-    ERRORS=$((ERRORS + 1))
-  else
-    echo "OK ($INSTALLED_SKILL_COUNT skills)"
-  fi
+  echo "OK"
 fi
-rm -rf "$TMP_HOME" "$TMP_SCRIPT_DIR" "$TMP_ARCHIVE_DIR"
+rm -rf "$TMP_HOME"
+
+echo -n "Codex --user mode is rejected with migration message... "
+if HOME="$(mktemp -d)" bash "$ROOT_DIR/scripts/install-codex.sh" --user >/tmp/gopher-ai-user-rejected.log 2>&1; then
+  echo "FAIL (--user should exit non-zero)"
+  ERRORS=$((ERRORS + 1))
+elif ! grep -q "removed" /tmp/gopher-ai-user-rejected.log; then
+  echo "FAIL (no migration message)"
+  sed -n '1,40p' /tmp/gopher-ai-user-rejected.log
+  ERRORS=$((ERRORS + 1))
+else
+  echo "OK"
+fi
+
+echo -n "Build no longer emits dist/codex/skills/... "
+if [ -d "$ROOT_DIR/dist/codex/skills" ]; then
+  echo "FAIL (dist/codex/skills/ still exists after build)"
+  ERRORS=$((ERRORS + 1))
+else
+  echo "OK"
+fi
 
 echo ""
 if [ $ERRORS -gt 0 ]; then

--- a/scripts/test-installation.sh
+++ b/scripts/test-installation.sh
@@ -242,10 +242,15 @@ for skill_dir in "$ROOT_DIR"/plugins/*/skills/*/; do
 done
 JQ_PATH="$(command -v jq 2>/dev/null || true)"
 if [ -n "$JQ_PATH" ]; then
-  JQ_DIR="$(dirname "$JQ_PATH")"
-  SAFE_PATH=$(printf '%s' "$PATH" | tr ':' '\n' | grep -v "^${JQ_DIR}\$" | tr '\n' ':' | sed 's/:$//')
-  # Force Codex-only: no ~/.claude/ in TMP_HOME, and gemini binary won't be reachable.
-  if HOME="$TMP_HOME" PATH="$SAFE_PATH" bash "$ROOT_DIR/scripts/install-all.sh" --force </dev/null >/tmp/gopher-ai-installall-nojq.log 2>&1; then
+  # Build a controlled PATH that contains only the directories required for
+  # the test — no jq, no gemini — so the test result reflects installer
+  # behavior rather than what else happens to be on the developer's PATH.
+  TMP_BIN=$(mktemp -d)
+  for cmd in bash sh awk sed grep find mkdir rm cp mktemp printf cat dirname basename tr head tail xargs sleep date wc; do
+    cmd_path="$(command -v "$cmd" 2>/dev/null || true)"
+    [ -n "$cmd_path" ] && ln -s "$cmd_path" "$TMP_BIN/$cmd"
+  done
+  if HOME="$TMP_HOME" PATH="$TMP_BIN" bash "$ROOT_DIR/scripts/install-all.sh" --force </dev/null >/tmp/gopher-ai-installall-nojq.log 2>&1; then
     if [ -d "$TMP_HOME/.codex/skills/$SEEDED_OWNED" ]; then
       echo "FAIL (cleanup did not run)"
       ERRORS=$((ERRORS + 1))
@@ -257,6 +262,7 @@ if [ -n "$JQ_PATH" ]; then
     sed -n '1,40p' /tmp/gopher-ai-installall-nojq.log
     ERRORS=$((ERRORS + 1))
   fi
+  rm -rf "$TMP_BIN"
 else
   echo "SKIP (jq not installed)"
 fi

--- a/scripts/test-installation.sh
+++ b/scripts/test-installation.sh
@@ -229,6 +229,39 @@ else
 fi
 rm -rf "$TMP_HOME"
 
+echo -n "install-all.sh runs Codex cleanup without jq on minimal machine... "
+TMP_HOME=$(mktemp -d)
+mkdir -p "$TMP_HOME/.codex/skills"
+SEEDED_OWNED=""
+for skill_dir in "$ROOT_DIR"/plugins/*/skills/*/; do
+  skill_name=$(basename "$skill_dir")
+  SEEDED_OWNED="$skill_name"
+  mkdir -p "$TMP_HOME/.codex/skills/$skill_name"
+  printf -- "---\nname: %s\ndescription: legacy\n---\n" "$skill_name" > "$TMP_HOME/.codex/skills/$skill_name/SKILL.md"
+  break
+done
+JQ_PATH="$(command -v jq 2>/dev/null || true)"
+if [ -n "$JQ_PATH" ]; then
+  JQ_DIR="$(dirname "$JQ_PATH")"
+  SAFE_PATH=$(printf '%s' "$PATH" | tr ':' '\n' | grep -v "^${JQ_DIR}\$" | tr '\n' ':' | sed 's/:$//')
+  # Force Codex-only: no ~/.claude/ in TMP_HOME, and gemini binary won't be reachable.
+  if HOME="$TMP_HOME" PATH="$SAFE_PATH" bash "$ROOT_DIR/scripts/install-all.sh" --force </dev/null >/tmp/gopher-ai-installall-nojq.log 2>&1; then
+    if [ -d "$TMP_HOME/.codex/skills/$SEEDED_OWNED" ]; then
+      echo "FAIL (cleanup did not run)"
+      ERRORS=$((ERRORS + 1))
+    else
+      echo "OK"
+    fi
+  else
+    echo "FAIL (install-all.sh exited non-zero on Codex-only/no-jq machine)"
+    sed -n '1,40p' /tmp/gopher-ai-installall-nojq.log
+    ERRORS=$((ERRORS + 1))
+  fi
+else
+  echo "SKIP (jq not installed)"
+fi
+rm -rf "$TMP_HOME"
+
 echo -n "Codex --cleanup works without jq installed... "
 TMP_HOME=$(mktemp -d)
 SKILLS_DIR="$TMP_HOME/.codex/skills"

--- a/scripts/test-installation.sh
+++ b/scripts/test-installation.sh
@@ -160,35 +160,95 @@ else
 fi
 rm -rf "$TMP_REPO"
 
-echo -n "Codex installer --cleanup removes legacy skills... "
+echo -n "Codex installer --cleanup --yes removes only matching skills... "
 TMP_HOME=$(mktemp -d)
 SKILLS_DIR="$TMP_HOME/.codex/skills"
 mkdir -p "$SKILLS_DIR"
-# Seed the fake home with one legacy skill name from the repo and one unrelated
-# skill that must NOT be removed.
-SEEDED_SKILL=""
+# Seed:
+#   1. A gopher-ai skill name with matching frontmatter — should be removed.
+#   2. A gopher-ai skill name with NON-matching frontmatter — should be kept
+#      (user redefined a skill that happens to share a generic name).
+#   3. A user-custom skill name — should be kept.
+SEEDED_OWNED=""
+SEEDED_DISGUISED=""
 for skill_dir in "$ROOT_DIR"/plugins/*/skills/*/; do
   skill_name=$(basename "$skill_dir")
-  mkdir -p "$SKILLS_DIR/$skill_name"
-  echo "stub" > "$SKILLS_DIR/$skill_name/SKILL.md"
-  SEEDED_SKILL="$skill_name"
-  break
+  if [ -z "$SEEDED_OWNED" ]; then
+    SEEDED_OWNED="$skill_name"
+    mkdir -p "$SKILLS_DIR/$skill_name"
+    printf -- "---\nname: %s\ndescription: legacy gopher-ai install\n---\n\nbody\n" "$skill_name" > "$SKILLS_DIR/$skill_name/SKILL.md"
+  elif [ -z "$SEEDED_DISGUISED" ]; then
+    SEEDED_DISGUISED="$skill_name"
+    mkdir -p "$SKILLS_DIR/$skill_name"
+    printf -- "---\nname: my-personal-%s\ndescription: user override\n---\n\nbody\n" "$skill_name" > "$SKILLS_DIR/$skill_name/SKILL.md"
+    break
+  fi
 done
 mkdir -p "$SKILLS_DIR/user-custom-skill"
-echo "user content" > "$SKILLS_DIR/user-custom-skill/SKILL.md"
+printf -- "---\nname: user-custom-skill\ndescription: stays\n---\n" > "$SKILLS_DIR/user-custom-skill/SKILL.md"
 
-if ! HOME="$TMP_HOME" bash "$ROOT_DIR/scripts/install-codex.sh" --cleanup >/tmp/gopher-ai-install-cleanup.log 2>&1; then
+if ! HOME="$TMP_HOME" bash "$ROOT_DIR/scripts/install-codex.sh" --cleanup --yes >/tmp/gopher-ai-install-cleanup.log 2>&1; then
   echo "FAIL"
   sed -n '1,120p' /tmp/gopher-ai-install-cleanup.log
   ERRORS=$((ERRORS + 1))
-elif [ -d "$SKILLS_DIR/$SEEDED_SKILL" ]; then
-  echo "FAIL (seeded gopher-ai skill not removed: $SEEDED_SKILL)"
+elif [ -d "$SKILLS_DIR/$SEEDED_OWNED" ]; then
+  echo "FAIL (seeded gopher-ai skill not removed: $SEEDED_OWNED)"
+  ERRORS=$((ERRORS + 1))
+elif [ ! -d "$SKILLS_DIR/$SEEDED_DISGUISED" ]; then
+  echo "FAIL (cleanup wrongly removed disguised user skill: $SEEDED_DISGUISED)"
   ERRORS=$((ERRORS + 1))
 elif [ ! -d "$SKILLS_DIR/user-custom-skill" ]; then
   echo "FAIL (cleanup wrongly removed user-custom-skill)"
   ERRORS=$((ERRORS + 1))
 else
   echo "OK"
+fi
+rm -rf "$TMP_HOME"
+
+echo -n "Codex --cleanup without --yes refuses to delete on non-tty... "
+TMP_HOME=$(mktemp -d)
+SKILLS_DIR="$TMP_HOME/.codex/skills"
+mkdir -p "$SKILLS_DIR"
+SEEDED_OWNED=""
+for skill_dir in "$ROOT_DIR"/plugins/*/skills/*/; do
+  skill_name=$(basename "$skill_dir")
+  SEEDED_OWNED="$skill_name"
+  mkdir -p "$SKILLS_DIR/$skill_name"
+  printf -- "---\nname: %s\ndescription: legacy\n---\n" "$skill_name" > "$SKILLS_DIR/$skill_name/SKILL.md"
+  break
+done
+# Pipe </dev/null so stdin is not a tty; expect non-zero exit and skill kept.
+if HOME="$TMP_HOME" bash "$ROOT_DIR/scripts/install-codex.sh" --cleanup </dev/null >/tmp/gopher-ai-cleanup-noconfirm.log 2>&1; then
+  echo "FAIL (should exit non-zero without --yes on non-tty)"
+  ERRORS=$((ERRORS + 1))
+elif [ ! -d "$SKILLS_DIR/$SEEDED_OWNED" ]; then
+  echo "FAIL (deleted skill without confirmation)"
+  ERRORS=$((ERRORS + 1))
+else
+  echo "OK"
+fi
+rm -rf "$TMP_HOME"
+
+echo -n "Codex --cleanup works without jq installed... "
+TMP_HOME=$(mktemp -d)
+SKILLS_DIR="$TMP_HOME/.codex/skills"
+mkdir -p "$SKILLS_DIR"
+# Hide jq via a PATH that excludes it. We deliberately keep core utilities by
+# pointing PATH at the original location minus jq's directory.
+JQ_PATH="$(command -v jq 2>/dev/null || true)"
+if [ -n "$JQ_PATH" ]; then
+  # Rebuild a sanitized PATH without jq's bin dir.
+  JQ_DIR="$(dirname "$JQ_PATH")"
+  SAFE_PATH=$(printf '%s' "$PATH" | tr ':' '\n' | grep -v "^${JQ_DIR}\$" | tr '\n' ':' | sed 's/:$//')
+  if HOME="$TMP_HOME" PATH="$SAFE_PATH" bash "$ROOT_DIR/scripts/install-codex.sh" --cleanup --yes >/tmp/gopher-ai-cleanup-nojq.log 2>&1; then
+    echo "OK"
+  else
+    echo "FAIL (cleanup should not require jq)"
+    sed -n '1,40p' /tmp/gopher-ai-cleanup-nojq.log
+    ERRORS=$((ERRORS + 1))
+  fi
+else
+  echo "SKIP (jq not installed locally)"
 fi
 rm -rf "$TMP_HOME"
 


### PR DESCRIPTION
## Summary

- Stops the build from emitting skills twice. Previously `build-universal.sh` produced both `dist/codex/plugins/<plugin>/skills/<skill>/` (canonical) and `dist/codex/skills/<skill>/` (flat), and the `--user` installer copied the flat layout into `~/.codex/skills/`. Users who also pulled the plugin marketplace got every gopher-ai skill twice — Codex's [skill metadata budget](https://developers.openai.com/codex/skills) (~2% of context, or 8K chars when unknown) overflowed and the new 0.122.0 warning fired.
- Removes `--user` mode from `install-codex.sh` and adds `--cleanup`, which deletes legacy `~/.codex/skills/<name>/` entries that match this repo's skill names. `--repo` also runs cleanup so updating a project also clears stale flat-install cruft. The repo's `.agents/plugins/marketplace.json` is the only Codex delivery path now.
- Trims verbose multi-paragraph `description:` frontmatter on 27 plugin SKILL.md files to single-line descriptions. **14,994 → 4,001 chars total** in description blocks. Skill *bodies* are unchanged — Codex still loads the full SKILL.md when it selects a skill (progressive disclosure), so all the WHEN/SKIP routing detail is preserved where Codex actually reads it.

### Why this fixes the warning

Codex's "Exceeded skills context budget of 2%" warning is triggered by metadata size, not skill count. With dedup removed *and* descriptions trimmed, total Codex skill metadata for gopher-ai is well under the default 8K cap on machines that don't know the model's context window, with substantial headroom on those that do.

### Migration

Anyone who previously ran `./scripts/install-codex.sh --user` should run once on each affected machine:

```
./scripts/install-codex.sh --cleanup
```

`--user` now exits non-zero with the migration instructions. `install-all.sh` runs `--cleanup` automatically on Codex.

## Test plan

- [x] `./scripts/test-installation.sh` — all 12 tests pass, including 3 new ones:
  - `Codex installer --cleanup removes legacy skills` (seeds a real gopher-ai skill name + an unrelated `user-custom-skill`, verifies the gopher-ai one is removed and the user one is preserved)
  - `Codex --user mode is rejected with migration message`
  - `Build no longer emits dist/codex/skills/`
- [x] `./scripts/build-universal.sh` produces `dist/codex/{plugins/, AGENTS.md}` only — no `skills/` directory.
- [x] Spot-checked frontmatter on `start-issue` and `go-profiling-optimization` — descriptions are concise; bodies untouched.
- [ ] After merge: run `./scripts/install-codex.sh --cleanup` on machines that previously did `--user` to clear `~/.codex/skills/`. Confirm the warning no longer fires in a fresh Codex session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)