### PR TITLE
fix(ship): block missing UI e2e verification

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -38,6 +38,14 @@ jobs:
       - name: Test hook files
         run: ./scripts/test-hooks.sh
 
+  test-ship-e2e-gate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Test ship E2E gate
+        run: ./scripts/test-ship-e2e-gate.sh
+
   check-shared-sync:
     runs-on: ubuntu-latest
     steps:

--- a/plugins/go-workflow/commands/ship.md
+++ b/plugins/go-workflow/commands/ship.md
@@ -31,13 +31,15 @@ Parse `$ARGUMENTS` to extract:
 - `--llm <value>`: `codex` (default), `gemini`, `ollama`
 - `--passes <n>`: max LLM review passes (default: 3)
 - `--no-merge`: stop after bot approval, don't auto-merge
-- `--skip-coverage`: skip coverage + e2e phases entirely
+- `--skip-coverage`: skip coverage analysis. E2E may be reused only when a
+  prior `/go-workflow:e2e-verify` pass is recorded; it is not skipped
+  automatically for UI-visible diffs.
 - `--coverage-threshold <n>`: override the default 60% threshold
 - `--tier <value>`: gemini service tier (`flex`/`standard`/`priority`; gemini only; default: unset)
 
 Store as `LLM_CHOICE`, `MAX_PASSES`, `NO_MERGE`, `SKIP_COVERAGE`, `COVERAGE_THRESHOLD` (default `60`), `GEMINI_TIER`.
 
-**Persist arguments** to `.local/state/ship.loop.local.json` via `jq` so the stop-hook can recover all fields on re-entry. The full jq invocation lives in `${CLAUDE_PLUGIN_ROOT}/lib/ship/state-fields.md` — fields written: `args, llm, pass, no_merge, pr_number, base_branch, bot_review_baseline, discovered_bots, has_ci, skip_coverage, coverage_threshold, coverage_result, coverage_tests_generated, e2e_attempted, e2e_result, e2e_pages_tested, review_clean, head_sha, gemini_tier`.
+**Persist arguments** to `.local/state/ship.loop.local.json` via `jq` so the stop-hook can recover all fields on re-entry. The full jq invocation lives in `${CLAUDE_PLUGIN_ROOT}/lib/ship/state-fields.md` — fields written: `args, llm, pass, no_merge, pr_number, base_branch, bot_review_baseline, discovered_bots, has_ci, skip_coverage, coverage_threshold, coverage_result, coverage_tests_generated, e2e_required, e2e_attempted, e2e_result, e2e_skip_reason, e2e_pages_tested, review_clean, head_sha, gemini_tier`.
 
 ## 2. Re-entry Check
 
