### PR TITLE
fix(install): make install-all actually install Codex plugins + self-heal duplicates

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -64,13 +64,13 @@ To add these plugins to **your own repo**:
 
 ### Global (Personal) Use
 
-For Codex, "global" means cloning this repo and running Codex inside it — Codex auto-discovers `.agents/plugins/marketplace.json` and offers the plugins through `/plugins`. There is no flat-skills install path; the previous `--user` mode has been removed because it double-loaded skills alongside the marketplace and overflowed Codex's skill metadata budget.
-
-If you previously ran `--user`, clean up the legacy entries once:
+For Codex, "global" means installing plugins to `~/.codex/plugins/<name>/` so they load in every Codex session, regardless of the working directory. This is what `install-all.sh` uses for the curl one-liner.
 
 ```bash
-./scripts/install-codex.sh --cleanup
+./scripts/install-codex.sh --user
 ```
+
+Each plugin gets a `.gopher-ai-installed` marker recording version + install timestamp, so the SessionStart cleanup hook can distinguish our installs from user-authored plugins of the same name. `--user` is idempotent: re-running cleanly replaces a prior install.
 
 The universal installer handles every detected platform in one step:
 
@@ -78,7 +78,16 @@ The universal installer handles every detected platform in one step:
 bash -c "$(curl -fsSL https://raw.githubusercontent.com/gopherguides/gopher-ai/main/scripts/install-all.sh)"
 ```
 
-It builds, installs Claude Code and Gemini, runs the Codex `--cleanup`, and cleans up after itself. Restart Codex after running it; use `/plugins` to verify.
+It builds, installs Claude Code and Gemini, runs `install-codex.sh --user` for Codex, and cleans up after itself. Restart Codex after running it; use `/plugins` to verify.
+
+### Migration
+
+Two earlier states are auto-handled by the SessionStart hook + `--user`:
+
+- Flat skills at `~/.codex/skills/<name>/` from the original (broken) `--user` mode that double-loaded against the marketplace.
+- Unmarked plugin directories at `~/.codex/plugins/<name>/` from when the README said "manually copy `dist/codex/plugins/` to `~/.codex/plugins/`".
+
+To migrate manually: `./scripts/install-codex.sh --user` (clean reinstall) or `./scripts/install-codex.sh --cleanup` (remove leftover skills only).
 
 ## Architecture
 

--- a/README.md
+++ b/README.md
@@ -64,12 +64,15 @@ To install plugins individually: `/plugin install go-workflow@gopher-ai`, etc.
 
 ```bash
 # Global install — plugins available in every Codex session, regardless of cwd.
-# This is what install-all.sh uses for the curl one-liner.
-./scripts/install-codex.sh --user
+# Easiest path (no clone needed):
+bash -c "$(curl -fsSL https://raw.githubusercontent.com/gopherguides/gopher-ai/main/scripts/install-all.sh)"
 
-# Repo-local install — plugins available only when running Codex inside the repo.
+# Or, if you've already cloned the repo:
 git clone https://github.com/gopherguides/gopher-ai
 cd gopher-ai
+./scripts/install-codex.sh --user
+
+# Repo-local install — plugins available only when running Codex inside this repo:
 codex   # Plugins load automatically from .agents/plugins/marketplace.json
 
 # Add the marketplace to another repo (project-scoped, like the gopher-ai repo itself):
@@ -79,8 +82,8 @@ codex   # Plugins load automatically from .agents/plugins/marketplace.json
 **Pick one mode.** `--user` and `--repo`-when-cwd'd-into-our-repo will both load the
 plugins, so having both active doubles the skill metadata Codex loads. The
 SessionStart hook on the Claude Code side auto-removes stale unmarked installs
-from earlier README versions, but if you switch between modes, run the
-appropriate install/cleanup explicitly.
+from earlier README versions and clears any stale gopher-ai marketplace cache
+when a marked global install is present.
 
 #### Google Gemini CLI
 

--- a/README.md
+++ b/README.md
@@ -63,21 +63,24 @@ To install plugins individually: `/plugin install go-workflow@gopher-ai`, etc.
 #### OpenAI Codex CLI
 
 ```bash
-# Repo-local (auto-discovered — just clone and run Codex)
+# Global install — plugins available in every Codex session, regardless of cwd.
+# This is what install-all.sh uses for the curl one-liner.
+./scripts/install-codex.sh --user
+
+# Repo-local install — plugins available only when running Codex inside the repo.
 git clone https://github.com/gopherguides/gopher-ai
 cd gopher-ai
 codex   # Plugins load automatically from .agents/plugins/marketplace.json
-# Use /plugins to browse, $start-issue 42 to invoke workflow skills
 
-# Add to another repo (so its Codex sessions discover gopher-ai too)
+# Add the marketplace to another repo (project-scoped, like the gopher-ai repo itself):
 ./scripts/install-codex.sh --repo /path/to/your-repo
-
-# Migrating from older versions: clean up legacy ~/.codex/skills/ entries
-./scripts/install-codex.sh --cleanup
-# Older versions installed flat skills into ~/.codex/skills/ via --user mode.
-# That double-loaded skills alongside the marketplace and overflowed Codex's
-# skill metadata budget. The marketplace is the only delivery path now.
 ```
+
+**Pick one mode.** `--user` and `--repo`-when-cwd'd-into-our-repo will both load the
+plugins, so having both active doubles the skill metadata Codex loads. The
+SessionStart hook on the Claude Code side auto-removes stale unmarked installs
+from earlier README versions, but if you switch between modes, run the
+appropriate install/cleanup explicitly.
 
 #### Google Gemini CLI
 
