### PR TITLE
refactor(skills): split start-issue.md (27 KB) into lib/start-issue/ siblings (PR 5/N)

### DIFF
--- a/plugins/go-workflow/commands/start-issue.md
+++ b/plugins/go-workflow/commands/start-issue.md
@@ -8,28 +8,25 @@ allowed-tools: ["Bash", "Read", "Glob", "Grep", "Edit", "Write", "AskUserQuestio
 
 **If `$ARGUMENTS` is empty or not provided:**
 
-Display usage information and ask for input:
-
-This command starts work on a GitHub issue, automatically detecting whether it's a bug fix or new feature and following the appropriate workflow.
-
-**Usage:** `/start-issue <issue-number> [--skip-coverage] [--coverage-threshold <n>]`
-
-**Example:** `/start-issue 123` or `/start-issue 123 --coverage-threshold 80`
-
-**Options:**
-- `--skip-coverage`: Skip coverage verification after implementation
-- `--coverage-threshold <n>`: Override default 60% coverage threshold
-- `--no-agents`: Use single-session workflow instead of subagent dispatch (for small/simple issues)
-
-**Workflow:**
-
-1. Fetch issue details, labels, and comments
-2. Optionally create a git worktree for isolated work
-3. Auto-detect issue type (bug vs feature)
-4. Create `fix/` or `feat/` branch (or use worktree branch)
-5. For bugs: Check duplicates → TDD red-green → verify → **coverage check** → security review
-6. For features: Plan approach → TDD red-green → verify → **coverage check** → security review
-7. Commit, push, and create PR
+> This command starts work on a GitHub issue, automatically detecting whether it's a bug fix or new feature and following the appropriate workflow.
+>
+> **Usage:** `/start-issue <issue-number> [--skip-coverage] [--coverage-threshold <n>]`
+>
+> **Example:** `/start-issue 123` or `/start-issue 123 --coverage-threshold 80`
+>
+> **Options:**
+> - `--skip-coverage`: Skip coverage verification after implementation
+> - `--coverage-threshold <n>`: Override default 60% coverage threshold
+> - `--no-agents`: Use single-session workflow instead of subagent dispatch (for small/simple issues)
+>
+> **Workflow:**
+> 1. Fetch issue details, labels, and comments
+> 2. Optionally create a git worktree for isolated work
+> 3. Auto-detect issue type (bug vs feature)
+> 4. Create `fix/` or `feat/` branch (or use worktree branch)
+> 5. For bugs: Check duplicates → TDD red-green → verify → **coverage check** → security review
+> 6. For features: Plan approach → TDD red-green → verify → **coverage check** → security review
+> 7. Commit, push, and create PR
 
 Ask the user: "What issue number would you like to work on?"
 
@@ -62,7 +59,6 @@ Store the parsed flags:
 
 ## Loop Initialization
 
-Initialize persistent loop to ensure work continues until complete (uses `$ISSUE_NUM`, not raw `$ARGUMENTS`):
 !`if [ ! -x "${CLAUDE_PLUGIN_ROOT}/scripts/setup-loop.sh" ]; then echo "ERROR: Plugin cache stale. Run /gopher-ai-refresh (or refresh-plugins.sh) and restart Claude Code."; exit 1; else ISSUE_NUM=$(echo "$ARGUMENTS" | sed 's/--skip-coverage//g; s/--coverage-threshold *[0-9]*//g; s/--no-agents//g' | tr -d ' '); "${CLAUDE_PLUGIN_ROOT}/scripts/setup-loop.sh" "start-issue-$ISSUE_NUM" "COMPLETE" "" "" '{}'; fi`
 
 ## Context
@@ -90,7 +86,7 @@ fi
 
 This resolves both `--git-dir` and `--git-common-dir` to absolute paths via `cd ... && pwd`, then compares them. In the main repo (even from a subdirectory) both resolve to the same absolute `.git` path. In a linked worktree, `--git-dir` resolves to `.git/worktrees/<name>` while `--git-common-dir` resolves to `.git`.
 
-**If `IN_WORKTREE=true`:** Skip the worktree question entirely. You are already in an isolated worktree. Proceed directly to "Plan Mode Check" (the "No, work in current directory" path). Display:
+**If `IN_WORKTREE=true`:** Skip the worktree question entirely. Proceed directly to "Plan Mode Check" (the "No, work in current directory" path). Display:
 
 ```
 Already running in a worktree — skipping worktree creation.
@@ -115,82 +111,17 @@ Use AskUserQuestion with this exact configuration:
 
 ---
 
-## If user chose "Yes, create worktree":
+## If user chose "Yes, create worktree"
 
-**CRITICAL: When executing bash commands below, use backticks (\`) for command substitution, NOT $(). Claude Code has a bug that mangles $() syntax.**
+→ Read `${CLAUDE_PLUGIN_ROOT}/lib/start-issue/worktree-create.md` and follow the full procedure: capture `SOURCE_DIR`, derive `WORKTREE_NAME`/`BRANCH_NAME` from issue title, fetch and create the worktree, search for env files (`.env`/`.env.local`/`.envrc`) and offer to copy with directory structure preserved, capture `WORKTREE_ABS_PATH`, register the worktree state file (enables hook-based path enforcement), and confirm to the user.
 
-**Create the worktree NOW, before entering plan mode.** This ensures the worktree path is a concrete, established fact when the plan is written.
+After the worktree is established, continue to **Plan Mode Check** below.
 
-1. **Capture source directory first**
-   ```bash
-   SOURCE_DIR=`pwd`
-   ```
+## If user chose "No, work in current directory"
 
-2. **Create worktree directory name**
-   ```bash
-   REPO_NAME=`basename \`git rev-parse --show-toplevel\``
-   ISSUE_TITLE=`gh issue view "$ISSUE_NUM" --json title --jq '.title' | sed 's/[^a-zA-Z0-9-]/-/g' | tr '[:upper:]' '[:lower:]' | sed 's/--*/-/g' | sed 's/^-//' | sed 's/-$//'`
-   WORKTREE_NAME="${REPO_NAME}-issue-$ISSUE_NUM-$ISSUE_TITLE"
-   WORKTREE_PATH="../$WORKTREE_NAME"
-   BRANCH_NAME="issue-$ISSUE_NUM-$ISSUE_TITLE"
-   ```
+Continue to **Step 1: Detect Issue Type** below. You will create a branch in the appropriate workflow step.
 
-3. **Fetch and create worktree**
-   ```bash
-   DEFAULT_BRANCH=`git remote show origin | grep 'HEAD branch' | sed 's/.*: //' | tr -cd '[:alnum:]-._/'`
-   git fetch origin "$DEFAULT_BRANCH"
-   git branch -D "$BRANCH_NAME" 2>/dev/null || true
-   git worktree add "$WORKTREE_PATH" "origin/$DEFAULT_BRANCH"
-   cd "$WORKTREE_PATH" && git checkout -b "$BRANCH_NAME"
-   ```
-
-4. **Search for environment files** (recursive, excludes node_modules/.git/vendor)
-   ```bash
-   ENV_FILES=`find "$SOURCE_DIR" \( -name "node_modules" -o -name ".git" -o -name "vendor" \) -prune -o \
-     \( -name ".env" -o -name ".env.local" -o -name ".envrc" \) -type f -print 2>/dev/null | \
-     sed "s|^$SOURCE_DIR/||" | grep -v "^-" | sort`
-   if [ -n "$ENV_FILES" ]; then
-     echo "Found env files:"
-     echo "$ENV_FILES"
-   fi
-   ```
-
-   **If environment files found**, list them and ask user: "Found environment files (may contain secrets). Copy them to worktree?"
-
-   If confirmed, copy preserving directory structure:
-   ```bash
-   echo "$ENV_FILES" | while read file; do
-     if [ -n "$file" ]; then
-       dir=`dirname "$file"`
-       if [ "$dir" != "." ]; then
-         mkdir -p "$WORKTREE_PATH/$dir"
-       fi
-       cp -P "$SOURCE_DIR/$file" "$WORKTREE_PATH/$file"
-       echo "Copied $file"
-     fi
-   done
-   ```
-
-5. **Capture absolute worktree path**
-
-   ```bash
-   WORKTREE_ABS_PATH=`cd "$WORKTREE_PATH" && pwd`
-   echo "Worktree absolute path: $WORKTREE_ABS_PATH"
-   ls "$WORKTREE_ABS_PATH"
-   ```
-
-   **Save this absolute path.** You will use it for EVERY tool call from this point forward.
-
-6. **Register worktree state** (enables hook-based path enforcement)
-
-   ```bash
-   REPO_ROOT=`git rev-parse --show-toplevel`
-   "${CLAUDE_PLUGIN_ROOT}/scripts/worktree-state.sh" save "$WORKTREE_ABS_PATH" "$REPO_ROOT" "$ISSUE_NUM"
-   ```
-
-   This saves the worktree path so the pre-tool-use hook will **block** any tool call that accidentally targets the original repo instead of the worktree.
-
-7. **Inform user**: "Created worktree at `$WORKTREE_ABS_PATH`. All work will happen there."
+**Now** call `EnterPlanMode` to create a plan for the implementation (if not already in plan mode).
 
 ---
 
@@ -200,7 +131,7 @@ Use AskUserQuestion with this exact configuration:
 
 If you are NOT currently in plan mode (no "Plan mode is active" in your system context), call the `EnterPlanMode` tool now.
 
-**CRITICAL: When writing your plan, you MUST include these facts at the top of the plan file:**
+**CRITICAL: When writing your plan, include these facts at the top of the plan file:**
 
 If a worktree was created:
 ```
@@ -210,7 +141,7 @@ Original repo (DO NOT USE): <the SOURCE_DIR value>
 The pre-tool-use hook will BLOCK any tool call targeting the original repo.
 ```
 
-If no worktree (working in current directory):
+If no worktree:
 ```
 ## Working Directory
 Working in current directory. A feature branch will be created.
@@ -223,8 +154,6 @@ If you ARE already in plan mode, continue with the workflow below.
 ## ⚠️ MANDATORY: All Work Happens in the Worktree ⚠️
 
 **Your shell CWD does NOT persist between Bash calls. Claude Code resets it every time.** You CANNOT just `cd` once — it will be forgotten. You must actively use the worktree path in EVERY tool call.
-
-**Rules for EVERY tool call from this point forward:**
 
 | Tool | How to use the worktree path |
 |------|------------------------------|
@@ -239,19 +168,9 @@ If you ARE already in plan mode, continue with the workflow below.
 
 **Self-check before EVERY file operation:** "Does this path start with `$WORKTREE_ABS_PATH`?" If not, STOP and fix it.
 
----
-
-**Note:** When using a worktree, the branch is already created as `issue-<num>-<title>`. Skip the "Create Branch" step in the workflows below.
+**Note:** When using a worktree, the branch is already `issue-<num>-<title>`. Skip the "Create Branch" step in the workflows below.
 
 Continue to **Step 1: Detect Issue Type** below.
-
----
-
-## If user chose "No, work in current directory":
-
-Continue to **Step 1: Detect Issue Type** below. You will create a branch in the appropriate workflow step.
-
-**Now** call `EnterPlanMode` to create a plan for the implementation (if not already in plan mode).
 
 ---
 
@@ -279,326 +198,46 @@ Analyze the issue to determine if it's a **bug fix** or **new feature**:
 - Bug patterns: "fix", "broken", "error", "fail", "crash", "doesn't work", "issue with", "problem", "bug", "regression", "incorrect"
 - Feature patterns: "add", "implement", "create", "new", "support", "enable", "allow", "introduce", "enhance"
 
-**If still uncertain**, ask the user:
-
-"I couldn't determine if this is a bug fix or new feature. Which workflow should I follow?"
-
-| Option | Description |
-|--------|-------------|
-| Bug Fix | TDD approach: write failing test (red), then fix (green) |
-| New Feature | TDD approach: write failing tests (red), then implement (green) |
+**If still uncertain**, ask the user via `AskUserQuestion`: "I couldn't determine if this is a bug fix or new feature. Which workflow should I follow?" with options **Bug Fix** / **New Feature**.
 
 ---
 
-## Subagent-Orchestrated Workflow (Default)
+## Implementation Workflow
 
-**If `NO_AGENTS` is `true`, skip to the "Manual Workflow (Fallback)" section below.**
+### Subagent-Orchestrated (default — when `NO_AGENTS=false`)
 
-This workflow uses focused subagents for exploration, implementation, and review. The orchestrator (this session) retains all control flow, verification gates, and external interactions.
+→ Read `${CLAUDE_PLUGIN_ROOT}/lib/start-issue/orchestrated-workflow.md` for the full 12-step procedure: duplicate check (bugs only), branch creation, Explore subagent dispatch, design approach (features only), task decomposition + parallel-dispatch decision, Implementer subagent dispatch (parallel or sequential), spec-compliance review (opus), quality review (sonnet), verify (build/test/lint), Step 9.5 coverage gate, security review, submit (PR template detection + creation), watch CI.
 
-### Step 1: Check for Duplicates (Bug Fix Only)
+### Manual (`--no-agents` fallback)
 
-If issue is a **bug**, search for related issues:
-
-```bash
-gh issue list --state all --limit 50 --search "<key terms from title/body>"
-```
-
-**If potential duplicates found**, present them and ask user how to proceed (Continue / Skip / Link).
-
-### Step 2: Create Branch (skip if worktree was created)
-
-**REQUIRED unless using a worktree.** Never commit to main/master.
-
-For bugs:
-```bash
-git checkout -b "fix/$ISSUE_NUM-<short-desc>"
-```
-
-For features:
-```bash
-git checkout -b "feat/$ISSUE_NUM-<short-desc>"
-```
-
-Verify you are on the new branch before proceeding:
-```bash
-git branch --show-current
-```
-
-### Step 3: Explore Phase
-
-Read `${CLAUDE_PLUGIN_ROOT}/agents/explore-prompt.md` and fill in the template variables:
-- `{ISSUE_TITLE}` — from issue context
-- `{ISSUE_BODY}` — from issue context (body + comments)
-- `{ISSUE_TYPE}` — "bug" or "feature"
-- `{WORKTREE_PATH}` — absolute path to working directory
-- `{REPO_CONVENTIONS}` — from CLAUDE.md or AGENTS.md if present in the repo
-
-Dispatch the Explore subagent:
-```
-Agent(prompt=<filled template>, model=sonnet, subagent_type=Explore)
-```
-
-Store the results: RELEVANT_FILES, PATTERNS, ROOT_CAUSE (bugs) or INTEGRATION_POINTS (features), PROPOSED_CHANGES, TASK_DECOMPOSITION.
-
-### Step 4: Design Approach (Features Only)
-
-Present the plan before implementing. Plan approval is the gate — once the user accepts the plan, you have approval for everything in it (including data migrations, schema changes, and new packages). Do not stop again to re-confirm individual items that were already in the approved plan.
-
-Using the Explore results, propose 2-3 approaches with concrete trade-offs:
-- What it changes (files, types, APIs, schema/migrations)
-- Trade-offs (complexity vs simplicity, performance vs maintainability)
-- Your recommendation and why
-
-**Surface migrations and schema changes explicitly in the plan** so the user can see them and approve in one shot. Do not treat migrations as a separate hard gate.
-
-**For trivial features** (single function, obvious implementation): state your plan and proceed unless the user objects.
-
-**For non-trivial features** (new package, API changes, data model changes): present approaches and recommend one. Use your judgment on whether to wait for an explicit reply — if the change is risky, irreversible, or you're genuinely uncertain which approach the user wants, ask. Otherwise, state the recommended plan and proceed unless the user objects.
-
-### Step 5: Task Decomposition
-
-Using the Explore results and approved approach:
-
-**For bugs:** Typically 1 task — fix the root cause identified in the Explore phase.
-
-**For features:** Decompose into N tasks where each task:
-- Has a clear description of what to implement
-- Lists TARGET_FILES (files to create/modify) — must be disjoint across tasks for parallel dispatch
-- Lists TEST_FILES
-- Lists CONTEXT_FILES (read-only reference files)
-- Notes dependencies on other tasks (empty = independent)
-
-**Parallel dispatch decision:** If ALL tasks have disjoint TARGET_FILES AND disjoint TEST_FILES (including shared test helpers in the same package) and no dependencies, they can run in parallel. Otherwise, sequential. Two tasks in the same Go package almost always share a `_test.go` file — default to sequential for same-package tasks.
-
-### Step 6: Implementation Phase
-
-For each task, read `${CLAUDE_PLUGIN_ROOT}/agents/implementer-prompt.md` and fill in the template variables:
-- `{TASK_DESCRIPTION}` — from task decomposition
-- `{TARGET_FILES}` — files this agent may create/modify
-- `{TEST_FILES}` — test file(s) for this task
-- `{WORKTREE_PATH}` — absolute path to working directory
-- `{PATTERNS}` — from Explore results
-- `{CONTEXT_FILES}` — read-only reference files
-- `{ISSUE_TYPE}` — "bug" or "feature"
-
-**Dispatch:**
-- **Parallel** (independent tasks with disjoint files):
-  ```
-  For each task: Agent(prompt=<filled>, model=sonnet, run_in_background=true)
-  Wait for all to complete. Collect results.
-  ```
-- **Sequential** (dependent tasks or overlapping files):
-  ```
-  For each task in order: Agent(prompt=<filled>, model=sonnet)
-  ```
-
-**Handle subagent status:**
-
-| Status | Action |
-|--------|--------|
-| DONE | Continue to next task or review phase |
-| DONE_WITH_CONCERNS | Evaluate concerns — fix correctness issues before proceeding |
-| NEEDS_CONTEXT | Supply the requested information, re-dispatch the implementer |
-| BLOCKED | Present blockers to user via AskUserQuestion, get guidance |
-
-### Step 7: Spec Compliance Review
-
-After ALL implementation tasks complete, determine the default branch and generate the diff:
-
-```bash
-DEFAULT_BRANCH=$(git remote show origin 2>/dev/null | grep 'HEAD branch' | sed 's/.*: //' || echo "main")
-git fetch origin "$DEFAULT_BRANCH" 2>/dev/null || true
-git diff "origin/${DEFAULT_BRANCH}...HEAD"
-```
-
-Read `${CLAUDE_PLUGIN_ROOT}/agents/spec-review-prompt.md` and fill in:
-- `{ISSUE_TITLE}`, `{ISSUE_BODY}`, `{ACCEPTANCE_CRITERIA}` — from issue context
-- `{WORKTREE_PATH}` — working directory
-- `{CHANGED_FILES}` — list of all files changed
-- `{DIFF}` — the full diff
-
-Dispatch:
-```
-Agent(prompt=<filled>, model=opus)
-```
-
-**If VERDICT = FAIL:**
-- Address missing requirements by re-dispatching implementer subagent(s) for the gaps
-- Re-run spec review (max 2 retry cycles)
-
-**If VERDICT = PASS:** Proceed to quality review.
-
-### Step 8: Code Quality Review
-
-Read `${CLAUDE_PLUGIN_ROOT}/agents/quality-review-prompt.md` and fill in:
-- `{WORKTREE_PATH}` — working directory
-- `{CHANGED_FILES}` — list of all files changed
-- `{DIFF}` — the full diff
-- `{PATTERNS}` — from Explore results
-- `{REPO_CONVENTIONS}` — from CLAUDE.md or AGENTS.md
-
-Dispatch:
-```
-Agent(prompt=<filled>, model=sonnet)
-```
-
-**If HAS_FINDINGS:**
-- Priority 0-1 (critical/high): Fix these directly, then re-run quality review (max 1 retry)
-- Priority 2-3 (medium/low): Note in PR description but do not block
-
-**If CLEAN:** Proceed to verification.
-
-### Step 9: Verify
-
-Run the full verification checklist. **All must pass before proceeding:**
-
-- **Build**: `go build ./...` — confirm compilation succeeds
-- **All tests**: `go test ./...` — confirm ALL tests pass
-- **Lint**: `golangci-lint run` (if available) — confirm no lint issues
-- **Build logs**: If a dev server is running, check its log output for errors
-
-If any step fails, fix the issue and re-run until all green.
-
-### Step 9.5: Coverage Verification
-
-Read `${CLAUDE_PLUGIN_ROOT}/skills/coverage/coverage-verification.md` and follow Steps A through F with these parameters:
-
-| Variable | Value |
-|----------|-------|
-| `BASE_BRANCH` | `origin/${DEFAULT_BRANCH}` (compute DEFAULT_BRANCH if not already set: `git remote show origin 2>/dev/null \| grep 'HEAD branch' \| sed 's/.*: //' \|\| echo "main"`) |
-| `STATE_FILE` | Absolute path to `.local/state/start-issue-$ISSUE_NUM.loop.local.json` (in the original repo, not the worktree) |
-| `SKIP_COVERAGE` | from parsed flags (default: `false`) |
-| `COVERAGE_THRESHOLD` | from parsed flags (default: `60`) |
-
-After coverage verification completes (or is skipped), continue to Step 10.
-
-### Step 10: Security Review
-
-Before submitting, scan for security issues in changed files:
-
-- **Dependency vulnerabilities**: Run `govulncheck ./...` (if available)
-- **Scan changed files** for common Go security issues:
-  - Hardcoded secrets or credentials
-  - SQL injection (string concatenation in queries instead of parameterized)
-  - Path traversal (`filepath.Join` with user input without `filepath.Clean`)
-  - Unsafe `exec.Command` with unsanitized user input
-  - Missing error checks on security-critical operations (crypto, auth, file permissions)
-- **If changes touch auth, crypto, or data handling code**, suggest running `/codex review` with a security focus
-
-### Step 11: Submit
-
-Commit and push changes, then create a PR:
-
-1. Stage and commit with a conventional commit message referencing the issue
-2. Push the branch: `git push -u origin <branch>`
-3. **Check for PR template** — look for a template file in these locations (in order):
-   - `.github/pull_request_template.md`
-   - `.github/PULL_REQUEST_TEMPLATE.md`
-   - `.github/PULL_REQUEST_TEMPLATE/` (directory with multiple templates — list and ask user which to use)
-   - `docs/pull_request_template.md`
-   - `docs/PULL_REQUEST_TEMPLATE/` (directory with multiple templates)
-   - `pull_request_template.md` (repo root)
-   - `PULL_REQUEST_TEMPLATE/` (repo root directory with multiple templates)
-4. **If template found**: Read the template and use its exact section structure for the PR body. Fill in every section — do not omit or skip sections. Always include `Fixes #<issue-number>` or `Closes #<issue-number>` even if the template doesn't have a dedicated section for it.
-5. **If no template found**: Use this default format:
-   ```
-   ## Summary
-   <1-3 bullet points describing what changed and why>
-
-   Fixes #<issue-number>
-
-   ## Test Plan
-   <How the changes were tested>
-   ```
-6. Create the PR with heredoc formatting:
-   ```bash
-   gh pr create --title "<type>(<scope>): <subject>" --body "`cat <<'EOF'
-   <filled-in template or default body>
-   EOF
-   `"
-   ```
-
-### Step 12: Watch CI
-
-After creating the PR, watch CI and fix any failures:
-
-1. Run: `gh pr checks --watch`
-2. **If "no checks reported"**: Wait 10 seconds and retry, up to 3 times:
-   ```bash
-   for i in 1 2 3; do sleep 10 && gh pr checks --watch && break; done
-   ```
-   If still no checks after retries, verify CI workflow files exist.
-3. If checks fail:
-   - Get failure details: `gh pr checks --json name,state,description`
-   - Analyze and fix the failing check
-   - Commit and push the fix
-   - Return to step 1
-4. Continue only when all checks pass
-
----
-
-## Manual Workflow (Fallback — `--no-agents`)
-
-**Use this workflow when `NO_AGENTS` is `true`.** This is the single-session flow for simple issues where subagent overhead is not justified.
-
-### Bug Fix (Manual)
-
-1. **Check for duplicates** (same as Step 1 above)
-2. **Create branch** (skip if worktree): `git checkout -b "fix/$ISSUE_NUM-<short-desc>"`
-3. **Explore root cause**: grep for error text, read max 3 files, form hypothesis
-4. **TDD Red — IRON LAW: No fix code before this test.** If you already wrote fix code, DELETE IT. Write a failing test. Run it. Verify it fails FOR THE RIGHT REASON. Red flag: test passes immediately = wrong test.
-5. **TDD Green**: Implement minimal fix. Run test. Verify it passes.
-6. **Verify**: `go build ./...` + `go test ./...` + `golangci-lint run` (if installed)
-7. **Coverage**: Read `${CLAUDE_PLUGIN_ROOT}/skills/coverage/coverage-verification.md`, follow Steps A-F
-8. **Security review**: govulncheck, scan for secrets/injection/traversal
-9. **Submit**: commit, push, create PR with template
-10. **Watch CI**: `gh pr checks --watch`, fix failures
-
-### Feature (Manual)
-
-1. **Understand requirements**: Read issue + comments, ask clarifying questions if ambiguous
-2. **Explore codebase**: Find similar implementations, patterns, integration points
-3. **Design approach — HARD GATE**: Propose 2-3 approaches, get user approval before coding
-4. **Create branch** (skip if worktree): `git checkout -b "feat/$ISSUE_NUM-<short-desc>"`
-5. **TDD Red — IRON LAW: No implementation code before these tests.** If you already wrote code, DELETE IT. Write comprehensive tests (happy path, edge cases, errors). Each test = ONE behavior. Run them. Verify they fail FOR THE RIGHT REASONS. Red flag: test passes immediately = wrong test.
-6. **TDD Green**: Implement minimal code. Run tests. Verify all pass.
-7. **Verify**: `go build ./...` + `go test ./...` + `golangci-lint run` (if installed)
-8. **Coverage**: Read `${CLAUDE_PLUGIN_ROOT}/skills/coverage/coverage-verification.md`, follow Steps A-F
-9. **Security review**: govulncheck, scan for secrets/injection/traversal
-10. **Submit**: commit, push, create PR with template
-11. **Watch CI**: `gh pr checks --watch`, fix failures
+→ Read `${CLAUDE_PLUGIN_ROOT}/lib/start-issue/manual-workflow.md` for the single-session bug and feature flows. Both follow the same shape: explore/design → TDD red (IRON LAW: no implementation code before failing tests) → green → verify → coverage → security → submit → watch CI.
 
 ---
 
 ## Verification Gate (HARD — applies before ANY completion signal)
 
-Before outputting `<done>COMPLETE</done>`, every claim MUST have FRESH evidence from THIS session:
+Before outputting `<done>COMPLETE</done>`, every claim MUST have FRESH evidence from THIS session — actual command output, not narrative:
 
-1. **"Tests pass"** → show actual `go test` output with "ok" lines and zero failures. Not "I ran the tests earlier" — run them NOW.
-2. **"Build succeeds"** → show actual `go build ./...` output with exit code 0.
-3. **"Lint clean"** → show actual `golangci-lint run` output (if golangci-lint is installed; skip this check if unavailable).
-4. **"CI passes"** → show actual `gh pr checks` output with all checks green.
+- **"Tests pass"** → `go test` output with "ok" lines, zero failures
+- **"Build succeeds"** → `go build ./...` exit 0
+- **"Lint clean"** → `golangci-lint run` output (skip if not installed)
+- **"CI passes"** → `gh pr checks` with all checks green
 
-**Red-flag language check** — if you are about to write any of the following, STOP and run verification instead:
-- "should work" / "should be fine"
-- "probably" / "likely"
-- "I believe this fixes..." / "I think this resolves..."
-- "Done!" / "Complete!" without preceding command output showing proof
+**Red-flag language check** — if you are about to write "should work" / "should be fine" / "probably" / "likely" / "I believe this fixes…" / "I think this resolves…" / "Done!" / "Complete!" without preceding command output proving it, STOP and run verification instead.
 
 **Do NOT commit, push, or create a PR without fresh verification evidence.**
 
 ## Completion Criteria
 
-**DO NOT output `<done>COMPLETE</done>` until ALL of these conditions are TRUE:**
+**DO NOT output `<done>COMPLETE</done>` until ALL of these are TRUE:**
 
-1. Code changes are implemented and address the issue
-2. Tests are written and ALL PASS (`go test ./...` or equivalent) — with output shown above
+1. Code changes implemented and address the issue
+2. Tests written and ALL PASS (`go test ./...` or equivalent) — with output shown above
 3. Coverage verified or skipped (per `--skip-coverage` flag)
 4. Linting passes (`golangci-lint run` or equivalent, if installed) — with output shown above
-5. Changes are committed with a proper commit message
-6. Changes are pushed to the remote branch
-7. PR is created and the PR URL is displayed
+5. Changes committed with a proper commit message
+6. Changes pushed to the remote branch
+7. PR created and the PR URL displayed
 8. CI checks pass (`gh pr checks` shows all green) — with output shown above
 
 **When ALL criteria are met, output exactly:**
@@ -609,8 +248,12 @@ Before outputting `<done>COMPLETE</done>`, every claim MUST have FRESH evidence 
 
 This signals the loop to exit. If you output this prematurely, the issue will not be properly resolved.
 
----
-
-**Safety note:** If you've iterated 15+ times without success, document what's blocking progress and ask the user for guidance.
+**Safety note:** If you've iterated 15+ times without success, document what's blocking and ask the user.
 
 Use extended thinking for complex analysis.
+
+## Further Reading
+
+- `${CLAUDE_PLUGIN_ROOT}/lib/start-issue/worktree-create.md` — full worktree creation procedure (env-file copy, state-file registration)
+- `${CLAUDE_PLUGIN_ROOT}/lib/start-issue/orchestrated-workflow.md` — 12-step subagent-orchestrated flow (Explore → Implementer → spec/quality review → verify → coverage → security → submit → CI)
+- `${CLAUDE_PLUGIN_ROOT}/lib/start-issue/manual-workflow.md` — single-session bug + feature flows for `--no-agents`

--- a/plugins/go-workflow/lib/start-issue/manual-workflow.md
+++ b/plugins/go-workflow/lib/start-issue/manual-workflow.md
@@ -1,0 +1,31 @@
+# Start-Issue — Manual Workflow (`--no-agents` fallback)
+
+Loaded by `commands/start-issue.md` when `NO_AGENTS=true`. Single-session
+flow for simple issues where subagent overhead is not justified.
+
+## Bug Fix (Manual)
+
+1. **Check for duplicates** (same as orchestrated Step 1)
+2. **Create branch** (skip if worktree): `git checkout -b "fix/$ISSUE_NUM-<short-desc>"`
+3. **Explore root cause**: grep for error text, read max 3 files, form hypothesis
+4. **TDD Red — IRON LAW: No fix code before this test.** If you already wrote fix code, DELETE IT. Write a failing test. Run it. Verify it fails FOR THE RIGHT REASON. **Red flag: test passes immediately = wrong test.**
+5. **TDD Green**: implement minimal fix. Run test. Verify it passes.
+6. **Verify**: `go build ./...` + `go test ./...` + `golangci-lint run` (if installed)
+7. **Coverage**: Read `${CLAUDE_PLUGIN_ROOT}/skills/coverage/coverage-verification.md`, follow Steps A-F
+8. **Security review**: govulncheck, scan for secrets/injection/traversal
+9. **Submit**: commit, push, create PR with template (per orchestrated Step 11)
+10. **Watch CI**: `gh pr checks --watch`, fix failures
+
+## Feature (Manual)
+
+1. **Understand requirements**: read issue + comments, ask clarifying questions if ambiguous
+2. **Explore codebase**: find similar implementations, patterns, integration points
+3. **Design approach — HARD GATE**: propose 2-3 approaches, get user approval before coding
+4. **Create branch** (skip if worktree): `git checkout -b "feat/$ISSUE_NUM-<short-desc>"`
+5. **TDD Red — IRON LAW: No implementation code before these tests.** If you already wrote code, DELETE IT. Write comprehensive tests (happy path, edge cases, errors). Each test = ONE behavior. Run them. Verify they fail FOR THE RIGHT REASONS. **Red flag: test passes immediately = wrong test.**
+6. **TDD Green**: implement minimal code. Run tests. Verify all pass.
+7. **Verify**: `go build ./...` + `go test ./...` + `golangci-lint run` (if installed)
+8. **Coverage**: Read `${CLAUDE_PLUGIN_ROOT}/skills/coverage/coverage-verification.md`, follow Steps A-F
+9. **Security review**: govulncheck, scan for secrets/injection/traversal
+10. **Submit**: commit, push, create PR with template (per orchestrated Step 11)
+11. **Watch CI**: `gh pr checks --watch`, fix failures

--- a/plugins/go-workflow/lib/start-issue/orchestrated-workflow.md
+++ b/plugins/go-workflow/lib/start-issue/orchestrated-workflow.md
@@ -1,0 +1,230 @@
+# Start-Issue — Subagent-Orchestrated Workflow
+
+Loaded by `commands/start-issue.md` when `NO_AGENTS=false` (the default).
+The orchestrator (the trunk's session) retains all control flow, verification
+gates, and external interactions; subagents handle exploration,
+implementation, and review.
+
+## Step 1: Check for Duplicates (Bug Fix Only)
+
+If issue is a **bug**:
+
+```bash
+gh issue list --state all --limit 50 --search "<key terms from title/body>"
+```
+
+If potential duplicates found, present them and ask the user via
+`AskUserQuestion` how to proceed (Continue / Skip / Link).
+
+## Step 2: Create Branch (skip if worktree was created)
+
+REQUIRED unless using a worktree. Never commit to main/master.
+
+For bugs: `git checkout -b "fix/$ISSUE_NUM-<short-desc>"`
+For features: `git checkout -b "feat/$ISSUE_NUM-<short-desc>"`
+
+Verify: `git branch --show-current`
+
+## Step 3: Explore Phase
+
+Read `${CLAUDE_PLUGIN_ROOT}/agents/explore-prompt.md` and fill in:
+
+- `{ISSUE_TITLE}` — from issue context
+- `{ISSUE_BODY}` — from issue context (body + comments)
+- `{ISSUE_TYPE}` — "bug" or "feature"
+- `{WORKTREE_PATH}` — absolute path to working directory
+- `{REPO_CONVENTIONS}` — from CLAUDE.md or AGENTS.md if present
+
+Dispatch:
+
+```
+Agent(prompt=<filled template>, model=sonnet, subagent_type=Explore)
+```
+
+Store the results: `RELEVANT_FILES`, `PATTERNS`, `ROOT_CAUSE` (bugs) or `INTEGRATION_POINTS` (features), `PROPOSED_CHANGES`, `TASK_DECOMPOSITION`.
+
+## Step 4: Design Approach (Features Only)
+
+Present the plan before implementing. Plan approval is the gate — once the user accepts the plan, you have approval for everything in it (including data migrations, schema changes, and new packages). Do not stop again to re-confirm individual items that were already in the approved plan.
+
+Using the Explore results, propose 2-3 approaches with concrete trade-offs:
+
+- What it changes (files, types, APIs, schema/migrations)
+- Trade-offs (complexity vs simplicity, performance vs maintainability)
+- Your recommendation and why
+
+**Surface migrations and schema changes explicitly in the plan** so the user can see them and approve in one shot. Do not treat migrations as a separate hard gate.
+
+**For trivial features** (single function, obvious implementation): state your plan and proceed unless the user objects.
+
+**For non-trivial features** (new package, API changes, data model changes): present approaches and recommend one. Use your judgment on whether to wait for an explicit reply — if the change is risky, irreversible, or you're genuinely uncertain which approach the user wants, ask. Otherwise, state the recommended plan and proceed unless the user objects.
+
+## Step 5: Task Decomposition
+
+Using the Explore results and approved approach:
+
+**For bugs:** Typically 1 task — fix the root cause identified in the Explore phase.
+
+**For features:** Decompose into N tasks where each task:
+
+- Has a clear description of what to implement
+- Lists `TARGET_FILES` (files to create/modify) — must be disjoint across tasks for parallel dispatch
+- Lists `TEST_FILES`
+- Lists `CONTEXT_FILES` (read-only reference files)
+- Notes dependencies on other tasks (empty = independent)
+
+**Parallel dispatch decision:** if ALL tasks have disjoint `TARGET_FILES` AND disjoint `TEST_FILES` (including shared test helpers in the same package) and no dependencies, they can run in parallel. Otherwise, sequential. Two tasks in the same Go package almost always share a `_test.go` file — default to sequential for same-package tasks.
+
+## Step 6: Implementation Phase
+
+For each task, read `${CLAUDE_PLUGIN_ROOT}/agents/implementer-prompt.md` and fill in:
+
+- `{TASK_DESCRIPTION}` — from task decomposition
+- `{TARGET_FILES}` — files this agent may create/modify
+- `{TEST_FILES}` — test file(s) for this task
+- `{WORKTREE_PATH}` — absolute path to working directory
+- `{PATTERNS}` — from Explore results
+- `{CONTEXT_FILES}` — read-only reference files
+- `{ISSUE_TYPE}` — "bug" or "feature"
+
+**Dispatch:**
+
+- **Parallel** (independent tasks with disjoint files):
+  ```
+  For each task: Agent(prompt=<filled>, model=sonnet, run_in_background=true)
+  Wait for all to complete. Collect results.
+  ```
+- **Sequential** (dependent tasks or overlapping files):
+  ```
+  For each task in order: Agent(prompt=<filled>, model=sonnet)
+  ```
+
+**Handle subagent status:**
+
+| Status | Action |
+|--------|--------|
+| DONE | Continue to next task or review phase |
+| DONE_WITH_CONCERNS | Evaluate concerns — fix correctness issues before proceeding |
+| NEEDS_CONTEXT | Supply the requested information, re-dispatch the implementer |
+| BLOCKED | Present blockers to user via `AskUserQuestion`, get guidance |
+
+## Step 7: Spec Compliance Review
+
+After ALL implementation tasks complete:
+
+```bash
+DEFAULT_BRANCH=$(git remote show origin 2>/dev/null | grep 'HEAD branch' | sed 's/.*: //' || echo "main")
+git fetch origin "$DEFAULT_BRANCH" 2>/dev/null || true
+git diff "origin/${DEFAULT_BRANCH}...HEAD"
+```
+
+Read `${CLAUDE_PLUGIN_ROOT}/agents/spec-review-prompt.md` and fill in:
+
+- `{ISSUE_TITLE}`, `{ISSUE_BODY}`, `{ACCEPTANCE_CRITERIA}` — from issue context
+- `{WORKTREE_PATH}` — working directory
+- `{CHANGED_FILES}` — list of all files changed
+- `{DIFF}` — the full diff
+
+Dispatch: `Agent(prompt=<filled>, model=opus)`
+
+**If VERDICT = FAIL:** address missing requirements by re-dispatching implementer subagent(s) for the gaps. Re-run spec review (max 2 retry cycles).
+
+**If VERDICT = PASS:** proceed to Step 8.
+
+## Step 8: Code Quality Review
+
+Read `${CLAUDE_PLUGIN_ROOT}/agents/quality-review-prompt.md` and fill in `{WORKTREE_PATH}`, `{CHANGED_FILES}`, `{DIFF}`, `{PATTERNS}` (from Explore), `{REPO_CONVENTIONS}` (from CLAUDE.md/AGENTS.md).
+
+Dispatch: `Agent(prompt=<filled>, model=sonnet)`
+
+**If HAS_FINDINGS:**
+
+- Priority 0-1 (critical/high): fix these directly, then re-run quality review (max 1 retry)
+- Priority 2-3 (medium/low): note in PR description but do not block
+
+**If CLEAN:** proceed to Step 9.
+
+## Step 9: Verify
+
+Run the full verification checklist. **All must pass before proceeding:**
+
+- **Build**: `go build ./...`
+- **All tests**: `go test ./...`
+- **Lint**: `golangci-lint run` (if available)
+- **Build logs**: if a dev server is running, check its log output for errors
+
+If any step fails, fix the issue and re-run until all green.
+
+## Step 9.5: Coverage Verification
+
+Read `${CLAUDE_PLUGIN_ROOT}/skills/coverage/coverage-verification.md` and follow Steps A through F with:
+
+| Variable | Value |
+|----------|-------|
+| `BASE_BRANCH` | `origin/${DEFAULT_BRANCH}` (compute if not already set: `git remote show origin 2>/dev/null \| grep 'HEAD branch' \| sed 's/.*: //' \|\| echo "main"`) |
+| `STATE_FILE` | Absolute path to `.local/state/start-issue-$ISSUE_NUM.loop.local.json` (in the original repo, not the worktree) |
+| `SKIP_COVERAGE` | from parsed flags (default: `false`) |
+| `COVERAGE_THRESHOLD` | from parsed flags (default: `60`) |
+
+After coverage verification completes (or is skipped), continue to Step 10.
+
+## Step 10: Security Review
+
+Before submitting, scan for security issues in changed files:
+
+- **Dependency vulnerabilities**: `govulncheck ./...` (if available)
+- **Scan changed files** for common Go security issues:
+  - Hardcoded secrets or credentials
+  - SQL injection (string concatenation in queries instead of parameterized)
+  - Path traversal (`filepath.Join` with user input without `filepath.Clean`)
+  - Unsafe `exec.Command` with unsanitized user input
+  - Missing error checks on security-critical operations (crypto, auth, file permissions)
+- **If changes touch auth, crypto, or data handling code**, suggest running `/codex review` with a security focus
+
+## Step 11: Submit
+
+1. Stage and commit with a conventional commit message referencing the issue
+2. Push the branch: `git push -u origin <branch>`
+3. **Check for PR template** — look in these locations (in order):
+   - `.github/pull_request_template.md`
+   - `.github/PULL_REQUEST_TEMPLATE.md`
+   - `.github/PULL_REQUEST_TEMPLATE/` (directory with multiple templates — list and ask user which to use)
+   - `docs/pull_request_template.md`
+   - `docs/PULL_REQUEST_TEMPLATE/` (directory with multiple templates)
+   - `pull_request_template.md` (repo root)
+   - `PULL_REQUEST_TEMPLATE/` (repo root directory with multiple templates)
+4. **If template found**: read the template and use its exact section structure for the PR body. Fill in every section — do not omit or skip sections. Always include `Fixes #<issue-number>` or `Closes #<issue-number>` even if the template doesn't have a dedicated section for it.
+5. **If no template found**, use this default:
+   ```
+   ## Summary
+   <1-3 bullet points describing what changed and why>
+
+   Fixes #<issue-number>
+
+   ## Test Plan
+   <How the changes were tested>
+   ```
+6. Create the PR with heredoc formatting:
+   ```bash
+   gh pr create --title "<type>(<scope>): <subject>" --body "`cat <<'EOF'
+   <filled-in template or default body>
+   EOF
+   `"
+   ```
+
+## Step 12: Watch CI
+
+After creating the PR, watch CI and fix any failures:
+
+1. `gh pr checks --watch`
+2. **If "no checks reported"**: wait 10 seconds and retry, up to 3 times:
+   ```bash
+   for i in 1 2 3; do sleep 10 && gh pr checks --watch && break; done
+   ```
+   If still no checks after retries, verify CI workflow files exist.
+3. If checks fail:
+   - Get failure details: `gh pr checks --json name,state,description`
+   - Analyze and fix the failing check
+   - Commit and push the fix
+   - Return to step 1
+4. Continue only when all checks pass.

--- a/plugins/go-workflow/lib/start-issue/worktree-create.md
+++ b/plugins/go-workflow/lib/start-issue/worktree-create.md
@@ -1,0 +1,91 @@
+# Start-Issue — Worktree Creation
+
+Loaded by `commands/start-issue.md` when the user picked "Yes, create worktree".
+Owns the full worktree creation procedure including env-file copy and state-file
+registration.
+
+**CRITICAL: When executing bash commands below, use backticks (`` ` ``) for command substitution, NOT `$()`. Claude Code has a bug that mangles `$()` syntax.**
+
+**Create the worktree NOW, before entering plan mode.** This ensures the worktree path is a concrete, established fact when the plan is written.
+
+## 1. Capture source directory first
+
+```bash
+SOURCE_DIR=`pwd`
+```
+
+## 2. Create worktree directory name
+
+```bash
+REPO_NAME=`basename \`git rev-parse --show-toplevel\``
+ISSUE_TITLE=`gh issue view "$ISSUE_NUM" --json title --jq '.title' | sed 's/[^a-zA-Z0-9-]/-/g' | tr '[:upper:]' '[:lower:]' | sed 's/--*/-/g' | sed 's/^-//' | sed 's/-$//'`
+WORKTREE_NAME="${REPO_NAME}-issue-$ISSUE_NUM-$ISSUE_TITLE"
+WORKTREE_PATH="../$WORKTREE_NAME"
+BRANCH_NAME="issue-$ISSUE_NUM-$ISSUE_TITLE"
+```
+
+## 3. Fetch and create worktree
+
+```bash
+DEFAULT_BRANCH=`git remote show origin | grep 'HEAD branch' | sed 's/.*: //' | tr -cd '[:alnum:]-._/'`
+git fetch origin "$DEFAULT_BRANCH"
+git branch -D "$BRANCH_NAME" 2>/dev/null || true
+git worktree add "$WORKTREE_PATH" "origin/$DEFAULT_BRANCH"
+cd "$WORKTREE_PATH" && git checkout -b "$BRANCH_NAME"
+```
+
+## 4. Search for environment files
+
+Recursive find, excludes `node_modules`, `.git`, `vendor`:
+
+```bash
+ENV_FILES=`find "$SOURCE_DIR" \( -name "node_modules" -o -name ".git" -o -name "vendor" \) -prune -o \
+  \( -name ".env" -o -name ".env.local" -o -name ".envrc" \) -type f -print 2>/dev/null | \
+  sed "s|^$SOURCE_DIR/||" | grep -v "^-" | sort`
+if [ -n "$ENV_FILES" ]; then
+  echo "Found env files:"
+  echo "$ENV_FILES"
+fi
+```
+
+If env files are found, list them and ask the user via `AskUserQuestion`: "Found environment files (may contain secrets). Copy them to worktree?"
+
+If confirmed, copy preserving directory structure:
+
+```bash
+echo "$ENV_FILES" | while read file; do
+  if [ -n "$file" ]; then
+    dir=`dirname "$file"`
+    if [ "$dir" != "." ]; then
+      mkdir -p "$WORKTREE_PATH/$dir"
+    fi
+    cp -P "$SOURCE_DIR/$file" "$WORKTREE_PATH/$file"
+    echo "Copied $file"
+  fi
+done
+```
+
+## 5. Capture absolute worktree path
+
+```bash
+WORKTREE_ABS_PATH=`cd "$WORKTREE_PATH" && pwd`
+echo "Worktree absolute path: $WORKTREE_ABS_PATH"
+ls "$WORKTREE_ABS_PATH"
+```
+
+**Save this absolute path.** You will use it for EVERY tool call from this point forward (see the trunk's "MANDATORY: All Work Happens in the Worktree" section).
+
+## 6. Register worktree state
+
+Enables hook-based path enforcement. The pre-tool-use hook reads this state file and **blocks** any tool call that accidentally targets the original repo:
+
+```bash
+REPO_ROOT=`git rev-parse --show-toplevel`
+"${CLAUDE_PLUGIN_ROOT}/scripts/worktree-state.sh" save "$WORKTREE_ABS_PATH" "$REPO_ROOT" "$ISSUE_NUM"
+```
+
+## 7. Inform user
+
+Display: "Created worktree at `$WORKTREE_ABS_PATH`. All work will happen there."
+
+Continue to the trunk's **Plan Mode Check** section.


### PR DESCRIPTION
## Summary

`start-issue.md` was 27,495 bytes. Split into a thin trunk plus three siblings under `plugins/go-workflow/lib/start-issue/`.

This is **PR 5** in the progressive-disclosure series (follow-up to #152, #153, #154, #155).

### Sizes

| File | Before | After | Δ |
|---|---|---|---|
| `commands/start-issue.md` (trunk) | 27,495 | 13,563 | **-51%** |

The trunk lands at 13.6 KB, ~5.6 KB over the 8 KB target. The remainder is essential decision-time content the agent must see before reading any sibling: argument parsing + validation, loop init, issue context, the worktree decision (must NOT proceed before asking), plan-mode rules, the MANDATORY worktree-path rule table (the agent forgets between Bash calls if it's not inline), branch protection, issue-type detection, the HARD verification gate, and completion criteria.

### New siblings

| File | Bytes | Owns |
|---|---|---|
| `lib/start-issue/worktree-create.md` | 3,081 | Full Steps 1–7 worktree creation: derive name, fetch+create, env-file find/copy with prune patterns, capture absolute path, register state for hook enforcement |
| `lib/start-issue/orchestrated-workflow.md` | 9,572 | Steps 1–12 of the subagent flow (duplicate check, branch, Explore subagent, design, decomposition + parallel decision, Implementer dispatch, spec review opus, quality review sonnet, verify, Step 9.5 coverage, security, submit + PR template detection, watch CI) |
| `lib/start-issue/manual-workflow.md` | 2,294 | Bug + feature flows for `--no-agents` (TDD IRON LAW preserved verbatim) |

### Behavior preserved

- Every bash block copied verbatim (worktree `git-dir`/`git-common-dir` resolution trick, env-file `find` with `prune`, `worktree-state.sh save`, etc.)
- All `AskUserQuestion` options character-for-character
- CRITICAL "use `ISSUE_NUM` not `ARGUMENTS`" rule stays in trunk
- MANDATORY worktree-path rule table stays in trunk (agent shell CWD doesn't persist between Bash calls)
- Plan-mode integration rules preserved
- TDD IRON LAW ("No fix code before this test … if you already wrote fix code, DELETE IT") preserved verbatim in `manual-workflow.md`
- HARD verification gate + red-flag language check preserved
- 8-point completion criteria preserved
- `bash -n` clean on every code block

### Not in this PR — go-web 90 KB scaffolders

`create-go-project.md` (92 KB) and `convert-to-go-project.md` (95 KB) are NOT in this PR. Their bulk is verbatim file templates (`.envrc`, `Makefile`, gitignore, env templates, Django/Flask conversion examples) — splitting them into `.md` siblings would force the agent to load multiple files during scaffolding, making things worse. They need a different approach (extract templates to actual template files under `plugins/go-web/templates/`). Filed for future work.

## Test plan

- [x] Trunk substantially smaller (27.5 KB → 13.6 KB, -51%)
- [x] All sibling pointers (`Read \`...\``) resolve to existing files
- [x] `bash -n` clean on every block
- [x] AskUserQuestion options preserved verbatim
- [x] Critical safety rules preserved inline (ISSUE_NUM rule, MANDATORY worktree table, TDD IRON LAW, verification gate)
- [ ] Smoke test: invoke `/start-issue <num>` on a low-stakes issue, confirm worktree creation flow + orchestrated workflow + manual fallback all route through the matching sibling
- [ ] PR 6: remaining 13 oversized commands (refactor-clean, validate-skills, gemini-image cmd, profile, create-worktree, migrate, tmux-start, verify, bench, audit, test-gen, llm-compare, optimize, init)
- [ ] Future: design template-extraction approach for the two go-web 90 KB scaffolders

🤖 Generated with [Claude Code](https://claude.com/claude-code)