### PR TITLE
docs(agent-skills): add marketing materials

### DIFF
--- a/agent-skills/README.md
+++ b/agent-skills/README.md
@@ -83,6 +83,7 @@ Customize rule severity in [`config/severity.yaml`](config/severity.yaml). See t
 - [API Reference](../docs/api/README.md) — REST API documentation
 - [API Usage](references/api-usage.md) — Quick API examples
 - [Demo Repository](examples/demo-repo/) — Sample project with intentional issues
+- [Marketing Materials](marketing/) — Draft awesome-copilot submission, blog post, and video outline
 
 ## License
 

--- a/agent-skills/examples/demo-repo/README.md
+++ b/agent-skills/examples/demo-repo/README.md
@@ -38,8 +38,8 @@ make coverage
 If testing from within the gopher-ai monorepo:
 
 ```bash
-make audit SKILLS_SCRIPTS=../../agent-skills/scripts
-make coverage SKILLS_SCRIPTS=../../agent-skills/scripts
+make audit SKILLS_SCRIPTS=../../scripts
+make coverage SKILLS_SCRIPTS=../../scripts
 ```
 
 ## Makefile Targets

--- a/agent-skills/marketing/README.md
+++ b/agent-skills/marketing/README.md
@@ -1,0 +1,33 @@
+# Agent Skills Marketing Materials
+
+Draft distribution materials for the Gopher AI Agent Skills package.
+
+These files are source material for external publishing. They should stay aligned
+with the canonical Agent Skills implementation in [`../`](../), especially the
+five skills under [`../skills/`](../skills/), the install script at
+[`../scripts/install.sh`](../scripts/install.sh), and the `.github/skills/`
+install target used by consuming repositories.
+
+## Materials
+
+| File | Purpose |
+|------|---------|
+| [`awesome-copilot-submission.md`](awesome-copilot-submission.md) | Submission brief and PR body draft for `github/awesome-copilot` |
+| [`blog-post.md`](blog-post.md) | Draft blog post for digitaldrywood.com |
+| [`youtube-outline.md`](youtube-outline.md) | 12-15 minute screen recording and talking-head outline |
+
+## Current Product Positioning
+
+Gopher AI Agent Skills give Go teams reusable, agent-discoverable code quality
+workflows:
+
+- `go-code-audit` for project-wide quality analysis
+- `go-code-review` for first-pass PR review
+- `go-lint-audit` for lint findings and configuration guidance
+- `go-standards-audit` for Gopher Guides standards checks
+- `go-test-coverage` for coverage gaps and test recommendations
+
+The local toolchain path works without a Gopher Guides API key. Setting
+`GOPHER_GUIDES_API_KEY` enables enhanced analysis powered by Gopher Guides
+training materials and should be disclosed anywhere external services are
+discussed.

