### PR TITLE
fix(codex): pin high reasoning effort, resize timeouts, refresh model lists

### DIFF
--- a/plugins/go-workflow/lib/ship/local-review.md
+++ b/plugins/go-workflow/lib/ship/local-review.md
@@ -49,9 +49,9 @@ DIFF_LINES=$(printf '%s\n' "$DIFF" | wc -l)
 DIFF_FILES=$(printf '%s\n' "$DIFF" | grep -c '^diff --git' || echo 0)
 echo "Diff size: $DIFF_LINES lines across $DIFF_FILES files"
 
-# Adaptive timeout: 120s base + 2s per 100 lines, capped at 600s
-CODEX_TIMEOUT=$(( 120 + (DIFF_LINES / 50) ))
-if [ "$CODEX_TIMEOUT" -gt 600 ]; then CODEX_TIMEOUT=600; fi
+# Adaptive timeout sized for high reasoning effort: 300s base + 4s per 100 lines, capped at 900s
+CODEX_TIMEOUT=$(( 300 + (DIFF_LINES / 25) ))
+if [ "$CODEX_TIMEOUT" -gt 900 ]; then CODEX_TIMEOUT=900; fi
 ```
 
 If `DIFF_LINES > 3000`, ask via `AskUserQuestion`:
@@ -85,15 +85,17 @@ SCHEMA_EOF
 ```bash
 PROMPT_FILE=$(mktemp /tmp/codex-review-prompt-XXXXXX)
 echo "$ASSEMBLED_PROMPT" > "$PROMPT_FILE"
-CODEX_TIMEOUT="${CODEX_TIMEOUT:-120}"
+CODEX_TIMEOUT="${CODEX_TIMEOUT:-300}"
 
 set +e
 if [ -n "$TIMEOUT_CMD" ]; then
   REVIEW_JSON=$($TIMEOUT_CMD "${CODEX_TIMEOUT}" $CODEX_CMD exec -m "${MODEL:-gpt-5.5}" -s read-only \
+    -c model_reasoning_effort="high" \
     --output-schema "$SCHEMA_FILE" \
     - < "$PROMPT_FILE" 2>"/tmp/codex-review-stderr-$$")
 else
   REVIEW_JSON=$($CODEX_CMD exec -m "${MODEL:-gpt-5.5}" -s read-only \
+    -c model_reasoning_effort="high" \
     --output-schema "$SCHEMA_FILE" \
     - < "$PROMPT_FILE" 2>"/tmp/codex-review-stderr-$$")
 fi
@@ -133,7 +135,7 @@ Rules:
 
 ```bash
 DOUBLED_TIMEOUT=$(( CODEX_TIMEOUT * 2 ))
-if [ "$DOUBLED_TIMEOUT" -gt 900 ]; then DOUBLED_TIMEOUT=900; fi
+if [ "$DOUBLED_TIMEOUT" -gt 1800 ]; then DOUBLED_TIMEOUT=1800; fi
 ```
 
 Display diff size, timeout used, partial output, stderr. `AskUserQuestion`:
@@ -174,7 +176,7 @@ If `codex exec` returns non-JSON or empty output (and exit code 0), do NOT fall 
 ### Codex Quick Mode (`codex review --base`)
 
 ```bash
-$CODEX_CMD review --base "$BASE_BRANCH" -c model="${MODEL:-gpt-5.5}"
+$CODEX_CMD review --base "$BASE_BRANCH" -c model="${MODEL:-gpt-5.5}" -c model_reasoning_effort="high"
 ```
 
 Capture output as free-text `FINDINGS`. Set `CODEX_EXEC_FALLBACK=true`. Persist `quick_mode=true`:

