### PR TITLE
fix(gemini-image): self-heal when Google retires a model ID

### DIFF
--- a/plugins/go-workflow/hooks/legacy-skill-hashes.txt
+++ b/plugins/go-workflow/hooks/legacy-skill-hashes.txt
@@ -7,7 +7,7 @@
 # this prevents accepting a hash from skill A as proof of ownership for skill B.
 # DO NOT EDIT BY HAND — re-run the regen script after committing SKILL.md changes.
 #
-# Total entries: 222
+# Total entries: 223
 017e2d820506e7bef4a89a4d65839150db1ffdc124852a43dc916023e6d37e16 review-deep
 0322d4a7ddc204a9bf5addfec4e512edaea92ab8f4ebdd0541ca099330a09408 worktree
 03dac3a27d6da4b0a0c64ff6511df17004747e20b47a1691b4f9f030478877b9 commit
@@ -207,6 +207,7 @@ e01feecf1e50dc969f6ebbe5d251044c84118fd4dcb786c371d97678e9fbda9e commit
 e09cee46457e5a13eb058c1ff77d1b5f03f5a223a5490c6d088324e623a5d6b1 tailwind-best-practices
 e338c2bc546babcb73c9a8f9e1b15a1953a9203b7233cbfe089054472302f665 gopher-guides
 e7398cc9bf011c03689c56e89b5eba0c52f2d73bd2fcf4619180514f16e76874 complete-issue
+ea5d1a65f4268ec942d60826f1c97912ad91abe3f39d415f3c4160beedfa3ccb gemini-image
 ed50c1c5b29b003f54116cfe28f02b20c762dcc6ddba100ddbaef593ac3b72b4 go-error-handling
 edfed0bd039ddc1e1e2dd5399c8692e2cfed148fadd3a32122eba997c9623219 go-code-organization
 ef18dd0b566badecc14918a46ec9cb2a2a1d0a97a5804705571cd6847c894c03 go-profiling-optimization