--- a/agent-skills/marketing/awesome-copilot-submission.md
+++ b/agent-skills/marketing/awesome-copilot-submission.md
@@ -1,0 +1,96 @@
+# awesome-copilot Submission Draft
+
+Target repository: <https://github.com/github/awesome-copilot>
+
+## Submission Type
+
+Submit the Gopher AI Go quality checks as Agent Skills under the upstream
+`skills/` directory. The current upstream flow expects each skill to live in
+`skills/<skill-name>/SKILL.md`, with frontmatter where `name` matches the folder
+name and `description` is non-empty.
+
+The five Gopher AI skills already follow that model in this repository:
+
+| Skill | Source | Description |
+|-------|--------|-------------|
+| `go-code-audit` | [`../skills/go-code-audit/SKILL.md`](../skills/go-code-audit/SKILL.md) | Comprehensive code quality analysis against Go best practices |
+| `go-code-review` | [`../skills/go-code-review/SKILL.md`](../skills/go-code-review/SKILL.md) | Automated first-pass PR code review with quality scoring |
+| `go-lint-audit` | [`../skills/go-lint-audit/SKILL.md`](../skills/go-lint-audit/SKILL.md) | Extended lint analysis with human-readable explanations |
+| `go-standards-audit` | [`../skills/go-standards-audit/SKILL.md`](../skills/go-standards-audit/SKILL.md) | Gopher Guides coding standards enforcement |
+| `go-test-coverage` | [`../skills/go-test-coverage/SKILL.md`](../skills/go-test-coverage/SKILL.md) | Test coverage gap analysis and recommendations |
+
+## Upstream Prep Checklist
+
+- Fork `github/awesome-copilot` and create a branch from `main`.
+- Run `npm install` in the fork.
+- Create each skill folder with `npm run skill:create -- --name <skill-name> --description "<description>"` or copy the prepared folder and verify the frontmatter.
+- Keep each skill self-contained for awesome-copilot. If helper scripts or config are included, place them inside that skill folder or replace shared-path references with links to this repository's installer.
+- Disclose that `GOPHER_GUIDES_API_KEY` is optional and that API-enhanced analysis sends code or diffs to gopherguides.com.
+- Run `npm run skill:validate`.
+- Run `npm start` so the upstream README tables are regenerated.
+- Test the submitted skills with GitHub Copilot before opening the PR.
+
+## Proposed PR Title
+
+Add Gopher AI Go code quality agent skills
+
+If an AI agent opens the PR, append the AI-agent marker requested by the current
+upstream contribution guide.
+
+## Proposed PR Body
+
+````markdown
+## Description
+
+Adds five Gopher AI Agent Skills for Go code quality workflows:
+
+- `go-code-audit` for project-wide quality analysis against Go best practices
+- `go-code-review` for first-pass PR review with quality scoring
+- `go-lint-audit` for lint explanations and `.golangci.yml` recommendations
+- `go-standards-audit` for Gopher Guides coding standards checks
+- `go-test-coverage` for coverage gap analysis and test recommendations
+
+These skills are based on the Gopher AI Agent Skills package:
+https://github.com/gopherguides/gopher-ai/tree/main/agent-skills
+
+The skills work with local Go tooling by default: `go vet`, `go test`,
+`staticcheck`, and `golangci-lint`. Teams can optionally set
+`GOPHER_GUIDES_API_KEY` for enhanced analysis from Gopher Guides training
+materials. API-enhanced analysis can send code or diff content to
+gopherguides.com, so the skill docs call out that teams should confirm their
+policy before enabling it.
+
+## Type of Contribution
+
+- [x] New skill file.
+
+## Validation
+
+- [x] I have read and followed the CONTRIBUTING.md guidelines.
+- [x] I have read and followed the guidance for submissions involving paid services.
+- [x] My contribution adds new skill folders in the `skills/` directory.
+- [x] The files follow the required naming convention.
+- [x] The content is clearly structured and follows the example format.
+- [x] I have tested the skills with GitHub Copilot.
+- [x] I have run `npm run skill:validate`.
+- [x] I have run `npm start` and verified `README.md` is up to date.
+- [x] I am targeting the `main` branch for this pull request.
+
+## Additional Notes
+
+Gopher AI also ships an installer for teams that want all five skills, helper
+scripts, severity configuration, and agentic workflow templates in one command:
+
+```bash
+bash <(curl -fsSL https://raw.githubusercontent.com/gopherguides/gopher-ai/main/agent-skills/scripts/install.sh) --repo .
+```
+````
+
+## Alternate Distribution Path
+
+If upstream maintainers prefer a single installable package instead of five
+direct skill entries, use the external plugin review workflow rather than
+opening a PR that edits `plugins/external.json` directly. The Gopher AI repo is
+public, MIT licensed, and already contains platform plugin manifests under
+`plugins/<name>/`, but the Agent Skills package itself is documented under
+[`../`](../).

