### PR TITLE
fix(e2e-verify): restore Step 7.0 E2E gate dropped during PR 152 split

### DIFF
--- a/plugins/go-workflow/hooks/legacy-skill-hashes.txt
+++ b/plugins/go-workflow/hooks/legacy-skill-hashes.txt
@@ -7,7 +7,7 @@
 # this prevents accepting a hash from skill A as proof of ownership for skill B.
 # DO NOT EDIT BY HAND — re-run the regen script after committing SKILL.md changes.
 #
-# Total entries: 160
+# Total entries: 161
 03dac3a27d6da4b0a0c64ff6511df17004747e20b47a1691b4f9f030478877b9 commit
 03dffb69f33f5e2549a05bb03daf154260288c350ccbea60804f373bda3b3d08 gopher-guides
 04f549258f56aee10034e6d678038954f94b5aec679b286edb2ff8c2aae23e69 htmx
@@ -25,6 +25,7 @@
 23a3a947abe2703b270473845edbd009798ab7cc8585d3f5b7c00721a86465ae create-worktree
 2656ea1fdf9b4e5d9512f6ca9d72147cd52a8d838d0304d85ff8dbf819cc542f complete-issue
 268241ea357f8423f4025fabe0ef026258e8ee5e1e84512f25293b836e02d1e3 e2e-verify
+271a1c41a77bf182feba2130189c505d9135cd4f64c9aaedb7d61a31f0dd4c48 e2e-verify
 2a903a9c729ed072861576c51f94926e17148734c577aa7e01501666f0be5cbf remove-worktree
 2ec03af0dc688eae8184c68f048231a0d2d5119e53b833689f6e2912fa287a64 tailwind-best-practices
 2ec0cf8b235fc84a5fcdec7bc5a24e70a041e5c5577aeac501ed3eef935d7223 htmx

--- a/plugins/go-workflow/skills/e2e-verify/SKILL.md
+++ b/plugins/go-workflow/skills/e2e-verify/SKILL.md
@@ -168,24 +168,40 @@ Read `pr-results-comment.md` for the structured PR comment: build results table,
 
 ---
 
-## Step 7: Finish (mode-specific)
+## Step 7: Finish (mode-specific, gated)
 
-Read `mode-finish.md` for the mode → finish-action mapping, the `run-full-ci` label add, the `fix-and-ship` CI watch loop, and the `/go-workflow:ship` invocation rules.
+Read `mode-finish.md` for the **Step 7.0 E2E gate** (mandatory pre-check that
+halts on UI-visible E2E failure with `<done>E2E_FAIL</done>`), then the mode →
+finish-action mapping, the `run-full-ci` label add, the `fix-and-ship` CI
+watch loop, and the `/go-workflow:ship` invocation rules.
+
+**Critical:** the gate is non-negotiable. UI-visible PRs that fail E2E must
+exit with `<done>E2E_FAIL</done>` — no labels, no ship.
 
 ---
 
 ## Completion Criteria
 
-Output `<done>VERIFIED</done>` when ALL of these are true:
+The loop terminates on a `<done>…</done>` sentinel. Which sentinel you emit
+depends on `E2E_RESULT` and whether the diff is UI-visible:
+
+| `E2E_RESULT` | UI-visible diff | Non-UI diff |
+|---|---|---|
+| `pass` | `<done>VERIFIED</done>` | `<done>VERIFIED</done>` |
+| `skipped` | not allowed — must be `pass` or a fail state | `<done>VERIFIED</done>` |
+| `fail`, `partial`, `skipped-server-failed`, `missing-browser-tooling`, `uninspected-screenshots` | post comment, then `<done>E2E_FAIL</done>`. No labels, no ship. | not applicable |
+
+Output `<done>VERIFIED</done>` only when ALL of these are true:
 
 1. Branch rebased onto base (or already up to date)
 2. Build passes (go build, go test)
 3. Review addressed (if `fix-and-verify` or `fix-and-ship` mode)
-4. E2E tests completed (pass or skipped — never blocks)
+4. E2E gate passed per the table above (UI: `pass`; non-UI: `skipped`)
 5. Results posted to PR as a comment
-6. Mode-specific finish action completed
+6. Mode-specific finish action completed (only reached when the E2E gate passed)
 
-**When ALL criteria are met, output exactly:** `<done>VERIFIED</done>`
+If the E2E gate failed on a UI-visible diff, output `<done>E2E_FAIL</done>`
+after Step 6 instead. Do not invoke `/go-workflow:ship`. Do not add labels.
 
 **Safety:** If 15+ iterations without success, document blockers and ask user.
 

--- a/plugins/go-workflow/skills/e2e-verify/mode-finish.md
+++ b/plugins/go-workflow/skills/e2e-verify/mode-finish.md
@@ -1,9 +1,29 @@
 # E2E Verify — Mode-Specific Finish Actions
 
-Loaded by `SKILL.md` Step 7. Maps `MODE` to the closing action and contains
-the `fix-and-ship` CI-watch loop and `/go-workflow:ship` invocation rules.
+Loaded by `SKILL.md` Step 7. Contains the **E2E gate** (must run before any
+finish action), maps `MODE` to the closing action, and contains the
+`fix-and-ship` CI-watch loop and `/go-workflow:ship` invocation rules.
 
