### PR TITLE
fix(release): sync Codex plugin versions

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -111,12 +111,13 @@ Use the `/release` command from the productivity plugin to create releases:
 
 ### Version Sync Requirement
 
-**Critical**: Claude Code uses `plugin.json` version (not `marketplace.json`) to create cache directories. Both files must stay in sync:
+**Critical**: Claude Code and Codex use `plugin.json` versions (not only `marketplace.json`) to create cache directories. All manifest versions must stay in sync:
 
 - `.claude-plugin/marketplace.json` - Marketplace-level versions
-- `plugins/<name>/.claude-plugin/plugin.json` - Individual plugin versions
+- `plugins/<name>/.claude-plugin/plugin.json` - Individual Claude Code plugin versions
+- `plugins/<name>/.codex-plugin/plugin.json` - Individual Codex plugin versions
 
-The `/release` command handles this automatically. If manually bumping versions, update both locations.
+The `/release` command handles this automatically. If manually bumping versions, update all three locations.
 
 ### Cache Refresh
 

--- a/plugins/go-dev/.codex-plugin/plugin.json
+++ b/plugins/go-dev/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "go-dev",
-  "version": "1.5.2",
+  "version": "1.6.0",
   "description": "Go-specific development tools with idiomatic best practices",
   "author": {
     "name": "Gopher Guides",

--- a/plugins/go-web/.codex-plugin/plugin.json
+++ b/plugins/go-web/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "go-web",
-  "version": "1.5.2",
+  "version": "1.6.0",
   "description": "Opinionated Go web app scaffolding with Templ + HTMX + Alpine.js + Tailwind",
   "author": {
     "name": "Gopher Guides",

--- a/plugins/go-workflow/.codex-plugin/plugin.json
+++ b/plugins/go-workflow/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "go-workflow",
-  "version": "1.5.2",
+  "version": "1.6.0",
   "description": "Issue-to-PR workflow automation with git worktree management",
   "author": {
     "name": "Gopher Guides",

--- a/plugins/gopher-guides/.codex-plugin/plugin.json
+++ b/plugins/gopher-guides/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "gopher-guides",
-  "version": "1.5.2",
+  "version": "1.6.0",
   "description": "Gopher Guides training materials integration",
   "author": {
     "name": "Gopher Guides",

--- a/plugins/llm-tools/.codex-plugin/plugin.json
+++ b/plugins/llm-tools/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "llm-tools",
-  "version": "1.5.2",
+  "version": "1.6.0",
   "description": "Multi-LLM integration for second opinions and task delegation",
   "author": {
     "name": "Gopher Guides",

--- a/plugins/productivity/commands/release.md
+++ b/plugins/productivity/commands/release.md
@@ -74,16 +74,17 @@ Ask the user to confirm the bump type using AskUserQuestion before proceeding.
    ' .claude-plugin/marketplace.json > /tmp/marketplace.json.tmp && \
    mv /tmp/marketplace.json.tmp .claude-plugin/marketplace.json
    ```
-   - **IMPORTANT**: Also update each individual `plugin.json` (Claude Code uses these for cache paths):
+   - **IMPORTANT**: Also update each individual `plugin.json` (Claude Code and Codex use these for cache paths):
    ```bash
-   for pjson in plugins/*/.claude-plugin/plugin.json; do
+   for pjson in plugins/*/.claude-plugin/plugin.json plugins/*/.codex-plugin/plugin.json; do
+     [ -f "$pjson" ] || continue
      jq --arg v "NEW_VERSION" '.version = $v' "$pjson" > /tmp/pj.tmp && mv /tmp/pj.tmp "$pjson"
    done
    ```
 
 5. **Commit and Tag**
    ```bash
-   git add .claude-plugin/marketplace.json plugins/*/.claude-plugin/plugin.json
+   git add .claude-plugin/marketplace.json plugins/*/.claude-plugin/plugin.json plugins/*/.codex-plugin/plugin.json
    git commit -m "chore: release vX.Y.Z"
    git tag -a vX.Y.Z -m "Release vX.Y.Z"
    ```

--- a/plugins/tailwind/.codex-plugin/plugin.json
+++ b/plugins/tailwind/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "tailwind",
-  "version": "1.5.2",
+  "version": "1.6.0",
   "description": "Tailwind CSS v4 tools for initialization, auditing, migration, and optimization",
   "author": {
     "name": "Gopher Guides",

--- a/scripts/test-installation.sh
+++ b/scripts/test-installation.sh
@@ -112,6 +112,28 @@ else
   echo "OK"
 fi
 
+echo -n "Codex plugin.json versions match marketplace... "
+CODEX_PLUGIN_JSON_MISMATCHES=""
+for i in $(seq 0 $((PLUGIN_COUNT - 1))); do
+  NAME=$(jq -r ".plugins[$i].name" "$MARKETPLACE")
+  EXPECTED_VER=$(jq -r ".plugins[$i].version" "$MARKETPLACE")
+  CODEX_PLUGIN_JSON="$ROOT_DIR/plugins/$NAME/.codex-plugin/plugin.json"
+  if [ -f "$CODEX_PLUGIN_JSON" ]; then
+    ACTUAL_VER=$(jq -r '.version // empty' "$CODEX_PLUGIN_JSON" 2>/dev/null)
+    if [ -z "$ACTUAL_VER" ]; then
+      CODEX_PLUGIN_JSON_MISMATCHES="$CODEX_PLUGIN_JSON_MISMATCHES $NAME(codex-plugin.json:missing-version)"
+    elif [ "$ACTUAL_VER" != "$EXPECTED_VER" ]; then
+      CODEX_PLUGIN_JSON_MISMATCHES="$CODEX_PLUGIN_JSON_MISMATCHES $NAME(codex-plugin.json:$ACTUAL_VER!=marketplace:$EXPECTED_VER)"
+    fi
+  fi
+done
+if [ -n "$CODEX_PLUGIN_JSON_MISMATCHES" ]; then
+  echo "FAIL:$CODEX_PLUGIN_JSON_MISMATCHES"
+  ERRORS=$((ERRORS + 1))
+else
+  echo "OK"
+fi
+
 echo -n "Codex distribution builds... "
 if ! "$ROOT_DIR/scripts/build-universal.sh" >/tmp/gopher-ai-build.log 2>&1; then
   echo "FAIL"


### PR DESCRIPTION
## Summary
- Keep Codex plugin manifest versions in lockstep with the marketplace release version.
- Update the release command and version-sync docs to include Codex manifests.
- Add an installation regression check for Codex plugin manifest versions.

## Test Plan
- `./scripts/test-installation.sh`
- `bash -lc 'export GOCACHE=/tmp/gopher-ai-go-build-cache GOMODCACHE=/tmp/gopher-ai-go-mod-cache; mkdir -p "$GOCACHE" "$GOMODCACHE"; ./scripts/test-commands.sh && ./scripts/test-hooks.sh && ./scripts/test-ship-e2e-gate.sh && ./scripts/check-shared-sync.sh && shellcheck agent-skills/scripts/*.sh && for skill_dir in agent-skills/skills/*/; do skill_name=$(basename "$skill_dir"); skill_file="$skill_dir/SKILL.md"; test -f "$skill_file"; lines=$(wc -l < "$skill_file"); test "$lines" -lt 500; name=$(sed -n "/^---$/,/^---$/p" "$skill_file" | awk "/^name:/ {print \\$2; exit}"); test "$name" = "$skill_name"; rg -q "^description:" "$skill_file"; done && ruby -ryaml -e "YAML.load_file(ARGV[0])" agent-skills/config/severity.yaml && (cd agent-skills/examples/demo-repo && go build -o /tmp/gopher-ai-demo . && go test ./...)'`

Fixes #194