--- a/agent-skills/marketing/blog-post.md
+++ b/agent-skills/marketing/blog-post.md
@@ -1,0 +1,231 @@
+# Automated Go Code Quality with GitHub Agent Skills
+
+Draft destination: digitaldrywood.com
+
+## Working Summary
+
+Gopher AI now ships five reusable Agent Skills that let GitHub Copilot and other
+compatible coding agents audit Go projects, review pull requests, explain lint
+findings, check Gopher Guides standards, and identify missing tests. The skills
+install into `.github/skills/` for a repository or `~/.copilot/skills/` for a
+personal setup, and they work with local Go tooling before any hosted API is
+configured.
+
+## Draft Post
+
+### Automated Go Code Quality with GitHub Agent Skills
+
+Code review gets expensive when every pull request asks reviewers to catch the
+same baseline issues: unchecked errors, missing tests, package stutter,
+confusing lint failures, undocumented exported APIs, and concurrency hazards.
+Those are exactly the kinds of repeatable checks an agent should help with
+before a human reviewer spends attention on product behavior and design.
+
+The Gopher AI Agent Skills package collects common Go quality workflows into
+five reusable skills:
+
+| Skill | Use it for |
+|-------|------------|
+| `go-code-audit` | Project-wide quality analysis against Go best practices |
+| `go-code-review` | First-pass PR review with categorized findings and scoring |
+| `go-lint-audit` | Lint explanations, categories, and configuration guidance |
+| `go-standards-audit` | Gopher Guides standards for documentation, structure, and concurrency |
+| `go-test-coverage` | Coverage gaps, missing edge cases, and test recommendations |
+
+Each skill is a folder with a `SKILL.md` file that follows the Agent Skills
+specification. Compatible agents load the right skill on demand, so your repo can
+carry durable review guidance without making every prompt longer.
+
+### Install in a Repository
+
+For a team repository, install the package into `.github/skills/`:
+
+```bash
+bash <(curl -fsSL https://raw.githubusercontent.com/gopherguides/gopher-ai/main/agent-skills/scripts/install.sh) --repo .
+```
+
+The installer copies:
+
+- skills to `.github/skills/<skill-name>/`
+- helper scripts to `.github/skills/scripts/`
+- severity configuration to `.github/skills/config/`
+- workflow templates to `.github/agentic-workflows/`
+
+Commit those files so every contributor's compatible agent can discover the
+same skills.
+
+```bash
+git add .github/skills .github/agentic-workflows
+git commit -m "feat: add Gopher AI agent skills"
+```
+
+### Install for Yourself
+
+For personal use across repositories:
+
+```bash
+bash <(curl -fsSL https://raw.githubusercontent.com/gopherguides/gopher-ai/main/agent-skills/scripts/install.sh) --personal
+```
+
+That installs the skills under `~/.copilot/skills/`.
+
+### Demo: Audit a Go Project
+
+After installation, ask Copilot or another compatible coding agent:
+
+```text
+Audit this Go project for code quality issues.
+```
+
+The `go-code-audit` skill guides the agent through local checks such as:
+
+```bash
+go vet ./...
+staticcheck ./...
+golangci-lint run --max-issues-per-linter 0 --max-same-issues 0 ./...
+```
+
+It then looks beyond tool output for review patterns such as package stutter,
+unclear exported APIs, weak error context, unbounded goroutines, and global
+mutable state.
+
+TODO: Add screenshot of an audit report showing critical, warning, and
+suggestion sections.
+
+### Demo: Review a Pull Request
+
+For PRs, ask:
+
+```text
+Review my changes before I open a pull request.
+```
+
+The `go-code-review` skill focuses on the diff, runs checks against changed Go
+packages, flags breaking API changes, and produces a reviewer-friendly summary.
+The goal is not to replace human review. The goal is to move predictable
+findings earlier so humans can focus on correctness, product behavior, and
+maintainability.
+
+TODO: Add screenshot of a PR review comment or local review summary.
+
+### Demo: Improve Test Coverage
+
+Ask:
+
+```text
+What tests am I missing?
+```
+
+The `go-test-coverage` skill runs coverage analysis, identifies untested
+exported functions and error paths, and recommends table-driven tests that fit
+the codebase.
+
+You can also run the helper script directly:
+
+```bash
+bash .github/skills/scripts/coverage-report.sh
+```
+
+### Customize Severity for Your Team
+
+Teams do not all gate on the same rules. After installation, edit:
+
+```text
+.github/skills/config/severity.yaml
+```
+
+For example, you might make formatting and data races critical while treating
+preallocation hints as suggestions:
+
+```yaml
+overrides:
+  gofmt: critical
+  race: critical
+  prealloc: suggestion
+```
+
+Coverage thresholds live in the same file.
+
+### CI/CD Integration
+
+Agent Skills are useful interactively, but the same package also supports
+automation. A GitHub Actions workflow can call the helper scripts directly:
+
+```yaml
+name: Code Quality
+
+on:
+  pull_request:
+    types: [opened, synchronize]
+
+jobs:
+  audit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version: '1.22'
+      - name: Install tools
+        run: |
+          go install github.com/golangci/golangci-lint/cmd/golangci-lint@latest
+          go install honnef.co/go/tools/cmd/staticcheck@latest
+      - name: Run audit
+        run: bash .github/skills/scripts/audit.sh . --yes
+      - name: Coverage report
+        run: bash .github/skills/scripts/coverage-report.sh
+```
+
+If you have a Gopher Guides API key, add it as a repository secret and pass it to
+the audit step:
+
+```bash
+gh secret set GOPHER_GUIDES_API_KEY --body "your-key-here"
+```
+
+```yaml
+env:
+  GOPHER_GUIDES_API_KEY: ${{ secrets.GOPHER_GUIDES_API_KEY }}
+```
+
+The API is optional. The skills and scripts still run with local tooling only.
+When the API key is set, enhanced analysis can send source code or diffs to
+gopherguides.com, so make sure your organization's policy permits external code
+analysis.
+
+### Try It on the Demo Repository
+
+The Gopher AI repo includes a small demo project with intentional quality
+issues:
+
+```bash
+cd agent-skills/examples/demo-repo
+make audit SKILLS_SCRIPTS=../../scripts
+make coverage SKILLS_SCRIPTS=../../scripts
+```
+
+Use it to see the shape of the audit and coverage output before installing the
+skills in a production repository.
+
+### Wrap Up
+
+Agent Skills are a practical way to put team standards where coding agents can
+find and reuse them. Gopher AI's Go skills make the baseline quality pass
+repeatable: audit the project, review the diff, explain lint, enforce standards,
+and find missing tests.
+
+Install them from the Gopher AI repository:
+
+```bash
+bash <(curl -fsSL https://raw.githubusercontent.com/gopherguides/gopher-ai/main/agent-skills/scripts/install.sh) --repo .
+```
+
+Then commit `.github/skills/` so the whole team gets the same Go review
+baseline.
+
+## Links
+
+- Gopher AI Agent Skills: <https://github.com/gopherguides/gopher-ai/tree/main/agent-skills>
+- Setup guide: [`../SETUP.md`](../SETUP.md)
+- API reference: [`../../docs/api/README.md`](../../docs/api/README.md)
+- Demo repository: [`../examples/demo-repo/`](../examples/demo-repo/)