--- a/plugins/go-workflow/skills/complete-issue/phases.md
+++ b/plugins/go-workflow/skills/complete-issue/phases.md
@@ -33,16 +33,16 @@ an adaptive timeout sized to the diff:
 DEFAULT_BRANCH=$(git remote show origin 2>/dev/null | grep 'HEAD branch' | sed 's/.*: //' || echo "main")
 DIFF=$(git diff "origin/${DEFAULT_BRANCH}...HEAD")
 DIFF_LINES=$(printf '%s\n' "$DIFF" | wc -l)
-# Adaptive timeout: 120s base + 2s per 100 lines, capped at 600s
-CODEX_TIMEOUT=$(( 120 + (DIFF_LINES / 50) ))
-if [ "$CODEX_TIMEOUT" -gt 600 ]; then CODEX_TIMEOUT=600; fi
+# Adaptive timeout sized for high reasoning effort: 300s base + 4s per 100 lines, capped at 900s
+CODEX_TIMEOUT=$(( 300 + (DIFF_LINES / 25) ))
+if [ "$CODEX_TIMEOUT" -gt 900 ]; then CODEX_TIMEOUT=900; fi
 # Detect timeout command (macOS does not ship GNU timeout)
 if command -v gtimeout >/dev/null 2>&1; then TIMEOUT_CMD="gtimeout"
 elif command -v timeout >/dev/null 2>&1; then TIMEOUT_CMD="timeout"
 else TIMEOUT_CMD=""; fi
 ```
 
-If `$TIMEOUT_CMD` is available, invoke `$TIMEOUT_CMD $CODEX_TIMEOUT $CODEX_CMD exec` with structured output. If no timeout command is available, run `$CODEX_CMD exec` without a timeout wrapper.
+If `$TIMEOUT_CMD` is available, invoke `$TIMEOUT_CMD $CODEX_TIMEOUT $CODEX_CMD exec -c model_reasoning_effort="high"` with structured output. If no timeout command is available, run `$CODEX_CMD exec -c model_reasoning_effort="high"` without a timeout wrapper. Reasoning effort is always pinned to `high`.
 
 If the diff exceeds 3000 lines, warn the user via `AskUserQuestion` BEFORE starting:
 
@@ -51,7 +51,7 @@ If the diff exceeds 3000 lines, warn the user via `AskUserQuestion` BEFORE start
 Forward the user's choice to the appropriate code path:
 
 - **Proceed** → run codex with the adaptive timeout above.
-- **Use `codex review --base`** → swap the command for `codex review --base origin/${DEFAULT_BRANCH}`.
+- **Use `codex review --base`** → swap the command for `codex review --base origin/${DEFAULT_BRANCH} -c model_reasoning_effort="high"`.
 - **Agent review** → dispatch an Agent subagent (sonnet) with the diff and the same review checklist.
 - **Skip** → warn and proceed directly to Phase 3.
 

--- a/plugins/llm-tools/commands/codex.md
+++ b/plugins/llm-tools/commands/codex.md
@@ -34,9 +34,9 @@ Display usage and ask for input:
 | Model | Best For |
 |-------|----------|
 | `gpt-5.5` | Latest frontier model, best overall (default) |
-| `gpt-5.5-pro` | Maximum performance on complex tasks |
-| `gpt-5.3-codex` | Previous generation frontier model |
-| `gpt-5.1-codex-mini` | Simple tasks, cost-efficient |
+| `gpt-5.4` | Previous flagship, strong coding and reasoning |
+| `gpt-5.4-mini` | Fast and cost-efficient for lighter tasks |
+| `gpt-5.3-codex-spark` | Near-instant iteration (ChatGPT Pro only) |
 
 Ask the user: "What would you like Codex to do?"
 
@@ -114,7 +114,7 @@ Used for non-review tasks (and for fix-oriented review prompts from Step 1).
 
 → Read `${CLAUDE_PLUGIN_ROOT}/lib/codex/exec-flow.md` for the full procedure:
 
-- Default config (model `gpt-5.5`, sandbox `workspace-write`, no session context)
+- Default config (model `gpt-5.5`, reasoning effort `high`, sandbox `workspace-write`, no session context)
 - Interactive `--ask` flow: model selection, optional session-context summary/detailed, sandbox-mode pick (`read-only` / `workspace-write` / `danger-full-access` — confirmation required for `danger-full-access`)
 - Execution: bare `$CODEX_CMD exec` or temp-file prompt with assembled context block
 - Result reporting and `codex resume --last` follow-up

--- a/plugins/llm-tools/commands/llm-compare.md
+++ b/plugins/llm-tools/commands/llm-compare.md
@@ -62,7 +62,7 @@ Only skip if the user explicitly chooses "Skip this LLM".
 
 ## 2. Select Models (Optional)
 
-For each LLM, ask if user wants to specify a model. Defaults: **OpenAI** `gpt-5.2`, **Gemini** `gemini-2.5-flash`, **Ollama** first available code model (codellama, deepseek-coder, etc.).
+For each LLM, ask if user wants to specify a model. Defaults: **OpenAI** `gpt-5.5`, **Gemini** `gemini-2.5-flash`, **Ollama** first available code model (codellama, deepseek-coder, etc.).
 
 ## 3. Include Context (Optional)
 
@@ -103,7 +103,7 @@ Run in parallel where possible. Use `CLEAN_PROMPT`:
 
 ```bash
 # OpenAI (only if CODEX_AVAILABLE=true)