-## Mode → Action Table
+## Step 7.0: E2E Gate (applies to every mode before any finish action)
+
+**Before** doing anything in the per-mode table below, evaluate `E2E_RESULT`:
+
+- **UI-visible diff** (`WEB_CHANGES`, `HANDLER_CHANGES`, or layout-sensitive
+  keywords detected — see `e2e-test-execution.md` §5a.1):
+  - `E2E_RESULT=pass` → continue to the per-mode finish action below.
+  - `E2E_RESULT` is anything else (`fail`, `partial`, `skipped-server-failed`,
+    `missing-browser-tooling`, `uninspected-screenshots`) → **stop**. Do NOT
+    add `run-full-ci`. Do NOT add `e2e-verified`. Do NOT invoke
+    `/go-workflow:ship`. The Step 6 comment already records the failure with
+    findings. Output `<done>E2E_FAIL</done>` so the loop exits without a
+    verified state.
+- **Non-UI diff** (no web indicators, no UI-facing files changed):
+  - `E2E_RESULT=skipped` → continue to the per-mode finish action below
+    (treated as the success path).
+  - Any non-`skipped` value on a non-UI diff is a logic error — investigate
+    before continuing.
+
+## Step 7.1: Mode → Action Table (only reached when the gate above passed)
 
 | Mode | Action |
 |------|--------|

--- a/scripts/legacy-skill-hashes.txt
+++ b/scripts/legacy-skill-hashes.txt
@@ -7,7 +7,7 @@
 # this prevents accepting a hash from skill A as proof of ownership for skill B.
 # DO NOT EDIT BY HAND — re-run the regen script after committing SKILL.md changes.
 #
-# Total entries: 160
+# Total entries: 161
 03dac3a27d6da4b0a0c64ff6511df17004747e20b47a1691b4f9f030478877b9 commit
 03dffb69f33f5e2549a05bb03daf154260288c350ccbea60804f373bda3b3d08 gopher-guides
 04f549258f56aee10034e6d678038954f94b5aec679b286edb2ff8c2aae23e69 htmx
@@ -25,6 +25,7 @@
 23a3a947abe2703b270473845edbd009798ab7cc8585d3f5b7c00721a86465ae create-worktree
 2656ea1fdf9b4e5d9512f6ca9d72147cd52a8d838d0304d85ff8dbf819cc542f complete-issue
 268241ea357f8423f4025fabe0ef026258e8ee5e1e84512f25293b836e02d1e3 e2e-verify
+271a1c41a77bf182feba2130189c505d9135cd4f64c9aaedb7d61a31f0dd4c48 e2e-verify
 2a903a9c729ed072861576c51f94926e17148734c577aa7e01501666f0be5cbf remove-worktree
 2ec03af0dc688eae8184c68f048231a0d2d5119e53b833689f6e2912fa287a64 tailwind-best-practices
 2ec0cf8b235fc84a5fcdec7bc5a24e70a041e5c5577aeac501ed3eef935d7223 htmx


### PR DESCRIPTION
## Summary

- Restores the Step 7.0 E2E failure gate and `<done>E2E_FAIL</done>` sentinel that were dropped (not relocated) during the progressive-disclosure refactor in #152
- Re-asserts the completion-criteria sentinel table mapping `E2E_RESULT` × diff-type to `<done>VERIFIED</done>` vs `<done>E2E_FAIL</done>`
- Reverts completion-criteria item 4 from "E2E tests completed (pass or skipped — never blocks)" back to "E2E gate passed (UI: `pass`; non-UI: `skipped`)"

## Why

The refactor in #152 deleted Step 7.0 from the trunk without moving it to any sibling. That re-introduced the exact regression #151 had just fixed: a UI-visible PR with failing E2E would route into Step 7's per-mode actions (`run-full-ci` label, `/go-workflow:ship` invocation) instead of halting.

## How found

Retroactive behavior-preservation review across all 6 progressive-disclosure PRs (#152–#157). 11 parallel review agents diffed pre-refactor (`5947f0f`) against current `main` for each refactored skill/command.

**Results:**

| Unit | Verdict |
|---|---|
| go-profiling-optimization | clean |
| review-deep | 1 P2 (cosmetic option-table compression) |
| gemini-image (skill) | clean |
| **e2e-verify** | **FAIL — this PR fixes it** |
| complete-issue | clean (`disable-model-invocation` flag preserved) |
| coverage-verification.md (highest-risk) | clean |
| codex.md | clean |
| review-loop.md | clean |
| ship.md | 1 P2 (cosmetic re-entry-matrix drop) |
| start-issue.md | clean |
| Cross-cutting (pointers, YAML, plugin.json, shared/) | clean |

The two P2 findings on review-deep and ship.md are cosmetic and not addressed in this PR.

## Test plan

- [ ] CI green (test-installation, check-shared-sync, check-sync, test-commands, test-hooks)
- [ ] Manual review of the diff to confirm gate text matches `5947f0f` exactly
- [ ] No other files touched

🤖 Generated with [Claude Code](https://claude.com/claude-code)