--- a/agent-skills/marketing/youtube-outline.md
+++ b/agent-skills/marketing/youtube-outline.md
@@ -1,0 +1,201 @@
+# YouTube Video Outline: Gopher AI Agent Skills
+
+Target runtime: 12-15 minutes
+
+Format: talking head intro and wrap-up with screen recording for installation,
+agent prompts, terminal output, and GitHub PR workflow.
+
+## Title Options
+
+- Automated Go Code Quality with GitHub Agent Skills
+- Give GitHub Copilot a Go Code Review Playbook
+- Agent Skills for Go Audits, PR Review, Lint, and Coverage
+
+## Audience
+
+Go developers and team leads who want repeatable AI-assisted code quality checks
+inside GitHub Copilot, Claude Code, Codex, or another compatible agent.
+
+## Core Message
+
+Gopher AI turns Go review standards into reusable Agent Skills. Install once,
+commit the skills to `.github/skills/`, and let compatible agents run the same
+audit, review, lint, standards, and coverage playbooks across the team.
+
+## Segment Order
+
+### 1. Hook
+
+Talking head:
+
+- "Every Go PR has the same baseline review chores: errors, tests, lint,
+  package names, exported APIs, and concurrency checks."
+- "Instead of writing that prompt every time, put the review playbook in the
+  repo as Agent Skills."
+
+Screen:
+
+- Show the five skill folders under `agent-skills/skills/`.
+- Open one `SKILL.md` to show `name`, `description`, and task instructions.
+
+### 2. What Agent Skills Add
+
+Screen:
+
+- Show `agent-skills/README.md`.
+- Highlight the five skills:
+  - `go-code-audit`
+  - `go-code-review`
+  - `go-lint-audit`
+  - `go-standards-audit`
+  - `go-test-coverage`
+
+Talking points:
+
+- Skills are discoverable task instructions with optional bundled assets.
+- They keep repeatable guidance in version control.
+- The local path works without an API key; `GOPHER_GUIDES_API_KEY` only enables
+  enhanced analysis.
+
+### 3. Install in a Repository
+
+Screen recording:
+
+```bash
+bash <(curl -fsSL https://raw.githubusercontent.com/gopherguides/gopher-ai/main/agent-skills/scripts/install.sh) --repo .
+tree .github/skills -L 2
+tree .github/agentic-workflows -L 1
+```
+
+Callouts:
+
+- Skills install to `.github/skills/`.
+- Scripts install to `.github/skills/scripts/`.
+- Severity config installs to `.github/skills/config/severity.yaml`.
+- Workflow templates install to `.github/agentic-workflows/`.
+
+### 4. Demo the Code Audit
+
+Screen recording:
+
+- Open `agent-skills/examples/demo-repo/main.go`.
+- Point out intentional issues: unchecked errors, global mutable state, weak
+  error handling, and incomplete tests.
+- Ask the agent: "Audit this Go project for code quality issues."
+- Run the helper script:
+
+```bash
+cd agent-skills/examples/demo-repo
+make audit SKILLS_SCRIPTS=../../scripts
+```
+
+Talking points:
+
+- The skill combines local tools with agent review.
+- Findings are grouped by severity.
+- The API-enhanced path is optional and should follow organization policy.
+
+### 5. Demo Test Coverage
+
+Screen recording:
+
+```bash
+make coverage SKILLS_SCRIPTS=../../scripts
+```
+
+Ask the agent:
+
+```text
+What tests am I missing?
+```
+
+Talking points:
+
+- Coverage percentage alone is not enough.
+- The useful output is the missing edge cases and error paths.
+- The skill nudges toward table-driven tests.
+
+### 6. PR Review Workflow
+
+Screen recording:
+
+- Show a local branch with a small Go change.
+- Ask: "Review my changes before I open a pull request."
+- Show the generated summary format:
+  - must fix
+  - should fix
+  - nits
+  - breaking changes
+  - test recommendation
+
+Talking points:
+
+- The first-pass review is for predictable findings.
+- Human reviewers still own product behavior, design, and tradeoffs.
+- The goal is a cleaner PR before review starts.
+
+### 7. CI/CD Integration
+
+Screen recording:
+
+- Open `agent-skills/SETUP.md`.
+- Show the GitHub Actions example.
+- Show optional secret setup:
+
+```bash
+gh secret set GOPHER_GUIDES_API_KEY --body "your-key-here"
+```
+
+Talking points:
+
+- The same scripts can run in CI.
+- The API key is optional.
+- Teams can customize severity in `.github/skills/config/severity.yaml`.
+
+### 8. Wrap Up
+
+Talking head:
+
+- "Install the skills, commit `.github/skills/`, and start using the same Go
+  quality baseline in every repo."
+- Mention the repo path:
+  <https://github.com/gopherguides/gopher-ai/tree/main/agent-skills>
+
+Screen:
+
+- End on `agent-skills/README.md` with the install command visible.
+
+## Shot List
+
+- Talking head intro
+- Repo tree showing `agent-skills/`
+- `SKILL.md` frontmatter close-up
+- Terminal install command
+- `.github/skills/` installed tree
+- Demo repo audit output
+- Coverage output
+- Generated PR review summary
+- GitHub Actions YAML from setup guide
+- Talking head wrap-up
+
+## Assets to Capture
+
+- Screenshot: audit report with severity sections
+- Screenshot: PR review summary or comment
+- Screenshot: coverage report
+- Terminal recording: installer command
+- Terminal recording: demo audit and coverage commands
+- Browser capture: Gopher AI GitHub repo Agent Skills README
+
+## Description Draft
+
+Gopher AI Agent Skills give GitHub Copilot and compatible coding agents reusable
+Go code quality workflows: project audits, PR review, lint explanations, Gopher
+Guides standards checks, and test coverage analysis. This walkthrough installs
+the skills into `.github/skills/`, runs them on a demo Go project, and shows how
+to wire the helper scripts into CI.
+
+Links:
+
+- Gopher AI Agent Skills: https://github.com/gopherguides/gopher-ai/tree/main/agent-skills
+- Setup guide: https://github.com/gopherguides/gopher-ai/blob/main/agent-skills/SETUP.md