--- a/plugins/llm-tools/skills/gemini-image/SKILL.md
+++ b/plugins/llm-tools/skills/gemini-image/SKILL.md
@@ -70,7 +70,7 @@ export GEMINI_RESPONSE_FILE="$RESPONSE_FILE"
 echo "HTTP status: $HTTP_STATUS"
 ```
 
-If `HTTP_STATUS` is 429, wait 30s and retry once. If 400/403, see `troubleshooting.md`. Only proceed if 200.
+If `HTTP_STATUS` is 429, wait 30s and retry once. If 400/403/404, see `troubleshooting.md` — a 404 (or 400 naming the model) usually means the model ID was retired; the "Model Not Found" section there shows how to discover current IDs and retry. Only proceed if 200.
 
 ## 5. Extract and Save Image
 

--- a/plugins/llm-tools/skills/gemini-image/troubleshooting.md
+++ b/plugins/llm-tools/skills/gemini-image/troubleshooting.md
@@ -10,12 +10,37 @@ known model quirk. Each row maps the symptom to the action.
 | Missing `GEMINI_API_KEY` | Link to https://aistudio.google.com/apikey |
 | Missing `python3` | Inform user Python 3 is required |
 | API 429 (rate limit) | Wait 30s and retry once |
-| API 400 (bad request) | Show error, suggest simpler prompt |
+| API 400 (bad request) | If the error mentions the model name or "not found", the model was likely retired — see "Model Not Found or Retired" below. Otherwise show error, suggest simpler prompt |
 | API 403 (forbidden) | Check API key, suggest regenerating |
+| API 404 (not found) | Model retired or renamed — see "Model Not Found or Retired" below |
 | JPEG when PNG requested | Auto-convert: Pillow → magick → .jpg fallback (handled by parse block in `request-builder.md`) |
 | No image in response | Show model text, suggest rephrasing |
 | `imageSize` lowercase value | Warn about case sensitivity before sending request — see `reference.md` resolution table |
 | Invalid service tier value | Warn user, show valid options (`flex`, `standard`, `priority`), ask again |
+
+## Model Not Found or Retired
+
+Google rotates Gemini model IDs (preview suffixes graduate, old versions are
+retired). If a request fails with 404, or 400 with a model-related message,
+discover the currently available image models directly from the API:
+
+```bash
+curl -s "https://generativelanguage.googleapis.com/v1beta/models?key=$GEMINI_API_KEY" \
+  | jq -r '.models[] | select((.supportedGenerationMethods // []) | index("generateContent")) | select(.name | test("image")) | .name' \
+  | sed 's|^models/||'
+```
+
+Then:
+
+1. Pick the closest match to what the user selected (flash-tier for speed,
+   non-preview for stability), confirm the choice with the user, re-export
+   `GEMINI_MODEL`, and retry the request once.
+2. Tell the user the model table in `reference.md` is out of date and offer to
+   update it with the IDs the API just returned — that keeps the skill
+   self-healing instead of rotting when Google renames models.
+
+Do not run this discovery call preemptively on every invocation; it only pays
+for itself when a request has actually failed.
 
 ## JPEG → PNG Conversion Path
 

--- a/scripts/legacy-skill-hashes.txt
+++ b/scripts/legacy-skill-hashes.txt
@@ -7,7 +7,7 @@
 # this prevents accepting a hash from skill A as proof of ownership for skill B.
 # DO NOT EDIT BY HAND — re-run the regen script after committing SKILL.md changes.
 #
-# Total entries: 222
+# Total entries: 223
 017e2d820506e7bef4a89a4d65839150db1ffdc124852a43dc916023e6d37e16 review-deep
 0322d4a7ddc204a9bf5addfec4e512edaea92ab8f4ebdd0541ca099330a09408 worktree
 03dac3a27d6da4b0a0c64ff6511df17004747e20b47a1691b4f9f030478877b9 commit
@@ -207,6 +207,7 @@ e01feecf1e50dc969f6ebbe5d251044c84118fd4dcb786c371d97678e9fbda9e commit
 e09cee46457e5a13eb058c1ff77d1b5f03f5a223a5490c6d088324e623a5d6b1 tailwind-best-practices
 e338c2bc546babcb73c9a8f9e1b15a1953a9203b7233cbfe089054472302f665 gopher-guides
 e7398cc9bf011c03689c56e89b5eba0c52f2d73bd2fcf4619180514f16e76874 complete-issue
+ea5d1a65f4268ec942d60826f1c97912ad91abe3f39d415f3c4160beedfa3ccb gemini-image
 ed50c1c5b29b003f54116cfe28f02b20c762dcc6ddba100ddbaef593ac3b72b4 go-error-handling
 edfed0bd039ddc1e1e2dd5399c8692e2cfed148fadd3a32122eba997c9623219 go-code-organization
 ef18dd0b566badecc14918a46ec9cb2a2a1d0a97a5804705571cd6847c894c03 go-profiling-optimization


### PR DESCRIPTION
## Summary

Follow-up to #184's gemini-image model-ID externalization. Skills can't check anything periodically (they only run when invoked), and polling Google's model list preemptively would waste tokens on every invocation — so this adds the cheap alternative: **validate at point of failure**.

- New "Model Not Found or Retired" section in `troubleshooting.md`: on HTTP 404 (or 400 naming the model), one curl to the Gemini `models` endpoint lists currently available image-capable models; the skill confirms a replacement with the user, retries once, and offers to update the `reference.md` model table so it stays current.
- Error-triage table gains a 404 row and routes model-related 400s to the new section.
- SKILL.md step 4 points at the recovery path.

Zero cost in the happy path — discovery only runs after a request has actually failed.

## Test plan
- [x] bash block passes `bash -n`
- [x] `./scripts/test-installation.sh` (legacy hash manifest regenerated: 222 → 223 pairs)
- [x] `./scripts/test-commands.sh` via pre-commit sync check

🤖 Generated with [Claude Code](https://claude.com/claude-code)