-$CODEX_CMD exec -m <model> -s read-only --skip-git-repo-check "$CLEAN_PROMPT"
+$CODEX_CMD exec -m <model> -s read-only -c model_reasoning_effort="high" --skip-git-repo-check "$CLEAN_PROMPT"
 
 # Gemini
 gemini "$CLEAN_PROMPT" -m <model>
@@ -119,7 +119,7 @@ If `codex exec` fails (non-zero exit or no output), do NOT silently skip. Displa
 ```markdown
 ## LLM Comparison: <prompt>
 
-### OpenAI (gpt-5.2)
+### OpenAI (gpt-5.5)
 [Response]
 
 ---
@@ -186,7 +186,7 @@ After the report, if review-fix detection was active: check if ANY LLM produced 
 ```markdown
 ## LLM Comparison: Should I use channels or mutexes for this shared counter?
 
-### OpenAI (gpt-5.2)
+### OpenAI (gpt-5.5)
 For a simple shared counter, a mutex is more appropriate. Channels are designed for communication between goroutines, not protecting shared state. Use `sync/atomic` for even better performance.
 
 ### Gemini (gemini-2.5-flash)

--- a/plugins/llm-tools/commands/review-loop.md
+++ b/plugins/llm-tools/commands/review-loop.md
@@ -71,7 +71,7 @@ Use a **single `AskUserQuestion` call** with two questions.
 
 **Q2 — "Which model?":** show options based on `LLM_CHOICE`:
 
-- **codex:** `gpt-5.5` (Recommended), `gpt-5.5-pro`, `gpt-5.3-codex`, `gpt-5.1-codex-mini`
+- **codex:** `gpt-5.5` (Recommended), `gpt-5.4`, `gpt-5.4-mini`, `gpt-5.3-codex-spark` (ChatGPT Pro only)
 - **gemini:** `gemini-2.5-pro` (Recommended), `gemini-2.5-flash`
 - **ollama:** `codellama` (Recommended), `llama3`, `deepseek-coder`, Custom
 

--- a/plugins/llm-tools/lib/codex/exec-flow.md
+++ b/plugins/llm-tools/lib/codex/exec-flow.md
@@ -11,11 +11,12 @@ Use recommended defaults without prompting. Display a brief configuration summar
 ```
 Exec config (defaults — add --ask to customize):
   Model:    gpt-5.5
+  Effort:   high
   Context:  None
   Sandbox:  workspace-write
 ```
 