@@ -283,9 +286,13 @@ Plugins are distributed via the [Codex plugin system](https://developers.openai.
 
 **Install into another repo:** `./scripts/install-codex.sh --repo /path/to/your-repo` copies the current plugin set and merges entries into that repo's `.agents/plugins/marketplace.json` without removing unrelated plugin entries.
 
-**GitHub one-liner:** `bash -c "$(curl -fsSL https://raw.githubusercontent.com/gopherguides/gopher-ai/main/scripts/install-all.sh)"` auto-detects all platforms — installs Claude Code and Gemini, and runs the Codex `--cleanup --yes` migration. It does **not** install Codex plugins, since Codex now discovers gopher-ai through the in-repo marketplace. Either clone this repo and run Codex inside it, or use `--repo` to add the marketplace to another repo.
+**GitHub one-liner:** `bash -c "$(curl -fsSL https://raw.githubusercontent.com/gopherguides/gopher-ai/main/scripts/install-all.sh)"` auto-detects all platforms — installs Claude Code and Gemini, and installs Codex plugins globally to `~/.codex/plugins/<name>/` (so they load in every Codex session). Each plugin gets a `.gopher-ai-installed` marker so the SessionStart cleanup hook can tell our installs apart from user-authored plugins of the same name.
 
-**Migration from older versions:** Older releases offered a `--user` mode that copied flat skills into `~/.codex/skills/`. That conflicted with the plugin marketplace — Codex saw every gopher-ai skill twice and the duplicated metadata overflowed Codex's [skill metadata budget](https://developers.openai.com/codex/skills) (~2% of the context window). The flat layout is gone; run `./scripts/install-codex.sh --cleanup` once on machines that used `--user` previously. The marketplace is the only delivery path now.
+**Migration from older versions:** Two earlier states needed cleanup, both handled automatically by the SessionStart hook (no command required) plus by `install-codex.sh --user` whenever you run install-all:
+- Flat skills at `~/.codex/skills/<name>/` from the original (broken) `--user` mode — overflowed Codex's [skill metadata budget](https://developers.openai.com/codex/skills).
+- Unmarked plugin directories at `~/.codex/plugins/<name>/` from when the README said "manually copy `dist/codex/plugins/` to `~/.codex/plugins/`" — also caused double-loading.
+
+The current `--user` mode writes a `.gopher-ai-installed` marker so the cleanup hook leaves marked installs alone and only removes pre-marker leftovers. To migrate manually: `./scripts/install-codex.sh --user` (clean reinstall) or `./scripts/install-codex.sh --cleanup` (remove leftover skills only).
 
 **Workflow skills** (from `go-workflow` plugin):
 

--- a/plugins/go-workflow/hooks/codex-cleanup-on-start.sh
+++ b/plugins/go-workflow/hooks/codex-cleanup-on-start.sh
@@ -38,10 +38,18 @@ KNOWN_PLUGINS="go-dev go-web go-workflow gopher-guides llm-tools tailwind"
 [[ -d "$HOME/.codex" ]] || exit 0
 [[ -f "$MANIFEST" ]] || exit 0
 
-# Marker file scoped to plugin version. New gopher-ai versions trigger a
-# fresh check (in case new skills were added that need migration too).
+# Marker file scoped to (cleanup logic version, plugin version). Bump the
+# CLEANUP_LOGIC_VERSION whenever this script gains a new cleanup mode that
+# previously-migrated users need to run — otherwise old markers from a prior
+# logic version would short-circuit the new behavior. Plugin-version still
+# participates so that future SKILL.md / plugin updates also trigger a fresh
+# pass even at the same logic version.
+#
+# v1: skills cleanup only.
+# v2: + unmarked plugin cleanup, + stale marketplace cache cleanup.
+CLEANUP_LOGIC_VERSION="v2"
 PLUGIN_VERSION="$(awk -F'"' '/"version"/ {print $4; exit}' "$PLUGIN_ROOT/.claude-plugin/plugin.json" 2>/dev/null || echo "unknown")"
-MARKER="$HOME/.codex/.gopher-ai-cleanup-$PLUGIN_VERSION"
+MARKER="$HOME/.codex/.gopher-ai-cleanup-${CLEANUP_LOGIC_VERSION}-${PLUGIN_VERSION}"
 [[ -f "$MARKER" ]] && exit 0
 
 # Detect a portable sha256 implementation. macOS ships `shasum -a 256` but not

--- a/plugins/go-workflow/hooks/codex-cleanup-on-start.sh
+++ b/plugins/go-workflow/hooks/codex-cleanup-on-start.sh
@@ -1,30 +1,41 @@
 #!/bin/bash
-# codex-cleanup-on-start.sh — SessionStart hook that auto-removes legacy
-# gopher-ai skill files left in ~/.codex/skills/ from older `--user` installs.
+# codex-cleanup-on-start.sh — SessionStart hook that self-heals stale
+# gopher-ai installs in ~/.codex/.
 #
-# This makes the migration "just work" — users don't have to remember to run
-# install-codex.sh --cleanup. It runs once per (user, plugin-version), gated by
-# a marker file, so it's nearly free on subsequent sessions.
+# Two cleanups in one hook:
 #
-# Safety: a candidate is only removed when ALL of these hold:
-#   1. The directory ~/.codex/skills/<name>/ matches a gopher-ai skill name.
-#   2. The SKILL.md frontmatter `name:` field matches the directory name.
-#   3. The SKILL.md sha256 matches a (hash, skill_name) pair in the shipped
-#      legacy-skill-hashes.txt manifest.
-# All three together make false-positive deletion essentially impossible.
+# 1. ~/.codex/skills/<name>/ — legacy flat-skill installs from the original
+#    `--user` mode (which this repo no longer offers). Removed when:
+#    - Directory name matches a gopher-ai skill name
+#    - SKILL.md frontmatter `name:` matches the directory name
+#    - SKILL.md sha256 matches a (hash, skill_name) pair in the shipped
+#      legacy-skill-hashes.txt manifest
 #
-# Exits 0 on all paths so it never blocks a session start. Errors are
-# silenced; nothing prints unless a cleanup actually happened (visible to
-# the user in the Claude Code transcript).
+# 2. ~/.codex/plugins/<name>/ — UNMARKED legacy plugin installs from when the
+#    README said "manually copy dist/codex/plugins/ to ~/.codex/plugins/".
+#    Plugins installed by the current `--user` mode write a
+#    .gopher-ai-installed/ marker; the hook leaves those alone. An unmarked
+#    directory matching one of our seven plugin names AND containing a
+#    .codex-plugin/plugin.json that looks like ours is candidate for removal.
+#    These show up alongside the new install path and double-load skill
+#    metadata (the entire reason this hook exists).
+#
+# Both cleanups are gated by a per-version marker so subsequent sessions are
+# nearly free. Exits 0 on every path so it never blocks a session start.
 
 set -u
 
 PLUGIN_ROOT="${CLAUDE_PLUGIN_ROOT:-$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)}"
 MANIFEST="$PLUGIN_ROOT/hooks/legacy-skill-hashes.txt"
 SKILLS_HOME="$HOME/.codex/skills"
+PLUGINS_HOME="$HOME/.codex/plugins"
+
+# The seven plugins this repo ships for Codex. Used to scope the unmarked-
+# plugin cleanup so we never touch unrelated user-installed plugins.
+KNOWN_PLUGINS="go-dev go-web go-workflow gopher-guides llm-tools tailwind"
 
 # Fast-exit: nothing to clean.
-[[ -d "$SKILLS_HOME" ]] || exit 0
+[[ -d "$HOME/.codex" ]] || exit 0
 [[ -f "$MANIFEST" ]] || exit 0
 
 # Marker file scoped to plugin version. New gopher-ai versions trigger a
@@ -92,50 +103,115 @@ KNOWN_SKILLS="$(awk '
 
 [[ -n "$KNOWN_SKILLS" ]] || exit 0
 
-# Walk candidates and remove only those passing all three checks.
-removed=0
-candidates=""
-while IFS= read -r skill_name; do
-    [[ -n "$skill_name" ]] || continue
-    target="$SKILLS_HOME/$skill_name"
-    [[ -d "$target" ]] || continue
+# --- 1. Skills cleanup ----------------------------------------------------
+# Walk candidates in ~/.codex/skills/ and remove those passing all three checks.
+removed_skills=0
+removed_skill_paths=""
+if [[ -d "$SKILLS_HOME" ]]; then
+    while IFS= read -r skill_name; do
+        [[ -n "$skill_name" ]] || continue
+        target="$SKILLS_HOME/$skill_name"
+        [[ -d "$target" ]] || continue
 
-    skill_md="$target/SKILL.md"
-    [[ -f "$skill_md" ]] || continue
+        skill_md="$target/SKILL.md"
+        [[ -f "$skill_md" ]] || continue
 
-    # Check 1: frontmatter name matches directory name.
-    fm_name="$(skill_md_name "$skill_md")"
-    [[ "$fm_name" == "$skill_name" ]] || continue
+        # Check 1: frontmatter name matches directory name.
+        fm_name="$(skill_md_name "$skill_md")"
+        [[ "$fm_name" == "$skill_name" ]] || continue
 
-    # Check 2: SKILL.md content hash matches a (hash, skill_name) pair we shipped.
-    candidate_hash="$(sha256_of "$skill_md")"
-    [[ -n "$candidate_hash" ]] || continue
-    if ! awk -v target_hash="$candidate_hash" -v target_skill="$skill_name" '
-        /^[[:space:]]*#/ { next }
-        /^[[:space:]]*$/ { next }
-        $1 == target_hash && $2 == target_skill { found = 1; exit }
-        END { exit (found ? 0 : 1) }
-    ' "$MANIFEST"; then
-        continue
-    fi
+        # Check 2: SKILL.md content hash matches a (hash, skill_name) pair we shipped.
+        candidate_hash="$(sha256_of "$skill_md")"
+        [[ -n "$candidate_hash" ]] || continue
+        if ! awk -v target_hash="$candidate_hash" -v target_skill="$skill_name" '
+            /^[[:space:]]*#/ { next }
+            /^[[:space:]]*$/ { next }
+            $1 == target_hash && $2 == target_skill { found = 1; exit }
+            END { exit (found ? 0 : 1) }
+        ' "$MANIFEST"; then
+            continue
+        fi
 
-    # All checks passed — remove.
-    rm -rf "$target" 2>/dev/null && {
-        candidates="${candidates}${target}\n"
-        removed=$((removed + 1))
-    }
-done <<<"$KNOWN_SKILLS"
+        rm -rf "$target" 2>/dev/null && {
+            removed_skill_paths="${removed_skill_paths}${target}\n"
+            removed_skills=$((removed_skills + 1))
+        }
+    done <<<"$KNOWN_SKILLS"
+fi
+
+# --- 2. Unmarked plugin cleanup -------------------------------------------
+# Walk ~/.codex/plugins/<name>/ for the seven plugin names we ship. Remove a
+# directory only when ALL of these hold:
+#   - directory name matches one of our seven plugin names
+#   - NO .gopher-ai-installed marker file (we never touch marked installs)
+#   - .codex-plugin/plugin.json exists
+#   - plugin.json `name:` field matches the directory name
+#   - plugin.json `author.email` is "support@gopherguides.com" — distinctive
+#     to gopher-ai. A user-authored plugin that happens to share a name will
+#     have a different (or missing) author email and be left alone.
+# This pattern catches old README-era manual installs that pre-date the
+# marker convention while keeping user-authored plugins safe.
+removed_plugins=0
+removed_plugin_paths=""
+GOPHER_AI_AUTHOR_EMAIL="support@gopherguides.com"
+
+# Extract a JSON string field by name. Tolerant: works without jq, handles
+# quoted values, ignores arrays/objects. Returns the first match.
+json_string_field() {
+    local file="$1" field="$2"
+    awk -v f="$field" '
+        BEGIN { pat = "\""f"\"[[:space:]]*:[[:space:]]*\"" }
+        $0 ~ pat {
+            line = $0
+            sub(".*"pat, "", line)
+            sub(/".*/, "", line)
+            print line
+            exit
+        }
+    ' "$file" 2>/dev/null
+}
+
+if [[ -d "$PLUGINS_HOME" ]]; then
+    for plugin_name in $KNOWN_PLUGINS; do
+        target="$PLUGINS_HOME/$plugin_name"
+        [[ -d "$target" ]] || continue
+        [[ -f "$target/.gopher-ai-installed" ]] && continue
+
+        plugin_json="$target/.codex-plugin/plugin.json"
+        [[ -f "$plugin_json" ]] || continue
+
+        # Name match.
+        json_name="$(json_string_field "$plugin_json" "name")"
+        [[ "$json_name" == "$plugin_name" ]] || continue
+
+        # Author email match — the distinctive gopher-ai ownership signal.
+        json_email="$(json_string_field "$plugin_json" "email")"
+        [[ "$json_email" == "$GOPHER_AI_AUTHOR_EMAIL" ]] || continue
+
+        rm -rf "$target" 2>/dev/null && {
+            removed_plugin_paths="${removed_plugin_paths}${target}\n"
+            removed_plugins=$((removed_plugins + 1))
+        }
+    done
+fi
 
 # Always write the marker so we don't re-scan next session.
 mkdir -p "$(dirname "$MARKER")" 2>/dev/null
 : > "$MARKER" 2>/dev/null
 
-if [[ "$removed" -gt 0 ]]; then
+if [[ "$removed_skills" -gt 0 || "$removed_plugins" -gt 0 ]]; then
     {
-        printf '🧹 gopher-ai: removed %d legacy Codex skill director%s from ~/.codex/skills/:\n' \
-            "$removed" "$([ "$removed" -eq 1 ] && echo y || echo ies)"
-        printf '%b' "$candidates" | sed 's|^|  |'
-        printf '   (Codex now discovers gopher-ai via the plugin marketplace.)\n'
+        if [[ "$removed_skills" -gt 0 ]]; then
+            printf '🧹 gopher-ai: removed %d legacy Codex skill director%s from ~/.codex/skills/:\n' \
+                "$removed_skills" "$([ "$removed_skills" -eq 1 ] && echo y || echo ies)"
+            printf '%b' "$removed_skill_paths" | sed 's|^|  |'
+        fi
+        if [[ "$removed_plugins" -gt 0 ]]; then
+            printf '🧹 gopher-ai: removed %d unmarked legacy plugin director%s from ~/.codex/plugins/:\n' \
+                "$removed_plugins" "$([ "$removed_plugins" -eq 1 ] && echo y || echo ies)"
+            printf '%b' "$removed_plugin_paths" | sed 's|^|  |'
+            printf '   (Re-run install-all.sh to install marked global copies if you want them.)\n'
+        fi
     } >&2
 fi
 

--- a/plugins/go-workflow/hooks/codex-cleanup-on-start.sh
+++ b/plugins/go-workflow/hooks/codex-cleanup-on-start.sh
@@ -278,10 +278,14 @@ fi
 # marketplace cache so Codex doesn't load the same skills twice (once from
 # the global install, once from the cached marketplace copy). The cache
 # repopulates automatically if Codex rediscovers a marketplace.
+#
+# Scoped to the exact `gopher-ai` cache directory — names like
+# `gopher-ai-dev` or `gopher-ai-fork` are separate marketplaces and are
+# left alone.
 removed_cache=0
 removed_cache_paths=""
-CACHE_ROOT="$HOME/.codex/plugins/cache"
-if [[ -d "$CACHE_ROOT" && -d "$PLUGINS_HOME" ]]; then
+CACHE_TARGET="$HOME/.codex/plugins/cache/gopher-ai"
+if [[ -d "$CACHE_TARGET" && -d "$PLUGINS_HOME" ]]; then
     # Only act when at least one of OUR marked installs exists — otherwise
     # the cache may be the user's only working copy and we shouldn't touch it.
     has_marked=false
@@ -292,13 +296,10 @@ if [[ -d "$CACHE_ROOT" && -d "$PLUGINS_HOME" ]]; then
         fi
     done
     if [[ "$has_marked" == "true" ]]; then
-        for entry in "$CACHE_ROOT"/gopher-ai*; do
-            [[ -e "$entry" ]] || continue
-            rm -rf "$entry" 2>/dev/null && {
-                removed_cache_paths="${removed_cache_paths}${entry}\n"
-                removed_cache=$((removed_cache + 1))
-            }
-        done
+        rm -rf "$CACHE_TARGET" 2>/dev/null && {
+            removed_cache_paths="${CACHE_TARGET}\n"
+            removed_cache=1
+        }
     fi
 fi
 

--- a/plugins/go-workflow/hooks/codex-cleanup-on-start.sh
+++ b/plugins/go-workflow/hooks/codex-cleanup-on-start.sh
@@ -155,18 +155,87 @@ removed_plugins=0
 removed_plugin_paths=""
 GOPHER_AI_AUTHOR_EMAIL="support@gopherguides.com"
 
-# Extract a JSON string field by name. Tolerant: works without jq, handles
-# quoted values, ignores arrays/objects. Returns the first match.
-json_string_field() {
+# Extract a top-level JSON string field by name. Scoped to depth-1 keys so
+# `name` returns the top-level plugin name, not `author.name`.
+json_top_string() {
     local file="$1" field="$2"
-    awk -v f="$field" '
-        BEGIN { pat = "\""f"\"[[:space:]]*:[[:space:]]*\"" }
-        $0 ~ pat {
+    awk -v target="$field" '
+        BEGIN { depth = 0; pending_key = "" }
+        {
             line = $0
-            sub(".*"pat, "", line)
-            sub(/".*/, "", line)
-            print line
-            exit
+            while (length(line) > 0) {
+                c = substr(line, 1, 1)
+                line = substr(line, 2)
+                if (c == "\"") {
+                    tok = ""
+                    while (length(line) > 0) {
+                        cc = substr(line, 1, 1); line = substr(line, 2)
+                        if (cc == "\\") { tok = tok substr(line, 1, 1); line = substr(line, 2) }
+                        else if (cc == "\"") break
+                        else tok = tok cc
+                    }
+                    if (depth == 1 && pending_key == target) {
+                        print tok
+                        exit
+                    }
+                    last_token = tok
+                } else if (c == ":") {
+                    pending_key = last_token
+                } else if (c == "{") {
+                    depth++; pending_key = ""
+                } else if (c == "}") {
+                    depth--
+                } else if (c == ",") {
+                    pending_key = ""
+                }
+            }
+        }
+    ' "$file" 2>/dev/null
+}
+
+# Extract author.email from a plugin.json. Walks the JSON token stream,
+# tracking when we are inside the `author` object specifically — does not
+# match the first `"email"` anywhere in the file (which would be wrong if
+# any other object also has an email field).
+json_author_email() {
+    local file="$1"
+    if command -v jq >/dev/null 2>&1; then
+        jq -r '.author.email // ""' "$file" 2>/dev/null
+        return
+    fi
+    awk '
+        BEGIN { in_author = 0; depth = 0; author_depth = 0; pending_key = "" }
+        {
+            line = $0
+            while (length(line) > 0) {
+                c = substr(line, 1, 1)
+                line = substr(line, 2)
+                if (c == "\"") {
+                    tok = ""
+                    while (length(line) > 0) {
+                        cc = substr(line, 1, 1); line = substr(line, 2)
+                        if (cc == "\\") { tok = tok substr(line, 1, 1); line = substr(line, 2) }
+                        else if (cc == "\"") break
+                        else tok = tok cc
+                    }
+                    if (in_author && pending_key == "email") {
+                        print tok
+                        exit
+                    }
+                    last_token = tok
+                } else if (c == ":") {
+                    pending_key = last_token
+                } else if (c == "{") {
+                    depth++
+                    if (pending_key == "author") { in_author = 1; author_depth = depth }
+                    pending_key = ""
+                } else if (c == "}") {
+                    if (in_author && depth == author_depth) in_author = 0
+                    depth--
+                } else if (c == ",") {
+                    pending_key = ""
+                }
+            }
         }
     ' "$file" 2>/dev/null
 }
@@ -180,12 +249,13 @@ if [[ -d "$PLUGINS_HOME" ]]; then
         plugin_json="$target/.codex-plugin/plugin.json"
         [[ -f "$plugin_json" ]] || continue
 
-        # Name match.
-        json_name="$(json_string_field "$plugin_json" "name")"
+        # Top-level name match (NOT author.name — scoped to depth 1).
+        json_name="$(json_top_string "$plugin_json" "name")"
         [[ "$json_name" == "$plugin_name" ]] || continue
 
         # Author email match — the distinctive gopher-ai ownership signal.
-        json_email="$(json_string_field "$plugin_json" "email")"
+        # Scoped to author.email specifically, not the first "email" anywhere.
+        json_email="$(json_author_email "$plugin_json")"
         [[ "$json_email" == "$GOPHER_AI_AUTHOR_EMAIL" ]] || continue
 
         rm -rf "$target" 2>/dev/null && {
@@ -195,11 +265,40 @@ if [[ -d "$PLUGINS_HOME" ]]; then
     done
 fi
 
+# --- 3. Marketplace cache cleanup -----------------------------------------
+# If a marked global install is present, eliminate any stale gopher-ai
+# marketplace cache so Codex doesn't load the same skills twice (once from
+# the global install, once from the cached marketplace copy). The cache
+# repopulates automatically if Codex rediscovers a marketplace.
+removed_cache=0
+removed_cache_paths=""
+CACHE_ROOT="$HOME/.codex/plugins/cache"
+if [[ -d "$CACHE_ROOT" && -d "$PLUGINS_HOME" ]]; then
+    # Only act when at least one of OUR marked installs exists — otherwise
+    # the cache may be the user's only working copy and we shouldn't touch it.
+    has_marked=false
+    for plugin_name in $KNOWN_PLUGINS; do
+        if [[ -f "$PLUGINS_HOME/$plugin_name/.gopher-ai-installed" ]]; then
+            has_marked=true
+            break
+        fi
+    done
+    if [[ "$has_marked" == "true" ]]; then
+        for entry in "$CACHE_ROOT"/gopher-ai*; do
+            [[ -e "$entry" ]] || continue
+            rm -rf "$entry" 2>/dev/null && {
+                removed_cache_paths="${removed_cache_paths}${entry}\n"
+                removed_cache=$((removed_cache + 1))
+            }
+        done
+    fi
+fi
+
 # Always write the marker so we don't re-scan next session.
 mkdir -p "$(dirname "$MARKER")" 2>/dev/null
 : > "$MARKER" 2>/dev/null
 
-if [[ "$removed_skills" -gt 0 || "$removed_plugins" -gt 0 ]]; then
+if [[ "$removed_skills" -gt 0 || "$removed_plugins" -gt 0 || "$removed_cache" -gt 0 ]]; then
     {
         if [[ "$removed_skills" -gt 0 ]]; then
             printf '🧹 gopher-ai: removed %d legacy Codex skill director%s from ~/.codex/skills/:\n' \
@@ -211,6 +310,11 @@ if [[ "$removed_skills" -gt 0 || "$removed_plugins" -gt 0 ]]; then
                 "$removed_plugins" "$([ "$removed_plugins" -eq 1 ] && echo y || echo ies)"
             printf '%b' "$removed_plugin_paths" | sed 's|^|  |'
             printf '   (Re-run install-all.sh to install marked global copies if you want them.)\n'
+        fi
+        if [[ "$removed_cache" -gt 0 ]]; then
+            printf '🧹 gopher-ai: cleared %d stale marketplace cache entr%s alongside the marked global install:\n' \
+                "$removed_cache" "$([ "$removed_cache" -eq 1 ] && echo y || echo ies)"
+            printf '%b' "$removed_cache_paths" | sed 's|^|  |'
         fi
     } >&2
 fi

--- a/scripts/install-all.sh
+++ b/scripts/install-all.sh
@@ -7,9 +7,9 @@
 #
 # Platforms detected:
 #   - Claude Code: updates marketplace repo + plugin cache (requires ~/.claude/)
-#   - Codex CLI:   cleans up legacy ~/.codex/skills/ entries (migration only);
-#                  plugins are discovered via .agents/plugins/marketplace.json
-#                  in the repo. Cleanup runs without jq or git.
+#   - Codex CLI:   installs plugins globally to ~/.codex/plugins/ (so they
+#                  load in every Codex session) AND cleans up legacy
+#                  ~/.codex/skills/ entries from older flat-install attempts.
 #   - Gemini CLI:  installs extensions (requires gemini command)
 #
 # Remote install (no clone needed — downloads to tmp, installs, cleans up):
@@ -93,13 +93,13 @@ bootstrap_if_needed() {
 }
 
 # Check that the tools required for the platforms we're actually installing
-# are available. Codex --cleanup needs neither jq nor git nor the build step,
-# so we don't gate cleanup-only flows on those.
+# are available.
 check_prerequisites() {
     local missing=()
 
-    # jq is needed by build-universal.sh, which only runs for Claude/Gemini.
-    if $HAVE_CLAUDE || $HAVE_GEMINI; then
+    # jq is needed by build-universal.sh (Claude/Gemini) and by install-codex.sh
+    # for marketplace.json manipulation when installing globally.
+    if $HAVE_CLAUDE || $HAVE_GEMINI || $HAVE_CODEX; then
         if ! command -v jq >/dev/null 2>&1; then
             missing+=("jq (brew install jq / apt install jq)")
         fi
@@ -152,7 +152,7 @@ print_detection() {
     fi
 
     if $HAVE_CODEX; then
-        echo "  Codex CLI ...... found (~/.codex/ exists — will run cleanup migration only)"
+        echo "  Codex CLI ...... found (~/.codex/ exists — will install global plugins)"
     else
         echo "  Codex CLI ...... skipped (no ~/.codex/ directory)"
     fi
@@ -187,14 +187,10 @@ install_claude() {
 
 install_codex() {
     echo "=== Codex CLI ==="
-    echo "  Note: gopher-ai for Codex is delivered via the plugin marketplace,"
-    echo "  not via flat skills. This step only removes legacy ~/.codex/skills/"
-    echo "  entries from older --user installs. To use the plugins:"
-    echo "    - Run codex inside this repo (auto-discovered marketplace), OR"
-    echo "    - Run scripts/install-codex.sh --repo /path/to/your-repo to add"
-    echo "      the marketplace to another repo."
+    echo "  Installing gopher-ai plugins globally to ~/.codex/plugins/."
+    echo "  They will load in every Codex session, regardless of working directory."
     echo ""
-    "$ROOT_DIR/scripts/install-codex.sh" --cleanup --yes
+    "$ROOT_DIR/scripts/install-codex.sh" --user
     echo ""
 }
 
@@ -317,8 +313,8 @@ main() {
         echo ""
     fi
 
-    # Build is only needed for Claude and Gemini; Codex --cleanup walks
-    # plugins/*/skills/ directly and doesn't read dist/.
+    # Build is needed for Claude and Gemini. Codex --user copies straight from
+    # plugins/ source — no build artifacts required.
     if $HAVE_CLAUDE || $HAVE_GEMINI; then
         echo "Building distribution..."
         echo ""
@@ -345,10 +341,7 @@ main() {
         echo "  Claude Code: Restart Claude Code to reload plugins"
     fi
     if $HAVE_CODEX; then
-        echo "  Codex CLI:   Migration only — no plugins were installed."
-        echo "               To use gopher-ai with Codex: clone this repo and"
-        echo "               run 'codex' inside it (auto-discovers the marketplace),"
-        echo "               or run scripts/install-codex.sh --repo <target-repo>"
+        echo "  Codex CLI:   Plugins installed to ~/.codex/plugins/ — restart Codex to load."
     fi
     if $HAVE_GEMINI; then
         echo "  Gemini CLI:  Restart Gemini to load extensions"

--- a/scripts/install-all.sh
+++ b/scripts/install-all.sh
@@ -131,10 +131,11 @@ detect_platforms() {
         HAVE_CLAUDE=true
     fi
 
-    # Codex --cleanup doesn't require jq; treat ~/.codex/ as the signal so
-    # the migration runs even on minimal machines. (--repo would require jq,
-    # but install-all.sh only invokes --cleanup.)
-    if [[ -d "$HOME/.codex" ]]; then
+    # Detect Codex via either the CLI on PATH or an existing ~/.codex/. The
+    # CLI signal catches fresh installs that haven't run codex yet (no config
+    # dir created); the directory signal catches setups where the CLI is
+    # installed elsewhere (e.g. node global npm dir not on PATH for this shell).
+    if command -v codex >/dev/null 2>&1 || [[ -d "$HOME/.codex" ]]; then
         HAVE_CODEX=true
     fi
 
@@ -152,9 +153,9 @@ print_detection() {
     fi
 
     if $HAVE_CODEX; then
-        echo "  Codex CLI ...... found (~/.codex/ exists — will install global plugins)"
+        echo "  Codex CLI ...... found — will install global plugins to ~/.codex/plugins/"
     else
-        echo "  Codex CLI ...... skipped (no ~/.codex/ directory)"
+        echo "  Codex CLI ...... skipped (no codex binary, no ~/.codex/ directory)"
     fi
 
     if $HAVE_GEMINI; then

--- a/scripts/install-codex.sh
+++ b/scripts/install-codex.sh
@@ -334,11 +334,117 @@ build_repo_marketplace() {
     ' "$DIST_DIR/plugins/marketplace.json" >"$output_file"
 }
 
+# Returns 0 if the directory at $1 is safe to overwrite as a gopher-ai install:
+#   - empty or missing
+#   - has our marker (prior --user install)
+#   - has plugin.json with author.email == support@gopherguides.com (legacy
+#     manual install from old README — still ours to replace)
+# Returns 1 (refuse to overwrite) otherwise — e.g. a user-authored plugin that
+# happens to share one of our names but has a different author email.
+target_is_safe_to_overwrite() {
+    local target="$1"
+    [[ -d "$target" ]] || return 0
+    [[ -f "$target/.gopher-ai-installed" ]] && return 0
+    local plugin_json="$target/.codex-plugin/plugin.json"
+    [[ -f "$plugin_json" ]] || return 0  # not a Codex plugin — empty/leftover, safe
+    local owner_email
+    owner_email="$(plugin_json_author_email "$plugin_json")"
+    [[ "$owner_email" == "support@gopherguides.com" ]]
+}
+
+# Extract author.email from a plugin.json. Prefers jq (precise); falls back to
+# a scoped awk parser that walks tokens to find author -> email — does NOT
+# match the first "email" anywhere in the file, which would be wrong if any
+# other object in the JSON also has an email field.
+plugin_json_author_email() {
+    local f="$1"
+    [[ -f "$f" ]] || { echo ""; return; }
+    if command -v jq >/dev/null 2>&1; then
+        jq -r '.author.email // ""' "$f" 2>/dev/null
+        return
+    fi
+    awk '
+        BEGIN { in_author = 0; depth = 0; author_depth = 0 }
+        {
+            line = $0
+            while (length(line) > 0) {
+                c = substr(line, 1, 1)
+                line = substr(line, 2)
+                if (c == "\"") {
+                    # Read a quoted token, honoring backslash escapes.
+                    tok = ""
+                    while (length(line) > 0) {
+                        cc = substr(line, 1, 1)
+                        line = substr(line, 2)
+                        if (cc == "\\") {
+                            tok = tok substr(line, 1, 1)
+                            line = substr(line, 2)
+                        } else if (cc == "\"") {
+                            break
+                        } else {
+                            tok = tok cc
+                        }
+                    }
+                    last_key_token = tok
+                } else if (c == ":") {
+                    pending_key = last_key_token
+                } else if (c == "{") {
+                    depth++
+                    if (pending_key == "author") {
+                        in_author = 1
+                        author_depth = depth
+                    }
+                    pending_key = ""
+                } else if (c == "}") {
+                    if (in_author && depth == author_depth) in_author = 0
+                    depth--
+                } else if (in_author && pending_key == "email" && c ~ /[^[:space:]]/) {
+                    # Already past the colon; expect the next quoted token to
+                    # be the value. Re-prepend so the next iteration parses it.
+                    line = c line
+                    sub(/^[[:space:]]*"/, "", line)
+                    val = ""
+                    while (length(line) > 0) {
+                        cc = substr(line, 1, 1)
+                        line = substr(line, 2)
+                        if (cc == "\\") { val = val substr(line, 1, 1); line = substr(line, 2) }
+                        else if (cc == "\"") break
+                        else val = val cc
+                    }
+                    print val
+                    exit
+                }
+            }
+        }
+    ' "$f"
+}
+
+# Clear gopher-ai entries from the Codex marketplace cache. Codex caches
+# marketplace plugins under ~/.codex/plugins/cache/<marketplace-name>/ when
+# the marketplace is discovered. If a user has both a marked global install
+# AND a cached marketplace copy (e.g. from running `codex` inside this repo),
+# Codex loads both and skill metadata doubles. Removing the cache lets the
+# global install be the single source of truth; Codex will repopulate the
+# cache only if a marketplace is rediscovered.
+clear_gopher_ai_marketplace_cache() {
+    local cache_root="$HOME/.codex/plugins/cache"
+    [[ -d "$cache_root" ]] || return 0
+    local removed=0
+    local entry
+    for entry in "$cache_root"/gopher-ai*; do
+        [[ -e "$entry" ]] || continue
+        rm -rf "$entry"
+        echo "cleared marketplace cache: $entry"
+        removed=$((removed + 1))
+    done
+    [[ "$removed" -eq 0 ]] || echo "cleared $removed gopher-ai marketplace cache entr$([ "$removed" -eq 1 ] && echo "y" || echo "ies")"
+}
+
 # Install plugins globally to ~/.codex/plugins/<name>/. This is the path that
 # makes gopher-ai available in EVERY Codex session, regardless of cwd.
 # Idempotent: re-running cleanly replaces any prior install (whether from us
 # or from a pre-marker manual install). Each plugin gets a marker file
-# .gopher-ai-installed/ recording version + install timestamp so the
+# .gopher-ai-installed recording version + install timestamp so the
 # SessionStart cleanup hook can distinguish our installs from user-authored
 # plugins of the same name.
 install_user_plugins() {
@@ -351,6 +457,7 @@ install_user_plugins() {
     installed_at="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
 
     local installed=0
+    local skipped=()
     local plugin_dir
     for plugin_dir in "$ROOT_DIR"/plugins/*; do
         [[ -d "$plugin_dir" ]] || continue
@@ -358,6 +465,15 @@ install_user_plugins() {
         local plugin_name target
         plugin_name="$(basename "$plugin_dir")"
         target="$plugins_home/$plugin_name"
+
+        # Refuse to overwrite a user-authored plugin that happens to share one
+        # of our seven names. The hook applies the same gate at session-start;
+        # the installer needs it too so a fresh install doesn't nuke unrelated
+        # work between marker writes.
+        if ! target_is_safe_to_overwrite "$target"; then
+            skipped+=("$target (different author — leaving alone)")
+            continue
+        fi
 
         # Replace any existing install. cp -R after rm -rf is the safest way
         # to avoid mixing old + new files when SKILL.md or skills are renamed.
@@ -382,6 +498,18 @@ EOF
         echo "installed: $target ($plugin_name v$plugin_version)"
         installed=$((installed + 1))
     done
+
+    if [[ ${#skipped[@]} -gt 0 ]]; then
+        echo "skipped (not gopher-ai-owned):"
+        local entry
+        for entry in "${skipped[@]}"; do
+            echo "  $entry"
+        done
+    fi
+
+    # Eliminate any stale gopher-ai marketplace cache so the global install
+    # is the single source of truth (no double-loading).
+    clear_gopher_ai_marketplace_cache
 
     echo "installed $installed plugin(s) globally to $plugins_home/"
 }

--- a/scripts/install-codex.sh
+++ b/scripts/install-codex.sh
@@ -12,36 +12,41 @@ BOOTSTRAP_DIR=""
 usage() {
     cat <<'EOF'
 Usage:
+  scripts/install-codex.sh --user
   scripts/install-codex.sh --repo /path/to/repo
   scripts/install-codex.sh --cleanup [--yes]
 
-gopher-ai is delivered to Codex as plugins. Codex discovers them automatically
-when you run inside a repo that has .agents/plugins/marketplace.json (this repo
-ships one). To make them available in another repo, use --repo.
+gopher-ai for Codex can be installed in two ways:
 
-Options:
-  --repo PATH   Install plugins into PATH/plugins and merge entries into
-                PATH/.agents/plugins/marketplace.json. Auto-cleans legacy
+  --user        Install plugins globally to ~/.codex/plugins/<name>/ so they
+                load in EVERY Codex session, regardless of the working
+                directory. This is what install-all.sh uses for the curl
+                one-liner. Idempotent: re-running cleanly replaces any
+                existing install. Each plugin gets a marker file
+                .gopher-ai-installed/ recording version + install timestamp,
+                so the cleanup hook can distinguish our installs from
+                user-authored plugins of the same name. Also removes legacy
                 ~/.codex/skills/ entries left over from older installs
                 (with --yes semantics — assumes the user wants the migration).
+
+  --repo PATH   Install plugins into PATH/plugins and merge entries into
+                PATH/.agents/plugins/marketplace.json. Use this for project-
+                scoped installs where you want the plugins to load only when
+                running Codex inside that repo. Also runs the legacy
+                ~/.codex/skills/ cleanup.
+
   --cleanup     Remove legacy gopher-ai skills from ~/.codex/skills/ left over
-                from the old --user mode. Lists candidates and prompts before
-                deleting. Two ownership gates protect user-authored skills:
-                (1) the SKILL.md frontmatter must have `name: <dirname>`, and
-                (2) its content must hash-match a current or historical
-                gopher-ai-shipped version of that file (via git history when
-                this script runs from a clone, or just current sources in
-                bootstrap mode). A user-authored skill at a generic name like
-                `commit` or `ship` will fail the content check and be kept.
-  --yes         Skip the interactive confirmation in --cleanup (used by
+                from the old `--user` mode (which copied skills there). Two
+                ownership gates protect user-authored skills: (1) the SKILL.md
+                frontmatter must have `name: <dirname>`, and (2) its content
+                must hash-match a gopher-ai-shipped version of that file via
+                the bundled scripts/legacy-skill-hashes.txt manifest. A user-
+                authored skill at a generic name like `commit` or `ship` will
+                fail the content check and be kept.
+
+  --yes         Skip interactive confirmation in --cleanup (used by
                 install-all.sh and CI flows).
   --help        Show this help text
-
-Notes:
-  --user has been removed. The old mode copied skills into ~/.codex/skills/,
-  which double-loaded them alongside the plugin marketplace and overflowed the
-  Codex skill metadata budget. Run --cleanup once on machines that used --user
-  before, then rely on the marketplace for skill discovery.
 EOF
 }
 
@@ -329,6 +334,58 @@ build_repo_marketplace() {
     ' "$DIST_DIR/plugins/marketplace.json" >"$output_file"
 }
 
+# Install plugins globally to ~/.codex/plugins/<name>/. This is the path that
+# makes gopher-ai available in EVERY Codex session, regardless of cwd.
+# Idempotent: re-running cleanly replaces any prior install (whether from us
+# or from a pre-marker manual install). Each plugin gets a marker file
+# .gopher-ai-installed/ recording version + install timestamp so the
+# SessionStart cleanup hook can distinguish our installs from user-authored
+# plugins of the same name.
+install_user_plugins() {
+    local plugins_home="$HOME/.codex/plugins"
+    mkdir -p "$plugins_home"
+
+    local plugin_version
+    plugin_version="$(jq -r '.metadata.version' "$ROOT_DIR/.claude-plugin/marketplace.json" 2>/dev/null || echo "unknown")"
+    local installed_at
+    installed_at="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+
+    local installed=0
+    local plugin_dir
+    for plugin_dir in "$ROOT_DIR"/plugins/*; do
+        [[ -d "$plugin_dir" ]] || continue
+        [[ -f "$plugin_dir/.codex-plugin/plugin.json" ]] || continue
+        local plugin_name target
+        plugin_name="$(basename "$plugin_dir")"
+        target="$plugins_home/$plugin_name"
+
+        # Replace any existing install. cp -R after rm -rf is the safest way
+        # to avoid mixing old + new files when SKILL.md or skills are renamed.
+        rm -rf "${target:?}"
+        cp -R "$plugin_dir" "$target"
+
+        # Drop the .claude-plugin/ subdir if it sneaked in — Codex doesn't need
+        # it and shipping it confuses some marketplace tools.
+        rm -rf "$target/.claude-plugin"
+
+        # Write the ownership marker. This is what the cleanup hook checks
+        # to decide "ours, leave alone" vs "legacy unmarked, candidate for
+        # removal".
+        cat > "$target/.gopher-ai-installed" <<EOF
+gopher-ai global install
+plugin: $plugin_name
+version: $plugin_version
+installed_at: $installed_at
+source: scripts/install-codex.sh --user
+EOF
+
+        echo "installed: $target ($plugin_name v$plugin_version)"
+        installed=$((installed + 1))
+    done
+
+    echo "installed $installed plugin(s) globally to $plugins_home/"
+}
+
 copy_repo_plugins() {
     local target_repo="$1"
     mkdir -p "$target_repo/plugins"
@@ -370,19 +427,12 @@ main() {
             usage
             ;;
         --user)
-            cat >&2 <<'EOF'
-error: --user mode has been removed.
-
-The old --user mode copied skills into ~/.codex/skills/, which conflicted
-with the plugin marketplace and overflowed Codex's skill metadata budget.
-gopher-ai is now delivered as Codex plugins only.
-
-To migrate:
-  1. ./scripts/install-codex.sh --cleanup     # remove legacy ~/.codex/skills/ entries
-  2. Run codex inside a repo that has .agents/plugins/marketplace.json
-     (this repo ships one), or use --repo to add the marketplace to another repo.
-EOF
-            exit 1
+            require_cmd jq
+            bootstrap_repo
+            install_user_plugins
+            # --user is itself an explicit migration action; auto-confirm
+            # the legacy ~/.codex/skills/ cleanup that runs alongside it.
+            cleanup_legacy_user_skills "true"
             ;;
         --cleanup)
             bootstrap_repo

--- a/scripts/install-codex.sh
+++ b/scripts/install-codex.sh
@@ -419,25 +419,23 @@ plugin_json_author_email() {
     ' "$f"
 }
 
-# Clear gopher-ai entries from the Codex marketplace cache. Codex caches
+# Clear our gopher-ai entries from the Codex marketplace cache. Codex caches
 # marketplace plugins under ~/.codex/plugins/cache/<marketplace-name>/ when
 # the marketplace is discovered. If a user has both a marked global install
 # AND a cached marketplace copy (e.g. from running `codex` inside this repo),
 # Codex loads both and skill metadata doubles. Removing the cache lets the
 # global install be the single source of truth; Codex will repopulate the
 # cache only if a marketplace is rediscovered.
+#
+# Only the cache directory matching our exact marketplace name is removed.
+# Names like `gopher-ai-dev` or `gopher-ai-fork` (separate marketplaces a
+# user may have configured) are left alone.
 clear_gopher_ai_marketplace_cache() {
     local cache_root="$HOME/.codex/plugins/cache"
-    [[ -d "$cache_root" ]] || return 0
-    local removed=0
-    local entry
-    for entry in "$cache_root"/gopher-ai*; do
-        [[ -e "$entry" ]] || continue
-        rm -rf "$entry"
-        echo "cleared marketplace cache: $entry"
-        removed=$((removed + 1))
-    done
-    [[ "$removed" -eq 0 ]] || echo "cleared $removed gopher-ai marketplace cache entr$([ "$removed" -eq 1 ] && echo "y" || echo "ies")"
+    local target="$cache_root/gopher-ai"
+    [[ -d "$target" ]] || return 0
+    rm -rf "$target"
+    echo "cleared marketplace cache: $target"
 }
 
 # Install plugins globally to ~/.codex/plugins/<name>/. This is the path that

--- a/scripts/test-installation.sh
+++ b/scripts/test-installation.sh
@@ -699,6 +699,40 @@ else
 fi
 rm -rf "$TMP_HOME"
 
+echo -n "install-all.sh detects fresh Codex install (no ~/.codex/ yet)... "
+# Regression for #147 round 4: a user with the codex CLI but no ~/.codex/ yet
+# (fresh install, never ran codex) should still get global plugins installed.
+TMP_HOME=$(mktemp -d)
+TMP_BIN=$(mktemp -d)
+# Minimal fake codex on PATH so the detection picks it up.
+cat > "$TMP_BIN/codex" <<'STUB'
+#!/bin/sh
+echo "fake codex 0.0.0"
+STUB
+chmod +x "$TMP_BIN/codex"
+for cmd in bash sh awk sed grep find mkdir rm cp mktemp printf cat dirname basename tr head tail xargs sleep date wc sha256sum git sort uniq stat ln readlink jq; do
+  cmd_path="$(command -v "$cmd" 2>/dev/null || true)"
+  [ -n "$cmd_path" ] && ln -s "$cmd_path" "$TMP_BIN/$cmd"
+done
+# Skip Claude path (no ~/.claude/) and Gemini (no gemini binary).
+HOME="$TMP_HOME" PATH="$TMP_BIN" bash "$ROOT_DIR/scripts/install-all.sh" --force </dev/null >/tmp/gopher-ai-fresh-codex.log 2>&1
+EXIT=$?
+if [ "$EXIT" -ne 0 ]; then
+  echo "FAIL (install-all exited $EXIT)"
+  sed -n '1,30p' /tmp/gopher-ai-fresh-codex.log
+  ERRORS=$((ERRORS + 1))
+elif [ ! -d "$TMP_HOME/.codex/plugins/go-dev" ]; then
+  echo "FAIL (codex detected but plugins not installed)"
+  sed -n '1,30p' /tmp/gopher-ai-fresh-codex.log
+  ERRORS=$((ERRORS + 1))
+elif [ ! -f "$TMP_HOME/.codex/plugins/go-dev/.gopher-ai-installed" ]; then
+  echo "FAIL (no marker file)"
+  ERRORS=$((ERRORS + 1))
+else
+  echo "OK"
+fi
+rm -rf "$TMP_HOME" "$TMP_BIN"
+
 echo -n "SessionStart hook runs new cleanup despite legacy v1 marker present... "
 # Regression for #147 round 2: users who ran the previous (v1) hook on this
 # same plugin version have a marker like .gopher-ai-cleanup-1.5.0. The new

--- a/scripts/test-installation.sh
+++ b/scripts/test-installation.sh
@@ -699,6 +699,111 @@ else
 fi
 rm -rf "$TMP_HOME"
 
+echo -n "Codex --user refuses to overwrite user-authored same-named plugin... "
+TMP_HOME=$(mktemp -d)
+mkdir -p "$TMP_HOME/.codex/plugins/go-workflow/.codex-plugin"
+# Plant a user-authored plugin with one of our names but a different author.
+printf '{\n  "name": "go-workflow",\n  "version": "9.9.9",\n  "author": { "name": "Other", "email": "other@example.com" }\n}\n' \
+  > "$TMP_HOME/.codex/plugins/go-workflow/.codex-plugin/plugin.json"
+echo "user content" > "$TMP_HOME/.codex/plugins/go-workflow/USER_FILE"
+HOME="$TMP_HOME" bash "$ROOT_DIR/scripts/install-codex.sh" --user >/tmp/gopher-ai-user-skip.log 2>&1
+if [ ! -f "$TMP_HOME/.codex/plugins/go-workflow/USER_FILE" ]; then
+  echo "FAIL (user-authored plugin was overwritten by --user install)"
+  ERRORS=$((ERRORS + 1))
+elif [ -f "$TMP_HOME/.codex/plugins/go-workflow/.gopher-ai-installed" ]; then
+  echo "FAIL (user-authored plugin was marked as gopher-ai)"
+  ERRORS=$((ERRORS + 1))
+elif ! grep -q "skipped" /tmp/gopher-ai-user-skip.log; then
+  echo "FAIL (no skip message in output)"
+  cat /tmp/gopher-ai-user-skip.log
+  ERRORS=$((ERRORS + 1))
+elif [ ! -f "$TMP_HOME/.codex/plugins/go-dev/.gopher-ai-installed" ]; then
+  echo "FAIL (other plugins not installed)"
+  ERRORS=$((ERRORS + 1))
+else
+  echo "OK"
+fi
+rm -rf "$TMP_HOME"
+
+echo -n "Codex --user clears stale gopher-ai marketplace cache... "
+TMP_HOME=$(mktemp -d)
+mkdir -p "$TMP_HOME/.codex/plugins/cache/gopher-ai/go-dev/local"
+echo "cached" > "$TMP_HOME/.codex/plugins/cache/gopher-ai/go-dev/local/CACHE_MARKER"
+HOME="$TMP_HOME" bash "$ROOT_DIR/scripts/install-codex.sh" --user >/tmp/gopher-ai-user-cache.log 2>&1
+if [ -d "$TMP_HOME/.codex/plugins/cache/gopher-ai" ]; then
+  echo "FAIL (gopher-ai marketplace cache not cleared)"
+  ERRORS=$((ERRORS + 1))
+elif ! grep -q "cleared marketplace cache" /tmp/gopher-ai-user-cache.log; then
+  echo "FAIL (no clear message)"
+  cat /tmp/gopher-ai-user-cache.log
+  ERRORS=$((ERRORS + 1))
+else
+  echo "OK"
+fi
+rm -rf "$TMP_HOME"
+
+echo -n "SessionStart hook clears stale cache alongside marked installs... "
+TMP_HOME=$(mktemp -d)
+TMP_PLUGIN=$(mktemp -d)/go-workflow
+mkdir -p "$TMP_HOME/.codex/plugins/cache/gopher-ai/go-dev/local"
+echo "stale" > "$TMP_HOME/.codex/plugins/cache/gopher-ai/go-dev/local/SKILL.md"
+mkdir -p "$TMP_HOME/.codex/plugins/llm-tools/.codex-plugin" "$TMP_PLUGIN/hooks" "$TMP_PLUGIN/.claude-plugin"
+cp "$ROOT_DIR/plugins/go-workflow/hooks/codex-cleanup-on-start.sh" "$TMP_PLUGIN/hooks/"
+cp "$ROOT_DIR/plugins/go-workflow/hooks/legacy-skill-hashes.txt" "$TMP_PLUGIN/hooks/"
+cp "$ROOT_DIR/plugins/go-workflow/.claude-plugin/plugin.json" "$TMP_PLUGIN/.claude-plugin/"
+cp "$ROOT_DIR/plugins/llm-tools/.codex-plugin/plugin.json" "$TMP_HOME/.codex/plugins/llm-tools/.codex-plugin/"
+echo "marker" > "$TMP_HOME/.codex/plugins/llm-tools/.gopher-ai-installed"
+CLAUDE_PLUGIN_ROOT="$TMP_PLUGIN" HOME="$TMP_HOME" \
+  bash "$TMP_PLUGIN/hooks/codex-cleanup-on-start.sh" >/tmp/gopher-ai-hook-cache.log 2>&1
+if [ -d "$TMP_HOME/.codex/plugins/cache/gopher-ai" ]; then
+  echo "FAIL (cache not cleared in presence of marked install)"
+  cat /tmp/gopher-ai-hook-cache.log
+  ERRORS=$((ERRORS + 1))
+else
+  echo "OK"
+fi
+rm -rf "$TMP_HOME" "$(dirname "$TMP_PLUGIN")"
+
+echo -n "SessionStart hook leaves cache alone when no marked install exists... "
+TMP_HOME=$(mktemp -d)
+TMP_PLUGIN=$(mktemp -d)/go-workflow
+mkdir -p "$TMP_HOME/.codex/plugins/cache/gopher-ai/go-dev/local" "$TMP_PLUGIN/hooks" "$TMP_PLUGIN/.claude-plugin"
+echo "user-cache" > "$TMP_HOME/.codex/plugins/cache/gopher-ai/go-dev/local/SKILL.md"
+cp "$ROOT_DIR/plugins/go-workflow/hooks/codex-cleanup-on-start.sh" "$TMP_PLUGIN/hooks/"
+cp "$ROOT_DIR/plugins/go-workflow/hooks/legacy-skill-hashes.txt" "$TMP_PLUGIN/hooks/"
+cp "$ROOT_DIR/plugins/go-workflow/.claude-plugin/plugin.json" "$TMP_PLUGIN/.claude-plugin/"
+CLAUDE_PLUGIN_ROOT="$TMP_PLUGIN" HOME="$TMP_HOME" \
+  bash "$TMP_PLUGIN/hooks/codex-cleanup-on-start.sh" >/dev/null 2>&1
+if [ ! -d "$TMP_HOME/.codex/plugins/cache/gopher-ai" ]; then
+  echo "FAIL (cache wrongly cleared with no marked install present)"
+  ERRORS=$((ERRORS + 1))
+else
+  echo "OK"
+fi
+rm -rf "$TMP_HOME" "$(dirname "$TMP_PLUGIN")"
+
+echo -n "json_author_email parses author.email, not first email anywhere... "
+# Verify the hook's json_author_email function is correctly scoped to the
+# author object — a contributor field with email shouldn't fool it.
+TMP_PLUGIN_JSON=$(mktemp)
+cat > "$TMP_PLUGIN_JSON" <<'EOF'
+{
+  "name": "go-dev",
+  "contributors": [{"email": "first-match@wrong.com"}],
+  "author": {"name": "Gopher Guides", "email": "support@gopherguides.com"}
+}
+EOF
+# Source the function from the hook by extracting it.
+RESULT=$(awk '/^json_author_email\(\) \{/,/^\}/' "$ROOT_DIR/plugins/go-workflow/hooks/codex-cleanup-on-start.sh" \
+  | { cat; echo 'json_author_email "$1"'; } | bash -s "$TMP_PLUGIN_JSON" 2>/dev/null)
+if [ "$RESULT" = "support@gopherguides.com" ]; then
+  echo "OK"
+else
+  echo "FAIL (expected support@gopherguides.com, got: '$RESULT')"
+  ERRORS=$((ERRORS + 1))
+fi
+rm -f "$TMP_PLUGIN_JSON"
+
 echo -n "SessionStart hook removes unmarked legacy plugin directories... "
 TMP_HOME=$(mktemp -d)
 TMP_PLUGIN=$(mktemp -d)/go-workflow

--- a/scripts/test-installation.sh
+++ b/scripts/test-installation.sh
@@ -255,49 +255,37 @@ else
 fi
 rm -rf "$TMP_HOME"
 
-echo -n "install-all.sh runs Codex cleanup without jq on minimal machine... "
+echo -n "install-all.sh fails cleanly when jq is missing... "
+# install-all.sh requires jq for every platform now (including Codex --user,
+# which reads marketplace.json for the version field). This test verifies the
+# script reports a clear "missing jq" error rather than silently misbehaving.
 TMP_HOME=$(mktemp -d)
-mkdir -p "$TMP_HOME/.codex/skills"
-SEEDED_OWNED=""
-for skill_dir in "$ROOT_DIR"/plugins/*/skills/*/; do
-  skill_name=$(basename "$skill_dir")
-  # Skip support directories under skills/ that are not actual skills (e.g.
-  # plugins/go-workflow/skills/coverage/ holds shared docs, not a SKILL.md).
-  [ -f "$skill_dir/SKILL.md" ] || continue
-  SEEDED_OWNED="$skill_name"
-  mkdir -p "$TMP_HOME/.codex/skills/$skill_name"
-  # Verbatim copy so content fingerprint check recognizes it as gopher-ai-owned.
-  cp "$skill_dir/SKILL.md" "$TMP_HOME/.codex/skills/$skill_name/SKILL.md"
-  break
-done
+mkdir -p "$TMP_HOME/.codex"
 JQ_PATH="$(command -v jq 2>/dev/null || true)"
 if [ -n "$JQ_PATH" ]; then
-  # Build a controlled PATH that contains only the directories required for
-  # the test — no jq, no gemini — so the test result reflects installer
-  # behavior rather than what else happens to be on the developer's PATH.
   TMP_BIN=$(mktemp -d)
-  # Note: jq and gemini are intentionally excluded to simulate a minimal
-  # Codex-only machine. sha256sum, git, and sort are needed for the new
-  # content-fingerprint cleanup logic.
+  # Deliberately exclude jq and gemini from this controlled PATH.
   for cmd in bash sh awk sed grep find mkdir rm cp mktemp printf cat dirname basename tr head tail xargs sleep date wc sha256sum git sort uniq stat ln readlink; do
     cmd_path="$(command -v "$cmd" 2>/dev/null || true)"
     [ -n "$cmd_path" ] && ln -s "$cmd_path" "$TMP_BIN/$cmd"
   done
-  if HOME="$TMP_HOME" PATH="$TMP_BIN" bash "$ROOT_DIR/scripts/install-all.sh" --force </dev/null >/tmp/gopher-ai-installall-nojq.log 2>&1; then
-    if [ -d "$TMP_HOME/.codex/skills/$SEEDED_OWNED" ]; then
-      echo "FAIL (cleanup did not run)"
-      ERRORS=$((ERRORS + 1))
-    else
-      echo "OK"
-    fi
-  else
-    echo "FAIL (install-all.sh exited non-zero on Codex-only/no-jq machine)"
-    sed -n '1,40p' /tmp/gopher-ai-installall-nojq.log
+  set +e
+  HOME="$TMP_HOME" PATH="$TMP_BIN" bash "$ROOT_DIR/scripts/install-all.sh" --force </dev/null >/tmp/gopher-ai-installall-nojq.log 2>&1
+  EXIT=$?
+  set -e
+  if [ "$EXIT" -eq 0 ]; then
+    echo "FAIL (install-all.sh should error when jq is missing)"
     ERRORS=$((ERRORS + 1))
+  elif ! grep -q "jq" /tmp/gopher-ai-installall-nojq.log; then
+    echo "FAIL (error message did not mention jq)"
+    sed -n '1,20p' /tmp/gopher-ai-installall-nojq.log
+    ERRORS=$((ERRORS + 1))
+  else
+    echo "OK"
   fi
   rm -rf "$TMP_BIN"
 else
-  echo "SKIP (jq not installed)"
+  echo "SKIP (jq not installed locally)"
 fi
 rm -rf "$TMP_HOME"
 
@@ -662,17 +650,99 @@ else
   echo "OK"
 fi
 
-echo -n "Codex --user mode is rejected with migration message... "
-if HOME="$(mktemp -d)" bash "$ROOT_DIR/scripts/install-codex.sh" --user >/tmp/gopher-ai-user-rejected.log 2>&1; then
-  echo "FAIL (--user should exit non-zero)"
+echo -n "Codex --user installs plugins globally with marker file... "
+TMP_HOME=$(mktemp -d)
+if ! HOME="$TMP_HOME" bash "$ROOT_DIR/scripts/install-codex.sh" --user >/tmp/gopher-ai-user-install.log 2>&1; then
+  echo "FAIL (--user exited non-zero)"
+  sed -n '1,40p' /tmp/gopher-ai-user-install.log
   ERRORS=$((ERRORS + 1))
-elif ! grep -q "removed" /tmp/gopher-ai-user-rejected.log; then
-  echo "FAIL (no migration message)"
-  sed -n '1,40p' /tmp/gopher-ai-user-rejected.log
+else
+  EXPECTED_PLUGINS="go-dev go-web go-workflow gopher-guides llm-tools tailwind"
+  MISSING=""
+  UNMARKED=""
+  for p in $EXPECTED_PLUGINS; do
+    if [ ! -d "$TMP_HOME/.codex/plugins/$p" ]; then
+      MISSING="$MISSING $p"
+    elif [ ! -f "$TMP_HOME/.codex/plugins/$p/.gopher-ai-installed" ]; then
+      UNMARKED="$UNMARKED $p"
+    elif [ -d "$TMP_HOME/.codex/plugins/$p/.claude-plugin" ]; then
+      # Codex installs should not ship the Claude-Code-only manifest dir.
+      UNMARKED="$UNMARKED $p(has-claude-plugin)"
+    fi
+  done
+  if [ -n "$MISSING" ]; then
+    echo "FAIL (missing:$MISSING)"
+    ERRORS=$((ERRORS + 1))
+  elif [ -n "$UNMARKED" ]; then
+    echo "FAIL (no marker or stray .claude-plugin:$UNMARKED)"
+    ERRORS=$((ERRORS + 1))
+  else
+    echo "OK (6 plugins installed and marked)"
+  fi
+fi
+rm -rf "$TMP_HOME"
+
+echo -n "Codex --user is idempotent (re-running cleanly replaces) ... "
+TMP_HOME=$(mktemp -d)
+HOME="$TMP_HOME" bash "$ROOT_DIR/scripts/install-codex.sh" --user >/dev/null 2>&1
+# Drop a sentinel inside one plugin dir to ensure a re-run wipes it cleanly.
+echo "stale" > "$TMP_HOME/.codex/plugins/go-dev/STALE_FILE"
+HOME="$TMP_HOME" bash "$ROOT_DIR/scripts/install-codex.sh" --user >/dev/null 2>&1
+if [ -f "$TMP_HOME/.codex/plugins/go-dev/STALE_FILE" ]; then
+  echo "FAIL (stale file survived re-install)"
+  ERRORS=$((ERRORS + 1))
+elif [ ! -f "$TMP_HOME/.codex/plugins/go-dev/.gopher-ai-installed" ]; then
+  echo "FAIL (marker missing after re-run)"
   ERRORS=$((ERRORS + 1))
 else
   echo "OK"
 fi
+rm -rf "$TMP_HOME"
+
+echo -n "SessionStart hook removes unmarked legacy plugin directories... "
+TMP_HOME=$(mktemp -d)
+TMP_PLUGIN=$(mktemp -d)/go-workflow
+mkdir -p "$TMP_HOME/.codex/plugins" "$TMP_PLUGIN/hooks" "$TMP_PLUGIN/.claude-plugin"
+cp "$ROOT_DIR/plugins/go-workflow/hooks/codex-cleanup-on-start.sh" "$TMP_PLUGIN/hooks/"
+cp "$ROOT_DIR/plugins/go-workflow/hooks/legacy-skill-hashes.txt" "$TMP_PLUGIN/hooks/"
+cp "$ROOT_DIR/plugins/go-workflow/.claude-plugin/plugin.json" "$TMP_PLUGIN/.claude-plugin/"
+
+# Seed three scenarios:
+#   1. LEGACY:    gopher-ai plugin, no marker → MUST be removed
+#   2. MARKED:    gopher-ai plugin with marker → MUST be kept
+#   3. CONFLICT:  user-authored plugin sharing a gopher-ai name with different
+#                 author email → MUST be kept
+mkdir -p "$TMP_HOME/.codex/plugins/go-dev/.codex-plugin"
+cp "$ROOT_DIR/plugins/go-dev/.codex-plugin/plugin.json" "$TMP_HOME/.codex/plugins/go-dev/.codex-plugin/"
+
+mkdir -p "$TMP_HOME/.codex/plugins/llm-tools/.codex-plugin"
+cp "$ROOT_DIR/plugins/llm-tools/.codex-plugin/plugin.json" "$TMP_HOME/.codex/plugins/llm-tools/.codex-plugin/"
+echo "marker" > "$TMP_HOME/.codex/plugins/llm-tools/.gopher-ai-installed"
+
+mkdir -p "$TMP_HOME/.codex/plugins/go-workflow/.codex-plugin"
+printf '{\n  "name": "go-workflow",\n  "version": "0.1.0",\n  "author": { "name": "Other Author", "email": "other@example.com" }\n}\n' \
+  > "$TMP_HOME/.codex/plugins/go-workflow/.codex-plugin/plugin.json"
+
+CLAUDE_PLUGIN_ROOT="$TMP_PLUGIN" HOME="$TMP_HOME" \
+  bash "$TMP_PLUGIN/hooks/codex-cleanup-on-start.sh" >/tmp/gopher-ai-hook-plugins.log 2>&1
+if [ -d "$TMP_HOME/.codex/plugins/go-dev" ]; then
+  echo "FAIL (legacy unmarked plugin not removed: go-dev)"
+  cat /tmp/gopher-ai-hook-plugins.log
+  ERRORS=$((ERRORS + 1))
+elif [ ! -d "$TMP_HOME/.codex/plugins/llm-tools" ]; then
+  echo "FAIL (cleanup wrongly removed marked plugin: llm-tools)"
+  ERRORS=$((ERRORS + 1))
+elif [ ! -d "$TMP_HOME/.codex/plugins/go-workflow" ]; then
+  echo "FAIL (cleanup wrongly removed user-authored same-named plugin: go-workflow)"
+  ERRORS=$((ERRORS + 1))
+elif ! grep -q "removed 1 unmarked legacy plugin" /tmp/gopher-ai-hook-plugins.log; then
+  echo "FAIL (no removal message in stderr)"
+  cat /tmp/gopher-ai-hook-plugins.log
+  ERRORS=$((ERRORS + 1))
+else
+  echo "OK"
+fi
+rm -rf "$TMP_HOME" "$(dirname "$TMP_PLUGIN")"
 
 echo -n "Build no longer emits dist/codex/skills/... "
 if [ -d "$ROOT_DIR/dist/codex/skills" ]; then

--- a/scripts/test-installation.sh
+++ b/scripts/test-installation.sh
@@ -699,6 +699,40 @@ else
 fi
 rm -rf "$TMP_HOME"
 
+echo -n "SessionStart hook runs new cleanup despite legacy v1 marker present... "
+# Regression for #147 round 2: users who ran the previous (v1) hook on this
+# same plugin version have a marker like .gopher-ai-cleanup-1.5.0. The new
+# hook adds plugin and cache cleanup; if the marker check short-circuits on
+# that legacy marker, those users never get the new cleanups. Verify the
+# new marker schema (.gopher-ai-cleanup-v2-<plugin-version>) makes the hook
+# run regardless.
+TMP_HOME=$(mktemp -d)
+TMP_PLUGIN=$(mktemp -d)/go-workflow
+mkdir -p "$TMP_HOME/.codex/plugins/cache/gopher-ai/go-dev/local"
+mkdir -p "$TMP_HOME/.codex/plugins/llm-tools/.codex-plugin"
+mkdir -p "$TMP_PLUGIN/hooks" "$TMP_PLUGIN/.claude-plugin"
+cp "$ROOT_DIR/plugins/go-workflow/hooks/codex-cleanup-on-start.sh" "$TMP_PLUGIN/hooks/"
+cp "$ROOT_DIR/plugins/go-workflow/hooks/legacy-skill-hashes.txt" "$TMP_PLUGIN/hooks/"
+cp "$ROOT_DIR/plugins/go-workflow/.claude-plugin/plugin.json" "$TMP_PLUGIN/.claude-plugin/"
+cp "$ROOT_DIR/plugins/llm-tools/.codex-plugin/plugin.json" "$TMP_HOME/.codex/plugins/llm-tools/.codex-plugin/"
+echo "marker" > "$TMP_HOME/.codex/plugins/llm-tools/.gopher-ai-installed"
+# Plant the legacy v1-style marker (no v2- prefix).
+PLUGIN_VERSION=$(awk -F'"' '/"version"/ {print $4; exit}' "$TMP_PLUGIN/.claude-plugin/plugin.json")
+touch "$TMP_HOME/.codex/.gopher-ai-cleanup-${PLUGIN_VERSION}"
+CLAUDE_PLUGIN_ROOT="$TMP_PLUGIN" HOME="$TMP_HOME" \
+  bash "$TMP_PLUGIN/hooks/codex-cleanup-on-start.sh" >/tmp/gopher-ai-hook-marker-bump.log 2>&1
+if [ -d "$TMP_HOME/.codex/plugins/cache/gopher-ai" ]; then
+  echo "FAIL (legacy marker prevented new cache cleanup from running)"
+  cat /tmp/gopher-ai-hook-marker-bump.log
+  ERRORS=$((ERRORS + 1))
+elif ! ls "$TMP_HOME/.codex/.gopher-ai-cleanup-v2-"* >/dev/null 2>&1; then
+  echo "FAIL (new v2 marker not written)"
+  ERRORS=$((ERRORS + 1))
+else
+  echo "OK"
+fi
+rm -rf "$TMP_HOME" "$(dirname "$TMP_PLUGIN")"
+
 echo -n "Codex --user refuses to overwrite user-authored same-named plugin... "
 TMP_HOME=$(mktemp -d)
 mkdir -p "$TMP_HOME/.codex/plugins/go-workflow/.codex-plugin"


### PR DESCRIPTION
## Summary

Real-user feedback: Cory ran `install-all.sh`, plugins disappeared from `~/.codex/plugins/`, gopher-ai went silent. He's right — the script's name says install but for Codex it just ran cleanup. This PR fixes that.

### What was broken

#145 + #146 removed `--user` mode (which was genuinely broken — flat skills overflowing Codex's budget) but never replaced it with a working global-install path. So:

- `install-all.sh`'s Codex branch: only ran `--cleanup --yes`, never installed plugins.
- The only way to get gopher-ai globally was the old README instruction "manually copy `dist/codex/plugins/` to `~/.codex/plugins/`", which broke the moment we changed the build.
- When the SessionStart hook (#146) was about to be extended to clean up those manual-install leftovers, it would have removed every working install — silently breaking users who had no other path.

### What this PR does

**Resurrects `--user` as a proper global-plugin install:**
- Copies `plugins/<name>/` → `~/.codex/plugins/<name>/` for each Codex plugin.
- `rm -rf` before `cp -R` so re-running cleanly replaces stale installs.
- Drops the `.claude-plugin/` subdir from the Codex copy.
- Writes a `.gopher-ai-installed` marker file with version + timestamp + source. **This marker is the ownership signal** for the cleanup hook.
- Also runs the existing legacy `~/.codex/skills/` cleanup.

**`install-all.sh` actually installs Codex now:**
- Codex section calls `install-codex.sh --user` (was `--cleanup --yes`).
- "Next steps" tells users to restart Codex.

**SessionStart hook self-heals across both error modes:**
- Existing: removes legacy `~/.codex/skills/` skill dirs (three-gate check from #146).
- New: removes unmarked legacy `~/.codex/plugins/<name>/` plugin dirs (three-gate check):
  1. Dir name matches one of our seven plugin names.
  2. **No `.gopher-ai-installed` marker** — proper installs always have one.
  3. `plugin.json` `name:` matches dirname AND `author.email == support@gopherguides.com`.
- A user-authored plugin sharing one of our names with a different author email is preserved. A marked install is never touched.

## Migration paths the hook handles

| User state | What the hook does |
|------------|---|
| Old `--user` flat skills at `~/.codex/skills/` | Removes via skill manifest match (existing #146 behavior) |
| Old README "manually copy plugins" at `~/.codex/plugins/<name>/` (no marker) | **NEW:** removes via author-email check |
| Current `--user` install (has marker) | Leaves alone |
| User-authored plugin sharing one of our seven names | Leaves alone (different author.email) |

## Test plan

- [x] **27 installation tests pass** (4 new):
  - `Codex --user installs plugins globally with marker file` — all 6 plugins land at `~/.codex/plugins/<name>/`, each marked, no `.claude-plugin/` leaks in.
  - `Codex --user is idempotent` — sentinel file dropped in installed plugin gets wiped on re-run (proves `rm -rf` + `cp -R`, not overlay).
  - `SessionStart hook removes unmarked legacy plugin directories` — seeds legacy-unmarked + marked + user-authored-same-name; asserts only the unmarked is removed.
  - `install-all.sh fails cleanly when jq is missing` — replaces the old no-jq cleanup-only test (no longer applicable now that --user is the install path).
- [x] Manual end-to-end: ran `--user` against fresh `$HOME`, verified 6 plugins installed with marker. Ran the hook against seeded scenarios, verified discrimination.
- [ ] Manual: Cory runs the curl one-liner on his affected machine, verifies (a) gopher-ai plugins reappear at `~/.codex/plugins/<name>/`, (b) the budget warning stays gone (vercel still disabled), (c) restart Codex actually has skills available.

## Commits

```
e7839e9 feat(install): resurrect --user mode as global plugin install + self-healing cleanup
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)