@@ -196,7 +198,10 @@ set_loop_phase ".local/state/ship.loop.local.json" "merging"
                                             13 merging → <done>SHIPPED</done>
 ```
 
-`[coverage-check]` runs only on the final pass when `--skip-coverage` isn't set. `[e2e-testing]` runs only when MCP is available AND the project has web components.
+`[coverage-check]` runs only on the final pass when `--skip-coverage` isn't set.
+`[e2e-testing]` is mandatory for UI-visible diffs. Missing MCP/browser tooling
+or an unavailable dev server records `e2e_result=blocked` and stops before push
+or merge. Non-UI diffs may record `e2e_result=skipped`.
 
 ## Verification Gate (HARD — applies before ANY completion signal)
 
@@ -216,7 +221,8 @@ Output `<done>SHIPPED</done>` ONLY when ALL of these are true:
 
 1. LLM review passes completed (clean or max passes reached)
 2. Coverage verified for changed files (or skipped via `--skip-coverage`)
-3. E2E smoke tests passed (or skipped — no web components / MCP unavailable)
+3. E2E smoke tests passed for UI-visible diffs (or skipped only because the
+   diff is non-UI / no web components)
 4. Changes pushed to remote
 5. PR exists
 6. CI passes (or no CI configured) — with output shown above

--- a/plugins/go-workflow/lib/ship/local-review.md
+++ b/plugins/go-workflow/lib/ship/local-review.md
@@ -352,28 +352,75 @@ Read `${CLAUDE_PLUGIN_ROOT}/skills/coverage/coverage-verification.md` and follow
 
 Generated test files will be staged + committed in Step 8 alongside LLM review fixes.
 
-## Step 7.6: E2E Smoke Testing (optional)
+## Step 7.6: E2E Smoke Testing (blocking for UI-visible diffs)
 
-### Skip Conditions
+### Skip vs. block decision
 
-Skip to Step 8 if ANY of:
+E2E is a gate for UI-visible diffs. Skipping is allowed only when there is
+nothing visual to verify, or when a previous `/go-workflow:e2e-verify` pass is
+explicitly being reused.
 
-- `SKIP_COVERAGE=true`
-- Chrome DevTools MCP tools NOT available (check `mcp__chrome-devtools-mcp__navigate_page` in tool list)
-- Project has NO web components (none of: `.templ` files, Go HTTP handler patterns `http.Handler|echo.Context|gin.Context|chi.Router|http.HandleFunc`, `*.html` / `*.tsx` / `*.vue` files)
-- No web-facing files were changed in the diff
+Skip to Step 8 only when ONE of:
+
+- Project has NO web components (none of: `.templ` files, Go HTTP handler
+  patterns `http.Handler|echo.Context|gin.Context|chi.Router|http.HandleFunc`,
+  `*.html` / `*.tsx` / `*.vue` files).
+- No UI-visible files were changed in the diff.
+- `SKIP_COVERAGE=true` AND the PR is already marked `e2e-verified` or the
+  current loop state shows a prior passing E2E result. This is the deliberate
+  reuse path used after `/go-workflow:e2e-verify`; `--skip-coverage` alone is
+  not permission to skip E2E.
+
+Block the workflow when the diff is UI-visible and E2E cannot run or fails:
+
+- Chrome DevTools MCP tools are NOT available.
+- The dev server is unreachable and cannot be started, or project guidance says
+  the user must start it.
+- The dev server does not become ready within 30 seconds.
+- Browser smoke tests find route failures, console errors, network 5xx errors,
+  or MCP/browser failures before all required pages are inspected.
 
 ```bash
 if [ -z "$CHANGED_FILES" ]; then
   CHANGED_FILES=$(git diff --name-only "origin/${BASE_BRANCH}...HEAD")
 fi