### PR DESCRIPTION
## Summary

- Add Agent Skills marketing materials for the awesome-copilot submission, digitaldrywood.com blog draft, and YouTube outline.
- Link the new materials from the Agent Skills README.
- Fix the demo repository README script path for running from inside the monorepo.

## Validation

- `git diff --check`
- `GOCACHE=/tmp/gopher-ai-gocache GOPATH=/tmp/gopher-ai-gopath bash -lc './scripts/test-commands.sh && ./scripts/test-hooks.sh && ./scripts/test-ship-e2e-gate.sh && ./scripts/check-shared-sync.sh && shellcheck agent-skills/scripts/*.sh && for skill_dir in agent-skills/skills/*/; do skill_name=$(basename "$skill_dir"); skill_file="$skill_dir/SKILL.md"; test -f "$skill_file"; lines=$(wc -l < "$skill_file"); test "$lines" -lt 500; name=$(sed -n "/^---$/,/^---$/p" "$skill_file" | awk "/^name:/ {print \\$2; exit}"); test "$name" = "$skill_name"; rg -q "^description:" "$skill_file"; done && ruby -ryaml -e "YAML.load_file(ARGV[0])" agent-skills/config/severity.yaml && (cd agent-skills/examples/demo-repo && go build -o /tmp/gopher-ai-demo . && go test ./...)'`

Fixes #53