-Store: model = "gpt-5.5", context = "No", sandbox = "workspace-write". Proceed directly to Step 4 (Run Codex).
+Store: model = "gpt-5.5", context = "No", sandbox = "workspace-write". Reasoning effort is always `high` (pinned via `-c model_reasoning_effort="high"` on every codex invocation — not user-configurable). Proceed directly to Step 4 (Run Codex).
 
 ## If `INTERACTIVE_MODE` is `true` (`--ask` flag provided)
 
@@ -26,9 +27,9 @@ Ask the user which model to use:
 | Model | Best For |
 |-------|----------|
 | gpt-5.5 | Latest frontier model, best overall |
-| gpt-5.5-pro | Maximum performance on complex tasks |
-| gpt-5.3-codex | Previous generation frontier model |
-| gpt-5.1-codex-mini | Simple tasks, cost-efficient |
+| gpt-5.4 | Previous flagship, strong coding and reasoning |
+| gpt-5.4-mini | Fast and cost-efficient for lighter tasks |
+| gpt-5.3-codex-spark | Near-instant iteration (ChatGPT Pro only) |
 
 Default: `gpt-5.5`
 
@@ -83,7 +84,7 @@ Default: `read-only` (interactive). Always request confirmation before using `da
 ### If context was NOT requested
 
 ```bash
-$CODEX_CMD exec -m <model> -s <mode> --skip-git-repo-check "$CODEX_PROMPT"
+$CODEX_CMD exec -m <model> -s <mode> -c model_reasoning_effort="high" --skip-git-repo-check "$CODEX_PROMPT"
 ```
 
 ### If context WAS requested
@@ -108,7 +109,7 @@ Use the session context above to inform your review/analysis. The context descri
 being worked on in a previous AI coding session."
 
 printf '%s\n' "$EXEC_PROMPT" > "$PROMPT_FILE"
-$CODEX_CMD exec -m <model> -s <mode> --skip-git-repo-check - < "$PROMPT_FILE"
+$CODEX_CMD exec -m <model> -s <mode> -c model_reasoning_effort="high" --skip-git-repo-check - < "$PROMPT_FILE"
 rm -f "$PROMPT_FILE"
 trap - EXIT
 ```

--- a/plugins/llm-tools/lib/codex/review-flow.md
+++ b/plugins/llm-tools/lib/codex/review-flow.md
@@ -15,10 +15,11 @@ Review config (defaults — add --ask to customize):
   Review type:  Changes vs branch
   Context:      Auto-detect
   Model:        gpt-5.5
+  Effort:       high
   Depth:        Exhaustive
 ```
 
-Store: review type = "Changes vs branch", context = "Auto-detect", model = "gpt-5.5", depth = "Exhaustive". Proceed directly to R1.5.
+Store: review type = "Changes vs branch", context = "Auto-detect", model = "gpt-5.5", depth = "Exhaustive". Reasoning effort is always `high` (pinned via `-c model_reasoning_effort="high"` on every codex invocation — not user-configurable). Proceed directly to R1.5.
 
 ### If `INTERACTIVE_MODE` is `true` (`--ask` flag provided)
 
@@ -48,9 +49,9 @@ Ask all review configuration questions in a **single `AskUserQuestion` call** wi
 | Option | Description |
 |--------|-------------|
 | gpt-5.5 (Recommended) | Latest frontier model, best overall |
-| gpt-5.5-pro | Maximum performance on complex tasks |
-| gpt-5.3-codex | Previous generation frontier model |
-| gpt-5.1-codex-mini | Simple tasks, cost-efficient |
+| gpt-5.4 | Previous flagship, strong coding and reasoning |
+| gpt-5.4-mini | Fast and cost-efficient for lighter reviews |
+| gpt-5.3-codex-spark | Near-instant iteration (ChatGPT Pro only) |
 
 **Question 4 — "Review depth?"**
 
@@ -258,6 +259,7 @@ Write the assembled prompt to a temp file to avoid heredoc expansion issues with
 PROMPT_FILE=$(mktemp /tmp/codex-review-prompt-XXXXXX)
 echo "$ASSEMBLED_PROMPT" > "$PROMPT_FILE"
 REVIEW_JSON=$($CODEX_CMD exec -m <model> -s read-only \
+  -c model_reasoning_effort="high" \
   --output-schema "${CLAUDE_PLUGIN_ROOT}/schemas/codex-review.json" \
   - < "$PROMPT_FILE")
 # Strip codex exec headers (version/config info printed before JSON)
@@ -286,19 +288,19 @@ Use standard codex review commands:
 **For uncommitted changes:**
 
 ```bash
