### PR TITLE
fix(llm-tools): use Codex provider default

### DIFF
--- a/README.md
+++ b/README.md
@@ -299,6 +299,8 @@ Plugins are distributed via the [Codex plugin system](https://developers.openai.
 
 **Repo-local discovery:** Codex reads `.agents/plugins/marketplace.json` on startup and syncs plugins automatically. Use `/plugins` to browse and manage installed plugins. Plugins with `.codex-plugin/plugin.json` are packaged for Codex. Today that set is `go-workflow`, `go-dev`, `gopher-guides`, `llm-tools`, `go-web`, and `tailwind`. The repo's `productivity` module remains Claude-only.
 
+**Codex model defaults:** The `llm-tools` Codex commands omit `-m` by default so Codex CLI chooses its provider default. If `~/.codex/config.toml` contains a `model = "..."` line, that local pin overrides the provider default for every llm-tools Codex call that omits `-m`; leave it unset to keep using the latest recommended Codex model.
+
 **Install into another repo:** `./scripts/install-codex.sh --repo /path/to/your-repo` copies the current plugin set and merges entries into that repo's `.agents/plugins/marketplace.json` without removing unrelated plugin entries.
 
 **GitHub one-liner:** `bash -c "$(curl -fsSL https://raw.githubusercontent.com/gopherguides/gopher-ai/main/scripts/install-all.sh)"` auto-detects all platforms — installs Claude Code and Gemini, and installs Codex plugins globally via Codex's marketplace mechanism (so skills load in every Codex session). The Codex install runs `codex plugin marketplace add gopherguides/gopher-ai`, populates `~/.codex/plugins/cache/gopher-ai/<plugin>/<commit>/` from the marketplace clone, and writes `[plugins."<name>@gopher-ai"]\nenabled = true` entries to `~/.codex/config.toml`. The marketplace cache is the only path Codex actually loads from — direct copies to `~/.codex/plugins/<name>/` are silently ignored.

--- a/plugins/llm-tools/README.md
+++ b/plugins/llm-tools/README.md
@@ -45,6 +45,10 @@ npm install -g @google/gemini-cli
 brew install ollama
 ```
 
+## Codex Model Defaults
+
+llm-tools omits `-m` for Codex calls by default, so Codex CLI chooses its provider default. If `~/.codex/config.toml` contains a `model = "..."` line, that local pin overrides the provider default for these calls; leave it unset to keep using the latest recommended Codex model.
+
 ## Privacy Note
 
 - `/ollama` keeps all data local on your machine

--- a/plugins/llm-tools/commands/codex.md
+++ b/plugins/llm-tools/commands/codex.md
@@ -29,14 +29,12 @@ Display usage and ask for input:
 | `/codex review the auth changes --ask` | Review with interactive configuration |
 | `/codex refactor the module --ask` | Exec with interactive model/sandbox selection |
 
-**Available Models:**
+**Codex Model Selection:**
 
-| Model | Best For |
-|-------|----------|
-| `gpt-5.5` | Latest frontier model, best overall (default) |
-| `gpt-5.4` | Previous flagship, strong coding and reasoning |
-| `gpt-5.4-mini` | Fast and cost-efficient for lighter tasks |
-| `gpt-5.3-codex-spark` | Near-instant iteration (ChatGPT Pro only) |
+| Option | Behavior |
+|--------|----------|
+| Provider default | Let Codex CLI choose the latest recommended Codex model |
+| Custom model ID | Pass an explicit model with `-m` or `-c model=...` |
 
 Ask the user: "What would you like Codex to do?"
 
@@ -114,7 +112,7 @@ Used for non-review tasks (and for fix-oriented review prompts from Step 1).
 
 → Read `${CLAUDE_PLUGIN_ROOT}/lib/codex/exec-flow.md` for the full procedure:
 
-- Default config (model `gpt-5.5`, reasoning effort `high`, sandbox `workspace-write`, no session context)
+- Default config (provider default model, reasoning effort `high`, sandbox `workspace-write`, no session context)
 - Interactive `--ask` flow: model selection, optional session-context summary/detailed, sandbox-mode pick (`read-only` / `workspace-write` / `danger-full-access` — confirmation required for `danger-full-access`)
 - Execution: bare `$CODEX_CMD exec` or temp-file prompt with assembled context block
 - Result reporting and `codex resume --last` follow-up

--- a/plugins/llm-tools/commands/llm-compare.md
+++ b/plugins/llm-tools/commands/llm-compare.md
@@ -62,7 +62,7 @@ Only skip if the user explicitly chooses "Skip this LLM".
 
 ## 2. Select Models (Optional)
 
-For each LLM, ask if user wants to specify a model. Defaults: **OpenAI** `gpt-5.5`, **Gemini** `gemini-2.5-flash`, **Ollama** first available code model (codellama, deepseek-coder, etc.).
+For each LLM, ask if user wants to specify a model. Defaults: **OpenAI** provider default (no `-m`; Codex CLI chooses), **Gemini** `gemini-2.5-flash`, **Ollama** first available code model (codellama, deepseek-coder, etc.).
 
 ## 3. Include Context (Optional)
 
@@ -103,7 +103,12 @@ Run in parallel where possible. Use `CLEAN_PROMPT`:
 
 ```bash
 # OpenAI (only if CODEX_AVAILABLE=true)
-$CODEX_CMD exec -m <model> -s read-only -c model_reasoning_effort="high" --skip-git-repo-check "$CLEAN_PROMPT"
+OPENAI_MODEL_ARGS=()
+if [ -n "$OPENAI_MODEL" ]; then
+  OPENAI_MODEL_ARGS=(-m "$OPENAI_MODEL")
+fi
+
+$CODEX_CMD exec "${OPENAI_MODEL_ARGS[@]}" -s read-only -c model_reasoning_effort="high" --skip-git-repo-check "$CLEAN_PROMPT"
 
 # Gemini
 gemini "$CLEAN_PROMPT" -m <model>
@@ -119,7 +124,7 @@ If `codex exec` fails (non-zero exit or no output), do NOT silently skip. Displa
 ```markdown
 ## LLM Comparison: <prompt>
 
-### OpenAI (gpt-5.5)
+### OpenAI (Codex provider default)
 [Response]
 
 ---
@@ -186,7 +191,7 @@ After the report, if review-fix detection was active: check if ANY LLM produced 
 ```markdown
 ## LLM Comparison: Should I use channels or mutexes for this shared counter?
 
-### OpenAI (gpt-5.5)
+### OpenAI (Codex provider default)
 For a simple shared counter, a mutex is more appropriate. Channels are designed for communication between goroutines, not protecting shared state. Use `sync/atomic` for even better performance.
 
 ### Gemini (gemini-2.5-flash)

--- a/plugins/llm-tools/commands/review-loop.md
+++ b/plugins/llm-tools/commands/review-loop.md
@@ -76,7 +76,7 @@ Use a **single `AskUserQuestion` call** with two questions.
 
 **Q2 — "Which model?":** show options based on `LLM_CHOICE`:
 
-- **codex:** `gpt-5.5` (Recommended), `gpt-5.4`, `gpt-5.4-mini`, `gpt-5.3-codex-spark` (ChatGPT Pro only)
+- **codex:** Provider default (Recommended; latest recommended Codex model), Custom model ID
 - **gemini:** `gemini-2.5-pro` (Recommended), `gemini-2.5-flash`
 - **ollama:** `codellama` (Recommended), `llama3`, `deepseek-coder`, Custom
 - **fable:** skip Q2 entirely — the review subagent inherits the session's Claude model
@@ -85,7 +85,7 @@ Use a **single `AskUserQuestion` call** with two questions.
 
 For "Changes vs branch" / "Specific files": reuse `PR_JSON` from 4a, fall back to `origin/HEAD`/remote default/`main`. Display the detected branch.
 
-Remaining follow-ups (only ask if needed): "Specific files" → ask paths; "Custom" model → ask model name.
+Remaining follow-ups (only ask if needed): "Specific files" → ask paths; "Custom" model ID → ask model name. For Codex provider default, persist `model` as an empty string so no model flag is passed.
 
 Persist `scope`, `base_branch`, `model`, `file_paths` to the state file via `jq` (same pattern as Step 1). See `${CLAUDE_PLUGIN_ROOT}/lib/review-loop/state-persist.md` for the exact invocation.
 
@@ -157,7 +157,7 @@ Output a summary then `<done>REVIEW_CLEAN</done>`:
 ```
 ## Review Loop Complete
 
-- **LLM:** <llm> (<model>)
+- **LLM:** <llm> (<model or provider default>)
 - **Total passes:** <n>
 - **Findings addressed:** <n>
 - **Findings skipped:** <n> (with reasons listed)

--- a/plugins/llm-tools/lib/codex/exec-flow.md
+++ b/plugins/llm-tools/lib/codex/exec-flow.md
@@ -10,13 +10,13 @@ Use recommended defaults without prompting. Display a brief configuration summar
 
 ```
 Exec config (defaults — add --ask to customize):
-  Model:    gpt-5.5
+  Model:    Provider default
   Effort:   high
   Context:  None
   Sandbox:  workspace-write
 ```
 
-Store: model = "gpt-5.5", context = "No", sandbox = "workspace-write". Reasoning effort is always `high` (pinned via `-c model_reasoning_effort="high"` on every codex invocation — not user-configurable). Proceed directly to Step 4 (Run Codex).
+Store: model = "", context = "No", sandbox = "workspace-write". An empty model means Codex CLI selects its provider default, including any user-configured `~/.codex/config.toml` model override. Reasoning effort is always `high` (pinned via `-c model_reasoning_effort="high"` on every codex invocation — not user-configurable). Proceed directly to Step 4 (Run Codex).
 
 ## If `INTERACTIVE_MODE` is `true` (`--ask` flag provided)
 
@@ -24,14 +24,12 @@ Store: model = "gpt-5.5", context = "No", sandbox = "workspace-write". Reasoning
 
 Ask the user which model to use:
 
-| Model | Best For |
-|-------|----------|
-| gpt-5.5 | Latest frontier model, best overall |
-| gpt-5.4 | Previous flagship, strong coding and reasoning |
-| gpt-5.4-mini | Fast and cost-efficient for lighter tasks |
-| gpt-5.3-codex-spark | Near-instant iteration (ChatGPT Pro only) |
+| Option | Description |
+|--------|-------------|
+| Provider default (Recommended) | Let Codex CLI choose the latest recommended Codex model |
+| Custom model ID | Enter an exact model ID; only this choice passes `-m` |
 
-Default: `gpt-5.5`
+Default: Provider default. Store model = "" unless the user chooses a custom model ID.
 
 ### 2. Include Session Context (Optional)
 
@@ -84,7 +82,12 @@ Default: `read-only` (interactive). Always request confirmation before using `da
 ### If context was NOT requested
 
 ```bash
-$CODEX_CMD exec -m <model> -s <mode> -c model_reasoning_effort="high" --skip-git-repo-check "$CODEX_PROMPT"
+MODEL_ARGS=()
+if [ -n "$MODEL" ]; then
+  MODEL_ARGS=(-m "$MODEL")
+fi
+
+$CODEX_CMD exec "${MODEL_ARGS[@]}" -s <mode> -c model_reasoning_effort="high" --skip-git-repo-check "$CODEX_PROMPT"
 ```
 
 ### If context WAS requested
@@ -109,7 +112,12 @@ Use the session context above to inform your review/analysis. The context descri
 being worked on in a previous AI coding session."
 
 printf '%s\n' "$EXEC_PROMPT" > "$PROMPT_FILE"
-$CODEX_CMD exec -m <model> -s <mode> -c model_reasoning_effort="high" --skip-git-repo-check - < "$PROMPT_FILE"
+MODEL_ARGS=()
+if [ -n "$MODEL" ]; then
+  MODEL_ARGS=(-m "$MODEL")
+fi
+
+$CODEX_CMD exec "${MODEL_ARGS[@]}" -s <mode> -c model_reasoning_effort="high" --skip-git-repo-check - < "$PROMPT_FILE"
 rm -f "$PROMPT_FILE"
 trap - EXIT
 ```

--- a/plugins/llm-tools/lib/codex/review-flow.md
+++ b/plugins/llm-tools/lib/codex/review-flow.md
@@ -14,12 +14,12 @@ Use recommended defaults without prompting. Display a brief configuration summar
 Review config (defaults — add --ask to customize):
   Review type:  Changes vs branch
   Context:      Auto-detect
-  Model:        gpt-5.5
+  Model:        Provider default
   Effort:       high
   Depth:        Exhaustive
 ```
 
-Store: review type = "Changes vs branch", context = "Auto-detect", model = "gpt-5.5", depth = "Exhaustive". Reasoning effort is always `high` (pinned via `-c model_reasoning_effort="high"` on every codex invocation — not user-configurable). Proceed directly to R1.5.
+Store: review type = "Changes vs branch", context = "Auto-detect", model = "", depth = "Exhaustive". An empty model means Codex CLI selects its provider default, including any user-configured `~/.codex/config.toml` model override. Reasoning effort is always `high` (pinned via `-c model_reasoning_effort="high"` on every codex invocation — not user-configurable). Proceed directly to R1.5.
 
 ### If `INTERACTIVE_MODE` is `true` (`--ask` flag provided)
 
@@ -48,10 +48,8 @@ Ask all review configuration questions in a **single `AskUserQuestion` call** wi
 
 | Option | Description |
 |--------|-------------|
-| gpt-5.5 (Recommended) | Latest frontier model, best overall |
-| gpt-5.4 | Previous flagship, strong coding and reasoning |
-| gpt-5.4-mini | Fast and cost-efficient for lighter reviews |
-| gpt-5.3-codex-spark | Near-instant iteration (ChatGPT Pro only) |
+| Provider default (Recommended) | Let Codex CLI choose the latest recommended Codex model |
+| Custom model ID | Enter an exact model ID; only this choice passes `-m` or `-c model=...` |
 
 **Question 4 — "Review depth?"**
 
@@ -258,7 +256,12 @@ Write the assembled prompt to a temp file to avoid heredoc expansion issues with
 ```bash
 PROMPT_FILE=$(mktemp /tmp/codex-review-prompt-XXXXXX)
 echo "$ASSEMBLED_PROMPT" > "$PROMPT_FILE"
-REVIEW_JSON=$($CODEX_CMD exec -m <model> -s read-only \
+MODEL_ARGS=()
+if [ -n "$MODEL" ]; then
+  MODEL_ARGS=(-m "$MODEL")
+fi
+
+REVIEW_JSON=$($CODEX_CMD exec "${MODEL_ARGS[@]}" -s read-only \
   -c model_reasoning_effort="high" \
   --output-schema "${CLAUDE_PLUGIN_ROOT}/schemas/codex-review.json" \
   - < "$PROMPT_FILE")
@@ -285,22 +288,31 @@ Skip to R4 (Report Results).
 
 Use standard codex review commands:
 
+Build optional model config first. Leave `MODEL_CONFIG` empty for provider default:
+
+```bash
+MODEL_CONFIG=()
+if [ -n "$MODEL" ]; then
+  MODEL_CONFIG=(-c "model=$MODEL")
+fi
+```
+
 **For uncommitted changes:**
 
 ```bash
-$CODEX_CMD review --uncommitted -c model=<model> -c model_reasoning_effort="high"
+$CODEX_CMD review --uncommitted "${MODEL_CONFIG[@]}" -c model_reasoning_effort="high"
 ```
 
 **For changes vs branch:**
 
 ```bash
-$CODEX_CMD review --base <branch> -c model=<model> -c model_reasoning_effort="high"
+$CODEX_CMD review --base <branch> "${MODEL_CONFIG[@]}" -c model_reasoning_effort="high"
 ```
 
 **For specific commit:**
 
 ```bash
-$CODEX_CMD review --commit <sha> -c model=<model> -c model_reasoning_effort="high"
+$CODEX_CMD review --commit <sha> "${MODEL_CONFIG[@]}" -c model_reasoning_effort="high"
 ```
 
 Capture output as `FINDINGS`. Skip to R4 (or multi-pass loop below).
@@ -458,7 +470,12 @@ Review these changes against the requirements above. Ensure the implementation a
 #### Single Pass (or no multi-pass selected)
 
 ```bash
-$CODEX_CMD review -c model=<model> -c model_reasoning_effort="high" - <<'EOF'
+MODEL_CONFIG=()
+if [ -n "$MODEL" ]; then
+  MODEL_CONFIG=(-c "model=$MODEL")
+fi
+
+$CODEX_CMD review "${MODEL_CONFIG[@]}" -c model_reasoning_effort="high" - <<'EOF'
 <constructed context block with diff>
 EOF
 ```
@@ -502,7 +519,7 @@ If there are no new findings to report, respond with exactly: NO_NEW_FINDINGS
 Execute:
 
 ```bash
-$CODEX_CMD review -c model=<model> -c model_reasoning_effort="high" - <<'EOF'
+$CODEX_CMD review "${MODEL_CONFIG[@]}" -c model_reasoning_effort="high" - <<'EOF'
 <augmented context block>
 EOF
 ```

--- a/plugins/llm-tools/lib/review-loop/review-phase.md
+++ b/plugins/llm-tools/lib/review-loop/review-phase.md
@@ -72,14 +72,19 @@ Write the assembled prompt to a temp file (avoids heredoc expansion issues with 
 PROMPT_FILE=$(mktemp /tmp/codex-review-prompt-XXXXXX)
 echo "$ASSEMBLED_PROMPT" > "$PROMPT_FILE"
 
+MODEL_ARGS=()
+if [ -n "$MODEL" ]; then
+  MODEL_ARGS=(-m "$MODEL")
+fi
+
 set +e
 if [ -n "$TIMEOUT_CMD" ]; then
-  REVIEW_JSON=$($TIMEOUT_CMD "${CODEX_TIMEOUT}" $CODEX_CMD exec -m "$MODEL" -s read-only \
+  REVIEW_JSON=$($TIMEOUT_CMD "${CODEX_TIMEOUT}" $CODEX_CMD exec "${MODEL_ARGS[@]}" -s read-only \
     -c model_reasoning_effort="high" \
     --output-schema "${CLAUDE_PLUGIN_ROOT}/schemas/codex-review.json" \
     - < "$PROMPT_FILE" 2>"/tmp/codex-review-stderr-$$")
 else
-  REVIEW_JSON=$($CODEX_CMD exec -m "$MODEL" -s read-only \
+  REVIEW_JSON=$($CODEX_CMD exec "${MODEL_ARGS[@]}" -s read-only \
     -c model_reasoning_effort="high" \
     --output-schema "${CLAUDE_PLUGIN_ROOT}/schemas/codex-review.json" \
     - < "$PROMPT_FILE" 2>"/tmp/codex-review-stderr-$$")
@@ -155,15 +160,20 @@ output (first 500 chars), then ask:
 Standard `codex review`, faster but capped at 2-3 findings per pass.
 
 ```bash
+MODEL_CONFIG=()
+if [ -n "$MODEL" ]; then
+  MODEL_CONFIG=(-c "model=$MODEL")
+fi
+
 # For changes vs branch:
-$CODEX_CMD review --base "$BASE_BRANCH" -c model="$MODEL" -c model_reasoning_effort="high"
+$CODEX_CMD review --base "$BASE_BRANCH" "${MODEL_CONFIG[@]}" -c model_reasoning_effort="high"
 
 # For uncommitted:
-$CODEX_CMD review --uncommitted -c model="$MODEL" -c model_reasoning_effort="high"
+$CODEX_CMD review --uncommitted "${MODEL_CONFIG[@]}" -c model_reasoning_effort="high"
 
 # For specific files or when scope hint is provided, use stdin:
 DIFF=$(git diff ${BASE_BRANCH}...HEAD -- <files>)
-$CODEX_CMD review -c model="$MODEL" -c model_reasoning_effort="high" - <<EOF
+$CODEX_CMD review "${MODEL_CONFIG[@]}" -c model_reasoning_effort="high" - <<EOF
 $DIFF
 
 ## Review Instructions


### PR DESCRIPTION
## Summary
- Let llm-tools Codex flows use the Codex CLI provider default by omitting model flags unless a custom model is selected.
- Replace static Codex model menus with provider-default/custom-ID choices.
- Document how `~/.codex/config.toml` model pins override provider defaults for llm-tools Codex calls.

## Test Plan
- `git diff --check`
- `rg -n "gpt-5" plugins/llm-tools` returns no matches
- `rg -n "codex exec -m|\\$CODEX_CMD exec -m|model=<model>|-c model=\\"\\$MODEL\\"|-c model=\\$MODEL|Model: +gpt|model = \\"gpt|OpenAI \\(gpt" plugins/llm-tools` returns no matches
- `GOCACHE=/tmp/gopher-ai-go-build bash -lc './scripts/test-commands.sh && ./scripts/test-hooks.sh && ./scripts/test-ship-e2e-gate.sh && ./scripts/check-shared-sync.sh && shellcheck agent-skills/scripts/*.sh && for skill_dir in agent-skills/skills/*/; do skill_name=$(basename "$skill_dir"); skill_file="$skill_dir/SKILL.md"; test -f "$skill_file"; lines=$(wc -l < "$skill_file"); test "$lines" -lt 500; name=$(sed -n "/^---$/,/^---$/p" "$skill_file" | awk "/^name:/ {print \\$2; exit}"); test "$name" = "$skill_name"; rg -q "^description:" "$skill_file"; done && ruby -ryaml -e "YAML.load_file(ARGV[0])" agent-skills/config/severity.yaml && (cd agent-skills/examples/demo-repo && go build -o /tmp/gopher-ai-demo . && go test ./...)'`

Fixes #191