-WEB_CHANGES=$(echo "$CHANGED_FILES" | grep -E '\.(templ|html|tsx|vue|jsx)$' || true)
-HANDLER_CHANGES=$(echo "$CHANGED_FILES" | grep '\.go$' | while read f; do
+WEB_CHANGES=$(echo "$CHANGED_FILES" | grep -E '\.(templ|html|css|tsx|vue|jsx)$' || true)
+JS_CHANGES=$(echo "$CHANGED_FILES" | grep -E '(^|/)(cmd|web|ui|assets|static|templates)/.*\.js$' || true)
+HANDLER_CHANGES=$(echo "$CHANGED_FILES" | grep '\.go$' | while IFS= read -r f; do
   grep -l -E 'http\.Handler|echo\.Context|gin\.Context|chi\.Router|http\.HandleFunc|http\.ServeMux' "$f" 2>/dev/null
 done || true)
+UI_VISIBLE_CHANGES=$(printf '%s\n%s\n%s\n' "$WEB_CHANGES" "$JS_CHANGES" "$HANDLER_CHANGES" | sed '/^$/d')
 ```
 
-If both `WEB_CHANGES` and `HANDLER_CHANGES` are empty → skip to Step 8.
+If `UI_VISIBLE_CHANGES` is empty, persist:
+
+```bash
+TMP=".local/state/ship.loop.local.json.tmp"
+jq --arg required "false" --arg attempted "false" --arg result "skipped" --arg reason "no-ui-visible-changes" --argjson pages 0 \
+   '.e2e_required = $required | .e2e_attempted = $attempted | .e2e_result = $result | .e2e_skip_reason = $reason | .e2e_pages_tested = $pages' \
+   ".local/state/ship.loop.local.json" > "$TMP" && mv "$TMP" ".local/state/ship.loop.local.json"
+```
+
+Then skip to Step 8.
+
+If `UI_VISIBLE_CHANGES` is non-empty and Chrome DevTools MCP tools are missing,
+persist:
+
+```bash
+TMP=".local/state/ship.loop.local.json.tmp"
+jq --arg required "true" --arg attempted "false" --arg result "blocked" --arg reason "missing-browser-tooling" --argjson pages 0 \
+   '.e2e_required = $required | .e2e_attempted = $attempted | .e2e_result = $result | .e2e_skip_reason = $reason | .e2e_pages_tested = $pages' \
+   ".local/state/ship.loop.local.json" > "$TMP" && mv "$TMP" ".local/state/ship.loop.local.json"
+```
+
+Display:
+
+```
+E2E PREREQUISITE MISSING - Chrome DevTools MCP tooling is unavailable for a UI-visible diff.
+No merge. Fix the browser tooling or run /go-workflow:e2e-verify successfully, then re-run /go-workflow:ship.
+```
+
+Stop the workflow. Do not continue to push, CI watch, or merge.
 
 ### Set phase, detect dev server
 
@@ -387,16 +434,51 @@ Detect port: Air config, `PORT` env var, `.env`/`.env.local`, defaults `8080` (G
 
 ### Start server, wait for readiness
 
+First check whether the detected URL is already responding. If it is not
+responding, start `DEV_SERVER_CMD` only when project guidance permits the agent
+to start the dev server. If guidance says the user/operator owns the dev server,
+do not start it from `/ship`; block with the prerequisite message below.
+
 ```bash
-$DEV_SERVER_CMD &
-SERVER_PID=$!
+if curl -s -o /dev/null -w "%{http_code}" "http://localhost:$PORT" 2>/dev/null | grep -qE '^[1234]'; then
+  SERVER_ALREADY_RUNNING=true
+elif [ -n "${DEV_SERVER_CMD:-}" ]; then
+  # If AGENTS.md, CLAUDE.md, or project docs say the user runs the dev server,
+  # leave DEV_SERVER_CMD unset and block below instead of starting it.
+  $DEV_SERVER_CMD &
+  SERVER_PID=$!
+  SERVER_ALREADY_RUNNING=false
+else
+  SERVER_ALREADY_RUNNING=false
+  SERVER_START_SKIPPED=true
+fi
+
 for i in $(seq 1 30); do
-  curl -s -o /dev/null -w "%{http_code}" "http://localhost:$PORT" 2>/dev/null | grep -qE '^[23]' && break
+  curl -s -o /dev/null -w "%{http_code}" "http://localhost:$PORT" 2>/dev/null | grep -qE '^[1234]' && break
   sleep 1
 done
 ```
 
-If server fails to start within 30s → warn and skip to Step 8. Do NOT block shipping.
+If the server is still unreachable after 30 seconds, or no start was attempted
+because project guidance requires the user to run it, persist a blocked result:
+
+```bash
+TMP=".local/state/ship.loop.local.json.tmp"
+jq --arg required "true" --arg attempted "false" --arg result "blocked" --arg reason "dev-server-unavailable" --argjson pages 0 \
+   '.e2e_required = $required | .e2e_attempted = $attempted | .e2e_result = $result | .e2e_skip_reason = $reason | .e2e_pages_tested = $pages' \
+   ".local/state/ship.loop.local.json" > "$TMP" && mv "$TMP" ".local/state/ship.loop.local.json"
+```
+
+Display:
+
+```
+E2E PREREQUISITE MISSING - local dev server is not responding at http://localhost:$PORT.
+Start it (`make dev` or the project equivalent), then re-run `/go-workflow:ship`.
+Pages tested: 0
+No merge.
+```
+
+Stop the workflow. Do not continue to push, CI watch, or merge.
 
 ### Execute smoke tests
 
@@ -410,14 +492,23 @@ For each changed handler/route/template, identify the URL path and:
 
 Record per page: URL, HTTP status, console errors, screenshot path.
 
+If any page has an unexpected 4xx/5xx status, console JavaScript errors, failed
+5xx network requests, browser tooling errors, or an uninspected screenshot,
+persist `e2e_result="blocked"` with an explanatory `e2e_skip_reason`, display
+the failed route(s), and stop the workflow. No merge.
+
 ### Cleanup and report
 
 ```bash
-kill $SERVER_PID 2>/dev/null || true
+if [ "${SERVER_ALREADY_RUNNING:-false}" != "true" ]; then
+  if [ -n "${SERVER_PID:-}" ]; then
+    kill "$SERVER_PID" 2>/dev/null || true
+  fi
+fi
 
 TMP=".local/state/ship.loop.local.json.tmp"
-jq --arg attempted "true" --arg result "$E2E_RESULT" --argjson pages "$PAGES_TESTED" \
-   '.e2e_attempted = $attempted | .e2e_result = $result | .e2e_pages_tested = $pages' \
+jq --arg required "true" --arg attempted "true" --arg result "$E2E_RESULT" --arg reason "${E2E_SKIP_REASON:-}" --argjson pages "$PAGES_TESTED" \
+   '.e2e_required = $required | .e2e_attempted = $attempted | .e2e_result = $result | .e2e_skip_reason = $reason | .e2e_pages_tested = $pages' \
    ".local/state/ship.loop.local.json" > "$TMP" && mv "$TMP" ".local/state/ship.loop.local.json"
 
 rm -f .local/state/coverage.out .local/state/coverage.json 2>/dev/null || true
@@ -436,12 +527,9 @@ Display:
 Pages tested: N | Passed: N | Errors: N
 ```
 
-E2E failures are informational, NEVER block:
-
-- 500/404 → report as finding, don't block
-- Console JS errors → report, don't block
-- MCP tool fails mid-test → warn, skip remaining
-- All results are warnings, not gates
+For UI-visible diffs, only `e2e_result="passed"` allows `/ship` to continue.
+`e2e_result="blocked"` is a hard stop and must not be summarized as
+verification complete.
 
 ## Step 8: Commit, Increment Pass, Loop Decision
 

--- a/plugins/go-workflow/lib/ship/merge.md
+++ b/plugins/go-workflow/lib/ship/merge.md
@@ -48,6 +48,28 @@ BLOCKING_HUMANS=$(gh api graphql -f query='
 
 If unresolved threads OR active human `CHANGES_REQUESTED` exist, inform the user and ask how to proceed.
 
+4. Check the local E2E gate recorded during Phase 1. A UI-visible diff that did
+   not complete browser E2E must stop here even if CI is green:
+
+```bash
+E2E_REQUIRED=$(jq -r '.e2e_required // "false"' ".local/state/ship.loop.local.json")
+E2E_RESULT=$(jq -r '.e2e_result // "skipped"' ".local/state/ship.loop.local.json")
+E2E_SKIP_REASON=$(jq -r '.e2e_skip_reason // ""' ".local/state/ship.loop.local.json")
+E2E_PAGES=$(jq -r '.e2e_pages_tested // 0' ".local/state/ship.loop.local.json")
+
+if [ "$E2E_REQUIRED" = "true" ] && [ "$E2E_RESULT" != "passed" ]; then
+  echo "E2E PREREQUISITE MISSING - UI-visible diff has no passing browser E2E result."
+  echo "E2E status: ${E2E_RESULT}; reason: ${E2E_SKIP_REASON:-unknown}; pages tested: ${E2E_PAGES}"
+  echo "No merge. Start the dev server or fix E2E, then re-run /go-workflow:ship."
+  "${CLAUDE_PLUGIN_ROOT}/scripts/cleanup-loop.sh" "ship"
+  exit 1
+fi
+```
+
+This is a backstop for re-entry and manual phase jumps. Do not prompt to merge
+when `e2e_result` is `blocked`; the operator must explicitly fix or rerun the
+workflow.
+
 ## 13b. `--no-merge` early exit
 
 If `NO_MERGE=true`:
@@ -153,6 +175,8 @@ TESTS_GEN=$(jq -r '.coverage_tests_generated // 0' ".local/state/ship.loop.local
 E2E_ATTEMPTED=$(jq -r '.e2e_attempted // ""' ".local/state/ship.loop.local.json")
 E2E_RESULT=$(jq -r '.e2e_result // "skipped"' ".local/state/ship.loop.local.json")
 E2E_PAGES=$(jq -r '.e2e_pages_tested // 0' ".local/state/ship.loop.local.json")
+E2E_REQUIRED=$(jq -r '.e2e_required // "false"' ".local/state/ship.loop.local.json")
+E2E_SKIP_REASON=$(jq -r '.e2e_skip_reason // ""' ".local/state/ship.loop.local.json")
 
 # Coverage line: prefer skip_reason when present, then numeric value, else "skipped".
 if [ -n "$COV_SKIP_REASON" ]; then
@@ -165,6 +189,25 @@ elif [ -n "$COV_RESULT" ]; then
 else
   COV_LINE="skipped"
 fi
+
+# E2E line: never render missing required E2E as complete.
+if [ -z "$E2E_RESULT" ]; then
+  E2E_RESULT="skipped"
+fi
+
+if [ "$E2E_REQUIRED" = "true" ] && [ "$E2E_RESULT" != "passed" ]; then
+  E2E_LINE="blocked - ${E2E_SKIP_REASON:-required E2E did not pass}; ${E2E_PAGES} pages tested"
+  VERIFICATION_LINE="Verification partial - E2E was blocked. Unit, integration, lint, and CI may have passed, but browser verification did not."
+elif [ "$E2E_RESULT" = "skipped" ] && [ -n "$E2E_SKIP_REASON" ]; then
+  E2E_LINE="skipped - $E2E_SKIP_REASON"
+  VERIFICATION_LINE="Verification partial - E2E was skipped because $E2E_SKIP_REASON."
+elif [ "$E2E_RESULT" = "skipped" ]; then
+  E2E_LINE="skipped"
+  VERIFICATION_LINE="Verification partial - E2E was skipped."
+else
+  E2E_LINE="${E2E_PAGES} pages tested, ${E2E_RESULT}"
+  VERIFICATION_LINE="Verification complete."
+fi
 ```
 
 ```
@@ -176,11 +219,13 @@ fi
 - **Findings addressed:** <n>
 - **Coverage (changed files):** <COV_LINE>
 - **Tests generated:** <TESTS_GEN>
-- **E2E tests:** <E2E_PAGES> pages tested, <E2E_RESULT> — or "skipped — no web components" / "skipped — MCP unavailable"
+- **E2E tests:** <E2E_LINE>
 - **CI:** green
 - **Bot approvals:** <list or "none required">
 - **Merge strategy:** <merge|squash|rebase>
 - **Merged:** yes (or "skipped — --no-merge")
+
+<VERIFICATION_LINE>
 ```
 
 Output `<done>SHIPPED</done>`.

--- a/plugins/go-workflow/lib/ship/state-fields.md
+++ b/plugins/go-workflow/lib/ship/state-fields.md
@@ -13,9 +13,10 @@ jq --arg args "$ARGUMENTS" --arg llm "$LLM_CHOICE" --argjson pass 0 \
    --arg bot_review_baseline "" --arg discovered_bots "" --arg has_ci "" \
    --arg skip_coverage "$SKIP_COVERAGE" --arg coverage_threshold "$COVERAGE_THRESHOLD" \
    --arg coverage_result "" --argjson coverage_tests_generated 0 \
-   --arg e2e_attempted "" --arg e2e_result "" --argjson e2e_pages_tested 0 \
+   --arg e2e_required "" --arg e2e_attempted "" --arg e2e_result "" \
+   --arg e2e_skip_reason "" --argjson e2e_pages_tested 0 \
    --arg review_clean "" --arg head_sha "" --arg gemini_tier "$GEMINI_TIER" \
-   '. + {args: $args, llm: $llm, pass: $pass, no_merge: $no_merge, pr_number: $pr_number, base_branch: $base_branch, bot_review_baseline: $bot_review_baseline, discovered_bots: $discovered_bots, has_ci: $has_ci, skip_coverage: $skip_coverage, coverage_threshold: $coverage_threshold, coverage_result: $coverage_result, coverage_tests_generated: $coverage_tests_generated, e2e_attempted: $e2e_attempted, e2e_result: $e2e_result, e2e_pages_tested: $e2e_pages_tested, review_clean: $review_clean, head_sha: $head_sha, gemini_tier: $gemini_tier}' \
+   '. + {args: $args, llm: $llm, pass: $pass, no_merge: $no_merge, pr_number: $pr_number, base_branch: $base_branch, bot_review_baseline: $bot_review_baseline, discovered_bots: $discovered_bots, has_ci: $has_ci, skip_coverage: $skip_coverage, coverage_threshold: $coverage_threshold, coverage_result: $coverage_result, coverage_tests_generated: $coverage_tests_generated, e2e_required: $e2e_required, e2e_attempted: $e2e_attempted, e2e_result: $e2e_result, e2e_skip_reason: $e2e_skip_reason, e2e_pages_tested: $e2e_pages_tested, review_clean: $review_clean, head_sha: $head_sha, gemini_tier: $gemini_tier}' \
    "$STATE_FILE" > "$TMP" && mv "$TMP" "$STATE_FILE"
 ```
 
@@ -40,8 +41,10 @@ routing and subsequent steps depend on these exact names.
 | `coverage_result` | string | Step E.3 of coverage-verification.md | Aggregate percent, or empty when skipped |
 | `coverage_skip_reason` | string | Step E.3 of coverage-verification.md | Empty when computed; `"all-main"` when every changed file was `package main` |
 | `coverage_tests_generated` | int | Step F of coverage-verification.md | Count of new tests created |
+| `e2e_required` | string | Step 7.6 | `"true"` when the diff is UI-visible and browser E2E is required |
 | `e2e_attempted` | string | Step 7.6e | `"true"` when E2E ran |
-| `e2e_result` | string | Step 7.6e | `"passed"` / `"errors"` / `"skipped"` |
+| `e2e_result` | string | Step 7.6e | `"passed"` / `"blocked"` / `"skipped"`; `blocked` means required E2E did not pass and merge must stop |
+| `e2e_skip_reason` | string | Step 7.6e | Empty on pass; otherwise machine-readable reason such as `"no-ui-visible-changes"`, `"missing-browser-tooling"`, or `"dev-server-unavailable"` |
 | `e2e_pages_tested` | int | Step 7.6e | Number of routes tested |
 | `review_clean` | string | Step 5c | `"true"` when LLM returned no findings — fast-path past Step 6 on re-entry |
 | `head_sha` | string | Step 9c, 10e, 12c | Latest pushed commit; CI watch is anchored to this |

--- a/scripts/test-ship-e2e-gate.sh
+++ b/scripts/test-ship-e2e-gate.sh
@@ -1,0 +1,79 @@
+#!/bin/bash
+# Verify /ship treats missing UI E2E prerequisites as a blocking condition.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+LOCAL_REVIEW="$ROOT_DIR/plugins/go-workflow/lib/ship/local-review.md"
+SHIP_COMMAND="$ROOT_DIR/plugins/go-workflow/commands/ship.md"
+MERGE_DOC="$ROOT_DIR/plugins/go-workflow/lib/ship/merge.md"
+STATE_FIELDS="$ROOT_DIR/plugins/go-workflow/lib/ship/state-fields.md"
+
+ERRORS=0
+
+fail() {
+  echo "FAIL: $1"
+  ERRORS=$((ERRORS + 1))
+}
+
+require_text() {
+  local file="$1"
+  local pattern="$2"
+  local label="$3"
+
+  if ! grep -qE "$pattern" "$file"; then
+    fail "$label"
+  fi
+}
+
+reject_text() {
+  local file="$1"
+  local pattern="$2"
+  local label="$3"
+
+  if grep -qE "$pattern" "$file"; then
+    fail "$label"
+  fi
+}
+
+echo "=== Ship E2E Gate Tests ==="
+
+require_text "$LOCAL_REVIEW" "E2E PREREQUISITE MISSING" \
+  "ship local review must name the missing-dev-server blocker"
+require_text "$LOCAL_REVIEW" "e2e_result.*blocked" \
+  "ship local review must persist blocked E2E state"
+require_text "$LOCAL_REVIEW" "No merge" \
+  "ship local review must explicitly stop before merge"
+require_text "$SHIP_COMMAND" "E2E may be reused only when" \
+  "ship command must not document --skip-coverage as unconditional E2E skip"
+require_text "$SHIP_COMMAND" "e2e_result=blocked" \
+  "ship command must document blocked E2E state in the top-level phase summary"
+require_text "$SHIP_COMMAND" "skipped only because the[[:space:]]*$" \
+  "ship completion criteria must limit E2E skip to non-UI/no-web cases"
+reject_text "$LOCAL_REVIEW" "If server fails to start within 30s.*skip to Step 8\\. Do NOT block shipping" \
+  "ship local review still silently skips when dev server is missing"
+reject_text "$LOCAL_REVIEW" "E2E failures are informational, NEVER block" \
+  "ship local review still documents E2E failures as non-blocking"
+reject_text "$SHIP_COMMAND" "skip coverage \\+ e2e phases entirely" \
+  "ship command still says --skip-coverage skips E2E entirely"
+reject_text "$SHIP_COMMAND" "E2E smoke tests passed \\(or skipped .*[Mm]CP unavailable" \
+  "ship completion criteria still allows MCP-unavailable E2E skip"
+
+require_text "$MERGE_DOC" "e2e_result.*blocked" \
+  "ship merge phase must read blocked E2E state"
+require_text "$MERGE_DOC" "E2E PREREQUISITE MISSING" \
+  "ship merge phase must stop on blocked E2E state"
+require_text "$MERGE_DOC" "Verification partial" \
+  "ship summary must avoid unqualified verification-complete wording for partial E2E"
+
+require_text "$STATE_FIELDS" "blocked" \
+  "ship state fields must document blocked E2E result"
+
+if [ "$ERRORS" -gt 0 ]; then
+  echo "FAILED: $ERRORS ship E2E gate issue(s)"
+  exit 1
+fi
+
+echo "All ship E2E gate tests passed."


### PR DESCRIPTION
## Summary
- make /ship treat missing or failed browser E2E as a hard blocker for UI-visible diffs
- persist E2E required/result/skip reason state and add a merge-phase backstop
- add a regression test and CI job for the /ship E2E gate

Fixes #163

## Test Plan
- bash scripts/test-ship-e2e-gate.sh
- ./scripts/test-commands.sh
- ./scripts/test-hooks.sh
- ./scripts/check-shared-sync.sh
- ./scripts/test-loop-state.sh
- ./scripts/test-installation.sh
- git diff --check

Note: repo root has no go.mod, so root go build/go test are not applicable.