### PR TITLE
fix(go-workflow): de-pin ship Codex model

### DIFF
--- a/plugins/go-workflow/README.md
+++ b/plugins/go-workflow/README.md
@@ -67,6 +67,13 @@ Set `CLAUDE_CODE_SUBAGENT_MODEL=<model>` before running `$start-issue` or
 `$complete-issue` to override all subagent models for that run. Use
 `--no-agents` to switch to the single-session workflow.
 
+#### Codex Model Defaults
+
+The `$ship` and `$complete-issue` Codex review stages omit model flags by
+default. A `model = "..."` pin in `~/.codex/config.toml` overrides the provider
+default for those stages; leaving it unset lets the Codex CLI use its latest
+recommended model automatically.
+
 ### Address Review
 
 The `$address-review` skill handles PR review feedback automatically:

--- a/plugins/go-workflow/lib/ship/local-review.md
+++ b/plugins/go-workflow/lib/ship/local-review.md
@@ -91,15 +91,19 @@ SCHEMA_EOF
 PROMPT_FILE=$(mktemp /tmp/codex-review-prompt-XXXXXX)
 echo "$ASSEMBLED_PROMPT" > "$PROMPT_FILE"
 CODEX_TIMEOUT="${CODEX_TIMEOUT:-300}"
+CODEX_MODEL_ARGS=()
+if [ -n "${MODEL:-}" ]; then
+  CODEX_MODEL_ARGS=(-m "$MODEL")
+fi
 
 set +e
 if [ -n "$TIMEOUT_CMD" ]; then
-  REVIEW_JSON=$($TIMEOUT_CMD "${CODEX_TIMEOUT}" $CODEX_CMD exec -m "${MODEL:-gpt-5.5}" -s read-only \
+  REVIEW_JSON=$($TIMEOUT_CMD "${CODEX_TIMEOUT}" $CODEX_CMD exec "${CODEX_MODEL_ARGS[@]}" -s read-only \
     -c model_reasoning_effort="high" \
     --output-schema "$SCHEMA_FILE" \
     - < "$PROMPT_FILE" 2>"/tmp/codex-review-stderr-$$")
 else
-  REVIEW_JSON=$($CODEX_CMD exec -m "${MODEL:-gpt-5.5}" -s read-only \
+  REVIEW_JSON=$($CODEX_CMD exec "${CODEX_MODEL_ARGS[@]}" -s read-only \
     -c model_reasoning_effort="high" \
     --output-schema "$SCHEMA_FILE" \
     - < "$PROMPT_FILE" 2>"/tmp/codex-review-stderr-$$")
@@ -182,7 +186,12 @@ If `codex exec` returns non-JSON or empty output (and exit code 0), do NOT fall 
 ### Codex Quick Mode (`codex review --base`)
 
 ```bash
-$CODEX_CMD review --base "$BASE_BRANCH" -c model="${MODEL:-gpt-5.5}" -c model_reasoning_effort="high"
+CODEX_REVIEW_MODEL_ARGS=()
+if [ -n "${MODEL:-}" ]; then
+  CODEX_REVIEW_MODEL_ARGS=(-c "model=$MODEL")
+fi
+
+$CODEX_CMD review --base "$BASE_BRANCH" "${CODEX_REVIEW_MODEL_ARGS[@]}" -c model_reasoning_effort="high"
 ```
 
 Capture output as free-text `FINDINGS`. Set `CODEX_EXEC_FALLBACK=true`. Persist `quick_mode=true`:

--- a/plugins/go-workflow/skills/complete-issue/phases.md
+++ b/plugins/go-workflow/skills/complete-issue/phases.md
@@ -48,6 +48,10 @@ else TIMEOUT_CMD=""; fi
 
 If `$TIMEOUT_CMD` is available, invoke `$TIMEOUT_CMD $CODEX_TIMEOUT $CODEX_CMD exec -c model_reasoning_effort="high"` with structured output. If no timeout command is available, run `$CODEX_CMD exec -c model_reasoning_effort="high"` without a timeout wrapper. Reasoning effort is always pinned to `high`.
 
+No model flag is passed in either Codex path. A `model = "..."` pin in
+`~/.codex/config.toml` is respected; leaving it unset lets the Codex CLI choose
+its recommended default.
+
 If the diff exceeds 3000 lines, warn the user via `AskUserQuestion` BEFORE starting:
 
 > "Large diff ($DIFF_LINES lines) — codex exec may timeout. Proceed / Use `codex review --base` / Agent review / Skip?"


### PR DESCRIPTION
## Summary
- Omit Codex model flags in ship local review unless `MODEL` is explicitly set.
- Keep high reasoning effort pinned while letting Codex resolve its provider default.
- Document how `~/.codex/config.toml` model pins affect go-workflow Codex review stages.

## Test Plan
- `git diff --check`
- Bash syntax check for the changed optional model argument construction
- Mocked codex exec composition with and without `MODEL`
- `rg -n "gpt-5" plugins/go-workflow`
- `GOCACHE=/tmp/gopher-ai-go-build` configured validation gate

Fixes #193
