### PR TITLE
fix(llm-tools): use Gemini CLI auto routing

### DIFF
--- a/plugins/llm-tools/commands/gemini.md
+++ b/plugins/llm-tools/commands/gemini.md
@@ -23,13 +23,12 @@ This command delegates tasks to Google Gemini CLI for analysis and code review.
 | `/gemini suggest improvements for this function` | Refactoring advice |
 | `/gemini what are the security implications here` | Security analysis |
 
-**Available Models:**
+**Available Gemini Routing:**
 
-| Model | Best For |
-|-------|----------|
-| `gemini-2.5-flash` | Fast responses, general tasks (default) |
-| `gemini-2.5-pro` | Complex reasoning, detailed analysis |
-| `gemini-2.0-flash-lite` | Quick, simple tasks |
+| Option | Behavior |
+|--------|----------|
+| Auto (recommended) | Let the Gemini CLI route to the best current model |
+| Custom model ID | Ask for an exact model ID and pass it with `-m` |
 
 Ask the user: "What would you like Gemini to analyze?"
 
@@ -59,15 +58,16 @@ Then ask if they want to proceed after installation or use a different LLM (`/co
 
 ## 2. Select Model
 
-Ask the user which model to use:
+Ask the user how Gemini should choose a model:
 
-| Model | Best For |
-|-------|----------|
-| gemini-2.5-flash | Fast responses, general tasks |
-| gemini-2.5-pro | Complex reasoning, detailed analysis |
-| gemini-2.0-flash-lite | Quick, simple tasks |
+| Option | Description |
+|--------|-------------|
+| Auto (recommended) | Use Gemini CLI Auto routing; pass no `-m` flag |
+| Custom model ID | Ask for an exact Gemini model ID; pass it with `-m` |
 
-Default: `gemini-2.5-flash`
+Default: `Auto`
+
+If the user chooses Custom model ID, ask for the model ID and store it as `MODEL`. Otherwise leave `MODEL` unset or empty.
 
 ## 3. Include Context (Optional)
 
@@ -125,22 +125,31 @@ Proceed with the normal Gemini CLI invocation using `CLEAN_PROMPT` (without tier
 
 **IMPORTANT:** In all commands below, `<prompt>` refers to `CLEAN_PROMPT` — the user's prompt with `--tier <value>` stripped (from Step 4.5). If `--tier` was not provided, `CLEAN_PROMPT` equals the original `$ARGUMENTS`.
 
+Only include a model argument when the user explicitly selected Custom model ID:
+
+```bash
+GEMINI_MODEL_ARGS=()
+if [ -n "${MODEL:-}" ]; then
+  GEMINI_MODEL_ARGS=(-m "$MODEL")
+fi
+```
+
 **Without context:**
 
 ```bash
-gemini "$CLEAN_PROMPT" -m <model>
+gemini "$CLEAN_PROMPT" "${GEMINI_MODEL_ARGS[@]}"
 ```
 
 **With file context:**
 
 ```bash
-cat <file> | gemini "Given this code, $CLEAN_PROMPT" -m <model>
+cat <file> | gemini "Given this code, $CLEAN_PROMPT" "${GEMINI_MODEL_ARGS[@]}"
 ```
 
 **With diff context:**
 
 ```bash
-git diff <scope> | gemini "Review these changes: $CLEAN_PROMPT" -m <model>
+git diff <scope> | gemini "Review these changes: $CLEAN_PROMPT" "${GEMINI_MODEL_ARGS[@]}"
 ```
 
 **With session context:**
@@ -157,7 +166,7 @@ gemini "$(cat <<'EOF'
 
 $CLEAN_PROMPT
 EOF
-)" -m <model>
+)" "${GEMINI_MODEL_ARGS[@]}"
 ```
 
 ## 6. Report Results

--- a/plugins/llm-tools/commands/llm-compare.md
+++ b/plugins/llm-tools/commands/llm-compare.md
@@ -62,7 +62,10 @@ Only skip if the user explicitly chooses "Skip this LLM".
 
 ## 2. Select Models (Optional)
 
-For each LLM, ask if user wants to specify a model. Defaults: **OpenAI** provider default (no `-m`; Codex CLI chooses), **Gemini** `gemini-2.5-flash`, **Ollama** first available code model (codellama, deepseek-coder, etc.).
+For each LLM, ask if user wants to specify a model. Defaults: **OpenAI** provider default with no `-m` flag, **Gemini** CLI Auto routing with no `-m` flag, **Ollama** first available code model (codellama, deepseek-coder, etc.).
+
+If the user specifies a custom OpenAI model, store it as `OPENAI_MODEL`; otherwise leave `OPENAI_MODEL` unset or empty.
+If the user specifies a custom Gemini model, store it as `GEMINI_MODEL`; otherwise leave `GEMINI_MODEL` unset or empty.
 
 ## 3. Include Context (Optional)
 
@@ -110,8 +113,12 @@ fi
 
 $CODEX_CMD exec "${OPENAI_MODEL_ARGS[@]}" -s read-only -c model_reasoning_effort="high" --skip-git-repo-check "$CLEAN_PROMPT"
 
-# Gemini
-gemini "$CLEAN_PROMPT" -m <model>
+# Gemini (Auto routing by default; include -m only when GEMINI_MODEL is set)
+GEMINI_MODEL_ARGS=()
+if [ -n "${GEMINI_MODEL:-}" ]; then
+  GEMINI_MODEL_ARGS=(-m "$GEMINI_MODEL")
+fi
+gemini "$CLEAN_PROMPT" "${GEMINI_MODEL_ARGS[@]}"
 
 # Ollama
 ollama run <model> "$CLEAN_PROMPT"
@@ -129,7 +136,7 @@ If `codex exec` fails (non-zero exit or no output), do NOT silently skip. Displa
 
 ---
 
-### Google Gemini (gemini-2.5-flash)
+### Google Gemini (CLI default)
 [Response]
 
 ---
@@ -194,7 +201,7 @@ After the report, if review-fix detection was active: check if ANY LLM produced 
 ### OpenAI (Codex provider default)
 For a simple shared counter, a mutex is more appropriate. Channels are designed for communication between goroutines, not protecting shared state. Use `sync/atomic` for even better performance.
 
-### Gemini (gemini-2.5-flash)
+### Gemini (CLI default)
 Both work, but: Mutex — simpler for protecting shared state; Channels — better for coordination. For a counter specifically, consider `sync/atomic.Int64` which avoids locking entirely.
 
 ### Ollama (codellama:34b)

--- a/plugins/llm-tools/commands/review-loop.md
+++ b/plugins/llm-tools/commands/review-loop.md
@@ -77,7 +77,7 @@ Use a **single `AskUserQuestion` call** with two questions.
 **Q2 — "Which model?":** show options based on `LLM_CHOICE`:
 
 - **codex:** Provider default (Recommended; latest recommended Codex model), Custom model ID
-- **gemini:** `gemini-2.5-pro` (Recommended), `gemini-2.5-flash`
+- **gemini:** Auto (Recommended; CLI routes to the best current model), Custom model ID
 - **ollama:** `codellama` (Recommended), `llama3`, `deepseek-coder`, Custom
 - **fable:** skip Q2 entirely — the review subagent inherits the session's Claude model
 
@@ -85,7 +85,7 @@ Use a **single `AskUserQuestion` call** with two questions.
 
 For "Changes vs branch" / "Specific files": reuse `PR_JSON` from 4a, fall back to `origin/HEAD`/remote default/`main`. Display the detected branch.
 
-Remaining follow-ups (only ask if needed): "Specific files" → ask paths; "Custom" model ID → ask model name. For Codex provider default, persist `model` as an empty string so no model flag is passed.
+Remaining follow-ups (only ask if needed): "Specific files" → ask paths; "Custom model ID" → ask model name. For Codex provider default or Gemini Auto, persist `model` as an empty string so no model flag is passed.
 
 Persist `scope`, `base_branch`, `model`, `file_paths` to the state file via `jq` (same pattern as Step 1). See `${CLAUDE_PLUGIN_ROOT}/lib/review-loop/state-persist.md` for the exact invocation.
 

--- a/plugins/llm-tools/lib/review-loop/review-phase.md
+++ b/plugins/llm-tools/lib/review-loop/review-phase.md
@@ -243,7 +243,12 @@ If `GEMINI_TIER` is set and non-empty, display this warning before running:
 > **Note:** `--tier $GEMINI_TIER` was specified but the Gemini CLI does not support service tiers. The tier setting will be ignored for this review. When Gemini CLI adds `--service-tier` support, it will be applied automatically. Track [gemini-cli](https://github.com/google-gemini/gemini-cli) for updates.
 
 ```bash
-gemini -m "$MODEL" <<EOF
+GEMINI_MODEL_ARGS=()
+if [ -n "${MODEL:-}" ]; then
+  GEMINI_MODEL_ARGS=(-m "$MODEL")
+fi
+
+gemini "${GEMINI_MODEL_ARGS[@]}" <<EOF
 Review the following code changes for bugs, security issues, performance problems, and best practice violations.
 
 ${SCOPE_HINT:+Focus area: $SCOPE_HINT}


### PR DESCRIPTION
## Summary

- Replace static Gemini CLI model menus with Auto routing plus Custom model ID.
- Build Gemini `-m` arguments only when a custom model is explicitly selected.
- Rename llm-compare Gemini headers to describe the CLI default instead of a pinned model.

Fixes #192

## Validation

- `./scripts/test-commands.sh`
- Focused search: no `gemini-2.5` in the four in-scope files from #192
- Focused search: no in-scope `gemini-2.0`, stale `gemini "$CLEAN_PROMPT" -m`, stale `gemini -m "$MODEL"`, or old Gemini section headers
- `git diff --check`
- Full gate with writable Go cache: `GOCACHE=/tmp/gopher-ai-go-build-cache bash -lc './scripts/test-commands.sh && ./scripts/test-hooks.sh && ./scripts/test-ship-e2e-gate.sh && ./scripts/check-shared-sync.sh && shellcheck agent-skills/scripts/*.sh && for skill_dir in agent-skills/skills/*/; do skill_name=$(basename "$skill_dir"); skill_file="$skill_dir/SKILL.md"; test -f "$skill_file"; lines=$(wc -l < "$skill_file"); test "$lines" -lt 500; name=$(sed -n "/^---$/,/^---$/p" "$skill_file" | awk "/^name:/ {print \$2; exit}"); test "$name" = "$skill_name"; rg -q "^description:" "$skill_file"; done && ruby -ryaml -e "YAML.load_file(ARGV[0])" agent-skills/config/severity.yaml && (cd agent-skills/examples/demo-repo && go build -o /tmp/gopher-ai-demo . && go test ./...)'`
