### PR TITLE
fix(workflow): validate Codex hook config

### DIFF
--- a/WORKFLOW.md
+++ b/WORKFLOW.md
@@ -4,7 +4,6 @@ tracker:
   github_status_source: label
   repository: gopherguides/gopher-ai
   status_label_prefix: "detent:"
-  write_probe_issue: gopherguides/gopher-ai#187
   http_max_idle_conns: 100
   http_max_idle_conns_per_host: 32
   http_idle_conn_timeout_ms: 90000

--- a/plugins/go-workflow/hooks/hooks.json
+++ b/plugins/go-workflow/hooks/hooks.json
@@ -1,5 +1,4 @@
 {
-  "description": "Hooks for go-workflow plugin",
   "hooks": {
     "SessionStart": [
       {

--- a/scripts/test-hooks.sh
+++ b/scripts/test-hooks.sh
@@ -16,7 +16,7 @@ TOTAL=0
 for hook_file in $HOOK_FILES; do
   TOTAL=$((TOTAL + 1))
   PLUGIN_DIR=$(dirname "$hook_file")
-  REL_PATH="${hook_file#$ROOT_DIR/}"
+  REL_PATH="${hook_file#"$ROOT_DIR"/}"
 
   # Test: hooks.json is valid JSON
   echo -n "  $REL_PATH is valid JSON... "
@@ -27,13 +27,31 @@ for hook_file in $HOOK_FILES; do
   fi
   echo "OK"
 
+  echo -n "  $REL_PATH uses supported top-level keys... "
+  UNSUPPORTED_KEYS=$(jq -r 'keys_unsorted - ["hooks"] | join(", ")' "$hook_file")
+  if [ -n "$UNSUPPORTED_KEYS" ]; then
+    echo "FAIL (unsupported: $UNSUPPORTED_KEYS)"
+    ERRORS=$((ERRORS + 1))
+  else
+    echo "OK"
+  fi
+
+  echo -n "  $REL_PATH has hooks object... "
+  if ! jq -e '.hooks | type == "object"' "$hook_file" >/dev/null 2>&1; then
+    echo "FAIL"
+    ERRORS=$((ERRORS + 1))
+  else
+    echo "OK"
+  fi
+
   # Test: All referenced command scripts exist
   # Extract command paths from hooks.json (they use ${CLAUDE_PLUGIN_ROOT} prefix)
   COMMANDS=$(jq -r '.. | .command? // empty' "$hook_file" 2>/dev/null | sort -u)
+  PLUGIN_ROOT=$(dirname "$PLUGIN_DIR")
 
   for cmd in $COMMANDS; do
     # Replace ${CLAUDE_PLUGIN_ROOT} with the actual plugin directory (parent of hooks/)
-    ACTUAL_PATH=$(echo "$cmd" | sed "s|\${CLAUDE_PLUGIN_ROOT}|$(dirname "$PLUGIN_DIR")|g")
+    ACTUAL_PATH="${cmd//\$\{CLAUDE_PLUGIN_ROOT\}/$PLUGIN_ROOT}"
 
     echo -n "  Referenced script exists: ${cmd}... "
     if [ ! -f "$ACTUAL_PATH" ]; then


### PR DESCRIPTION
## Summary

- Remove the unsupported top-level `description` field from `plugins/go-workflow/hooks/hooks.json` so Codex accepts the hook config.
- Add `scripts/test-hooks.sh` validation for Codex hook config top-level keys and the required `.hooks` object.
- Clean shellcheck findings in the touched hook test script.

## Validation

- `jq -e 'keys_unsorted == ["hooks"]' plugins/go-workflow/hooks/hooks.json`
- `./scripts/test-hooks.sh`
- `shellcheck scripts/test-hooks.sh`
- Temporary `HOME` Codex CLI 0.142.5 local marketplace install of `go-workflow@gopher-ai` completed without the hook parse warning.
- `GOCACHE=/tmp/gopher-ai-go-build-cache bash -lc './scripts/test-commands.sh && ./scripts/test-hooks.sh && ./scripts/test-ship-e2e-gate.sh && ./scripts/check-shared-sync.sh && shellcheck agent-skills/scripts/*.sh && for skill_dir in agent-skills/skills/*/; do skill_name=$(basename "$skill_dir"); skill_file="$skill_dir/SKILL.md"; test -f "$skill_file"; lines=$(wc -l < "$skill_file"); test "$lines" -lt 500; name=$(sed -n "/^---$/,/^---$/p" "$skill_file" | awk "/^name:/ {print \$2; exit}"); test "$name" = "$skill_name"; rg -q "^description:" "$skill_file"; done && ruby -ryaml -e "YAML.load_file(ARGV[0])" agent-skills/config/severity.yaml && (cd agent-skills/examples/demo-repo && go build -o /tmp/gopher-ai-demo . && go test ./...)'`

## Notes

This branch already contained pre-existing commit `7d00165` touching `WORKFLOW.md`; this PR keeps that history intact and does not modify `WORKFLOW.md` in the hook-config fix commit.

Fixes #189
