### PR TITLE
feat(go-workflow): prepare awesome listing

### DIFF
--- a/.github/workflows/hol-plugin-scanner.yml
+++ b/.github/workflows/hol-plugin-scanner.yml
@@ -1,0 +1,34 @@
+name: HOL Plugin Scanner
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - ".github/workflows/hol-plugin-scanner.yml"
+      - "plugins/go-workflow/**"
+  pull_request:
+    branches: [main]
+    paths:
+      - ".github/workflows/hol-plugin-scanner.yml"
+      - "plugins/go-workflow/**"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  security-events: write
+
+jobs:
+  scan-go-workflow:
+    name: Scan go-workflow
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+      - name: HOL Plugin Scanner
+        uses: hashgraph-online/ai-plugin-scanner-action@92661b8271321b5134b3e4d0f2897b0e2fc5d6d3
+        with:
+          plugin_dir: plugins/go-workflow
+          mode: scan
+          min_score: 80
+          fail_on_severity: high
+          format: sarif
+          upload_sarif: true

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,11 @@
+# Security Policy
+
+## Supported Versions
+
+Security updates are applied to the latest `main` branch and the latest published Gopher AI plugin release.
+
+## Reporting a Vulnerability
+
+Report suspected vulnerabilities privately by emailing support@gopherguides.com. Please include the affected plugin, the vulnerable files or behavior, reproduction steps, and any relevant logs.
+
+Do not open a public issue with exploit details. The maintainers will acknowledge reports, assess impact, and coordinate fixes or disclosure as appropriate.

--- a/plugins/go-workflow/.codex-plugin/plugin.json
+++ b/plugins/go-workflow/.codex-plugin/plugin.json
@@ -14,6 +14,7 @@
   "interface": {
     "displayName": "Go Workflow",
     "shortDescription": "Issue-to-PR workflow automation with git worktree management",
+    "composerIcon": "./assets/icon.svg",
     "developerName": "Gopher Guides",
     "category": "Development"
   }

--- a/plugins/go-workflow/assets/icon.svg
+++ b/plugins/go-workflow/assets/icon.svg
@@ -1,0 +1,24 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" role="img" aria-labelledby="title desc">
+  <title id="title">Go Workflow</title>
+  <desc id="desc">Connected workflow nodes inside a rounded square.</desc>
+  <defs>
+    <linearGradient id="bg" x1="72" x2="440" y1="64" y2="448" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#0f766e"/>
+      <stop offset="0.55" stop-color="#2563eb"/>
+      <stop offset="1" stop-color="#7c3aed"/>
+    </linearGradient>
+    <filter id="shadow" x="-20%" y="-20%" width="140%" height="140%" color-interpolation-filters="sRGB">
+      <feDropShadow dx="0" dy="18" stdDeviation="22" flood-color="#0f172a" flood-opacity="0.28"/>
+    </filter>
+  </defs>
+  <rect width="512" height="512" rx="112" fill="url(#bg)"/>
+  <path d="M151 177h105c58 0 105 47 105 105v53" fill="none" stroke="#dff7ff" stroke-width="30" stroke-linecap="round"/>
+  <path d="M304 315l57 57 57-57" fill="none" stroke="#dff7ff" stroke-width="30" stroke-linecap="round" stroke-linejoin="round"/>
+  <g filter="url(#shadow)">
+    <circle cx="151" cy="177" r="64" fill="#f8fafc"/>
+    <circle cx="256" cy="177" r="42" fill="#22d3ee"/>
+    <circle cx="361" cy="372" r="64" fill="#f8fafc"/>
+  </g>
+  <circle cx="151" cy="177" r="26" fill="#0f766e"/>
+  <circle cx="361" cy="372" r="26" fill="#2563eb"/>
+</svg>


### PR DESCRIPTION
## Summary
- Add the `go-workflow` Codex `composerIcon` metadata and SVG asset required by the awesome-codex-plugins validator.
- Add a repository security policy for private vulnerability reporting.
- Add HOL Plugin Scanner CI for `go-workflow` using pinned action SHAs.
- Refresh legacy skill hash manifests required by installation CI after the branch update.

Fixes #129

## Test Plan
- `jq . plugins/go-workflow/.codex-plugin/plugin.json >/dev/null`
- `ruby -ryaml -e 'YAML.load_file(ARGV[0])' .github/workflows/hol-plugin-scanner.yml`
- `UV_CACHE_DIR=/tmp/uv-cache-go-workflow-after UV_TOOL_DIR=/tmp/uv-tools-go-workflow-after uvx --from 'plugin-scanner==2.0.921' plugin-scanner scan plugins/go-workflow --format text` (85/100, no critical/high findings)
- `./scripts/test-installation.sh`
- Exact configured gate was attempted and reached the final Go build, then failed because Go tried to write `~/Library/Caches/go-build` outside the sandbox.
- `GOCACHE=/tmp/gopher-ai-go-build-cache bash -lc './scripts/test-commands.sh && ./scripts/test-hooks.sh && ./scripts/test-ship-e2e-gate.sh && ./scripts/check-shared-sync.sh && shellcheck agent-skills/scripts/*.sh && for skill_dir in agent-skills/skills/*/; do skill_name=$(basename "$skill_dir"); skill_file="$skill_dir/SKILL.md"; test -f "$skill_file"; lines=$(wc -l < "$skill_file"); test "$lines" -lt 500; name=$(sed -n "/^---$/,/^---$/p" "$skill_file" | awk "/^name:/ {print \$2; exit}"); test "$name" = "$skill_name"; rg -q "^description:" "$skill_file"; done && ruby -ryaml -e "YAML.load_file(ARGV[0])" agent-skills/config/severity.yaml && (cd agent-skills/examples/demo-repo && GOCACHE=/tmp/gopher-ai-go-build-cache go build -o /tmp/gopher-ai-demo . && GOCACHE=/tmp/gopher-ai-go-build-cache go test ./...)'`