-$CODEX_CMD review --uncommitted -c model=<model>
+$CODEX_CMD review --uncommitted -c model=<model> -c model_reasoning_effort="high"
 ```
 
 **For changes vs branch:**
 
 ```bash
-$CODEX_CMD review --base <branch> -c model=<model>
+$CODEX_CMD review --base <branch> -c model=<model> -c model_reasoning_effort="high"
 ```
 
 **For specific commit:**
 
 ```bash
-$CODEX_CMD review --commit <sha> -c model=<model>
+$CODEX_CMD review --commit <sha> -c model=<model> -c model_reasoning_effort="high"
 ```
 
 Capture output as `FINDINGS`. Skip to R4 (or multi-pass loop below).
@@ -456,7 +458,7 @@ Review these changes against the requirements above. Ensure the implementation a
 #### Single Pass (or no multi-pass selected)
 
 ```bash
-$CODEX_CMD review -c model=<model> - <<'EOF'
+$CODEX_CMD review -c model=<model> -c model_reasoning_effort="high" - <<'EOF'
 <constructed context block with diff>
 EOF
 ```
@@ -500,7 +502,7 @@ If there are no new findings to report, respond with exactly: NO_NEW_FINDINGS
 Execute:
 
 ```bash
-$CODEX_CMD review -c model=<model> - <<'EOF'
+$CODEX_CMD review -c model=<model> -c model_reasoning_effort="high" - <<'EOF'
 <augmented context block>
 EOF
 ```

--- a/plugins/llm-tools/lib/review-loop/review-phase.md
+++ b/plugins/llm-tools/lib/review-loop/review-phase.md
@@ -38,9 +38,9 @@ DIFF_LINES=$(printf '%s\n' "$DIFF" | wc -l)
 DIFF_FILES=$(printf '%s\n' "$DIFF" | grep -c '^diff --git' || echo 0)
 echo "Diff size: $DIFF_LINES lines across $DIFF_FILES files"
 
-# Adaptive timeout: 120s base + 2s per 100 lines, capped at 600s
-CODEX_TIMEOUT=$(( 120 + (DIFF_LINES / 50) ))
-if [ "$CODEX_TIMEOUT" -gt 600 ]; then CODEX_TIMEOUT=600; fi
+# Adaptive timeout sized for high reasoning effort: 300s base + 4s per 100 lines, capped at 900s
+CODEX_TIMEOUT=$(( 300 + (DIFF_LINES / 25) ))
+if [ "$CODEX_TIMEOUT" -gt 900 ]; then CODEX_TIMEOUT=900; fi
 ```
 
 ### Large-diff warning (>3000 lines)
@@ -75,10 +75,12 @@ echo "$ASSEMBLED_PROMPT" > "$PROMPT_FILE"
 set +e
 if [ -n "$TIMEOUT_CMD" ]; then
   REVIEW_JSON=$($TIMEOUT_CMD "${CODEX_TIMEOUT}" $CODEX_CMD exec -m "$MODEL" -s read-only \
+    -c model_reasoning_effort="high" \
     --output-schema "${CLAUDE_PLUGIN_ROOT}/schemas/codex-review.json" \
     - < "$PROMPT_FILE" 2>"/tmp/codex-review-stderr-$$")
 else
   REVIEW_JSON=$($CODEX_CMD exec -m "$MODEL" -s read-only \
+    -c model_reasoning_effort="high" \
     --output-schema "${CLAUDE_PLUGIN_ROOT}/schemas/codex-review.json" \
     - < "$PROMPT_FILE" 2>"/tmp/codex-review-stderr-$$")
 fi
