### PR TITLE
fix(scripts): register refreshed plugins at user scope

### DIFF
--- a/scripts/refresh-plugins.sh
+++ b/scripts/refresh-plugins.sh
@@ -128,19 +128,21 @@ if command -v jq &> /dev/null; then
     for entry in "${UPDATED_PLUGINS[@]}"; do
         p_name="${entry%%:*}"
         p_version="${entry##*:}"
+        # Scope must be "user" (no projectPath): project-scoped entries only
+        # load when Claude is launched from that exact projectPath, which
+        # silently disables all plugin skills in every other directory.
         jq --arg name "${p_name}@gopher-ai" \
            --arg path "$CACHE_DIR/$p_name/$p_version" \
            --arg ver "$p_version" \
            --arg ts "$NOW" \
            --arg sha "$GIT_SHA" \
            '.plugins[$name] = [{
-                "scope": "project",
+                "scope": "user",
                 "installPath": $path,
                 "version": $ver,
                 "installedAt": $ts,
                 "lastUpdated": $ts,
-                "gitCommitSha": $sha,
-                "projectPath": env.HOME
+                "gitCommitSha": $sha
             }]' "$TMPFILE" > "$TMPFILE2" \
             && mv "$TMPFILE2" "$TMPFILE"
     done


### PR DESCRIPTION
## Problem

`scripts/refresh-plugins.sh` re-registers plugins in `~/.claude/plugins/installed_plugins.json` with `"scope": "project"` and `"projectPath": $HOME`. Recent Claude Code versions enforce project scoping strictly, so after running a refresh, all seven gopher-ai plugins only loaded when Claude was launched from the home directory itself. In any actual project directory, every plugin skill and command silently disappeared — while `claude plugin list` still reported the plugins as installed and enabled (enablement comes from `enabledPlugins` in user settings, which was untouched).

## Fix

Register at `"scope": "user"` with no `projectPath`, matching exactly what `claude plugin install <plugin>@gopher-ai --scope user` writes. User-scoped installs load in every project.

Because step 3 of the script already strips all `@gopher-ai` entries before writing fresh ones, running the fixed script also cleans up any stale project-scoped entries left by the old version — no manual cleanup needed on affected machines.

## Verification

Ran the patched script end-to-end on an affected machine: marketplace pull, cache sync, and registration all succeeded, and all seven plugins came out registered at user scope:

```
go-dev@gopher-ai: user
gopher-guides@gopher-ai: user
go-web@gopher-ai: user
go-workflow@gopher-ai: user
llm-tools@gopher-ai: user
productivity@gopher-ai: user
tailwind@gopher-ai: user
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)