@@ -103,7 +105,7 @@ rm -f "$PROMPT_FILE"
 
 ```bash
 DOUBLED_TIMEOUT=$(( CODEX_TIMEOUT * 2 ))
-if [ "$DOUBLED_TIMEOUT" -gt 900 ]; then DOUBLED_TIMEOUT=900; fi
+if [ "$DOUBLED_TIMEOUT" -gt 1800 ]; then DOUBLED_TIMEOUT=1800; fi
 ```
 
 Display diff size, timeout used, partial output, and stderr. Then ask:
@@ -154,14 +156,14 @@ Standard `codex review`, faster but capped at 2-3 findings per pass.
 
 ```bash
 # For changes vs branch:
-$CODEX_CMD review --base "$BASE_BRANCH" -c model="$MODEL"
+$CODEX_CMD review --base "$BASE_BRANCH" -c model="$MODEL" -c model_reasoning_effort="high"
 
 # For uncommitted:
-$CODEX_CMD review --uncommitted -c model="$MODEL"
+$CODEX_CMD review --uncommitted -c model="$MODEL" -c model_reasoning_effort="high"
 
 # For specific files or when scope hint is provided, use stdin:
 DIFF=$(git diff ${BASE_BRANCH}...HEAD -- <files>)
-$CODEX_CMD review -c model="$MODEL" - <<EOF
+$CODEX_CMD review -c model="$MODEL" -c model_reasoning_effort="high" - <<EOF
 $DIFF
 
 ## Review Instructions


### PR DESCRIPTION
## Summary

Codex reviews driven by these skills were timing out since the GPT-5.5 rollout. Root causes: no reasoning effort was pinned (so behavior depended on each machine's codex config), and the adaptive timeout (120s base + 2s/100 lines, capped at 600s) was sized for older, faster models — gpt-5.5 latency degrades sharply at higher reasoning efforts, with slow first turns widely reported (https://github.com/openai/codex/issues/24260, https://github.com/openai/codex/issues/14795).

- Pin `-c model_reasoning_effort="high"` on **every** `codex exec` and `codex review` invocation across ship local-review, review-loop, codex review/exec flows, complete-issue, and llm-compare — effort is deliberately not user-configurable
- Resize the adaptive timeout for high effort: **300s base + 4s per 100 diff lines, capped at 900s** (was 120s/600s); the exit-124 retry doubling now caps at **1800s** (was 900s)
- Refresh model menus to the current Codex CLI lineup (https://developers.openai.com/codex/models): drop deprecated `gpt-5.3-codex`, `gpt-5.1-codex-mini`, `gpt-5.5-pro`, `gpt-5.2`; add `gpt-5.4`, `gpt-5.4-mini`, `gpt-5.3-codex-spark`; `llm-compare` OpenAI default is now `gpt-5.5`

Existing ask-on-timeout behavior is unchanged (no silent fallbacks). A follow-up PR will add a Fable/Claude review backend as an alternative reviewer.

## Test plan

- [x] `bash -n` syntax check on every bash block in the 8 edited markdown files (placeholder tokens substituted) — all pass; the one pre-existing prose-placeholder block in local-review.md is untouched by this diff
- [x] `./scripts/test-commands.sh` — 44 command files, frontmatter OK
- [x] Grepped repo for remaining stale model strings (`gpt-5.5-pro`, `gpt-5.3-codex`, `gpt-5.1-codex-mini`, `gpt-5.2`) — none remain
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)