### PR TITLE
fix(llm-tools): resolve Ollama models dynamically

### DIFF
--- a/plugins/llm-tools/commands/llm-compare.md
+++ b/plugins/llm-tools/commands/llm-compare.md
@@ -62,7 +62,14 @@ Only skip if the user explicitly chooses "Skip this LLM".
 
 ## 2. Select Models (Optional)
 
-For each LLM, ask if user wants to specify a model. Defaults: **OpenAI** provider default with no `-m` flag, **Gemini** CLI Auto routing with no `-m` flag, **Ollama** first available code model (codellama, deepseek-coder, etc.).
+For each LLM, ask if user wants to specify a model. Defaults: **OpenAI** provider default with no `-m` flag, **Gemini** CLI Auto routing with no `-m` flag.
+
+For Ollama, run `ollama list` and build model choices from installed local
+models. Default to the first installed model whose name contains `code` or
+`coder` (case-insensitive), otherwise the first installed model. If no Ollama
+models are installed, ask whether to pull an example model such as
+`qwen3-coder`, `qwen2.5-coder`, or `deepseek-coder-v2`, choose a custom model,
+skip Ollama, or abort.
 
 If the user specifies a custom OpenAI model, store it as `OPENAI_MODEL`; otherwise leave `OPENAI_MODEL` unset or empty.
 If the user specifies a custom Gemini model, store it as `GEMINI_MODEL`; otherwise leave `GEMINI_MODEL` unset or empty.
@@ -141,7 +148,7 @@ If `codex exec` fails (non-zero exit or no output), do NOT silently skip. Displa
 
 ---
 
-### Ollama (codellama:34b)
+### Ollama (<selected Ollama model>)
 [Response]
 
 ---
@@ -204,7 +211,7 @@ For a simple shared counter, a mutex is more appropriate. Channels are designed 
 ### Gemini (CLI default)
 Both work, but: Mutex — simpler for protecting shared state; Channels — better for coordination. For a counter specifically, consider `sync/atomic.Int64` which avoids locking entirely.
 
-### Ollama (codellama:34b)
+### Ollama (<selected local model>)
 Use `sync.Mutex` for the counter. Channels add unnecessary complexity. The Go proverb "share memory by communicating" applies when you need coordination, not just protection.
 
 ## Analysis

--- a/plugins/llm-tools/commands/llm-compare.md
+++ b/plugins/llm-tools/commands/llm-compare.md
@@ -1,7 +1,7 @@
 ---
 argument-hint: "[--tier flex|standard|priority] <prompt>"
 description: "Compare responses from multiple LLMs"
-allowed-tools: ["Bash(codex:*)", "Bash(gemini:*)", "Bash(ollama:*)", "Bash(npx:*)", "Bash(command:*)", "Bash(echo:*)", "Bash(git:*)", "Bash(cat:*)", "Read", "AskUserQuestion"]
+allowed-tools: ["Bash(codex:*)", "Bash(gemini:*)", "Bash(ollama:*)", "Bash(npx:*)", "Bash(command:*)", "Bash(echo:*)", "Bash(git:*)", "Bash(cat:*)", "Bash(sleep:*)", "Read", "AskUserQuestion"]
 ---
 
 # Compare Multiple LLMs
@@ -64,10 +64,25 @@ Only skip if the user explicitly chooses "Skip this LLM".
 
 For each LLM, ask if user wants to specify a model. Defaults: **OpenAI** provider default with no `-m` flag, **Gemini** CLI Auto routing with no `-m` flag.
 
-For Ollama, run `ollama list` and build model choices from installed local
-models. Default to the first installed model whose name contains `code` or
-`coder` (case-insensitive), otherwise the first installed model. If no Ollama
-models are installed, ask whether to pull an example model such as
+For Ollama, verify the local server is running before listing models:
+
+```bash
+ollama ps 2>/dev/null
+```
+
+If the server is not running, ask whether to start Ollama, skip Ollama, or
+abort. If the user chooses to start it:
+
+```bash
+ollama serve &
+sleep 2
+ollama ps 2>/dev/null
+```
+
+Only after the server is running, run `ollama list` and build model choices from
+installed local models. Default to the first installed model whose name contains
+`code` or `coder` (case-insensitive), otherwise the first installed model. If no
+Ollama models are installed, ask whether to pull an example model such as
 `qwen3-coder`, `qwen2.5-coder`, or `deepseek-coder-v2`, choose a custom model,
 skip Ollama, or abort.
 

--- a/plugins/llm-tools/commands/ollama.md
+++ b/plugins/llm-tools/commands/ollama.md
@@ -23,14 +23,11 @@ This command runs prompts through local models via Ollama. Your data stays on yo
 | `/ollama suggest Go idioms for this function` | Best practices |
 | `/ollama what security issues do you see` | Security analysis |
 
-**Recommended Models for Code:**
-
-| Model | Best For |
-|-------|----------|
-| `codellama:34b` | Code generation, large context |
-| `deepseek-coder:33b` | Code review, analysis |
-| `qwen2.5-coder:32b` | Code-focused tasks |
-| `llama3.3:70b` | General reasoning, complex tasks |
+Model choice is based on what is installed locally. When running a prompt,
+first call `ollama list`, prefer the first installed model whose name contains
+`code` or `coder`, and fall back to the first installed model. If no models are
+installed, offer pull suggestions such as `qwen3-coder`, `qwen2.5-coder`, or
+`deepseek-coder-v2` as examples only.
 
 **Privacy Note:** All processing happens locally. Your code never leaves your machine.
 
@@ -82,26 +79,37 @@ sleep 2
 ollama list
 ```
 
-Show the user which models are already downloaded.
+Show the user which models are already downloaded. Use the first column
+(`NAME`) as the installed model list, excluding the header row.
 
 ## 4. Select Model
 
-Ask the user which model to use:
+Build the model menu from the actual `ollama list` output, not from a static
+table.
 
-| Model | Size | Best For |
-|-------|------|----------|
-| codellama:34b | ~19GB | Code generation, large context |
-| deepseek-coder:33b | ~19GB | Code review, detailed analysis |
-| qwen2.5-coder:32b | ~18GB | Code-focused tasks |
-| llama3.3:70b | ~40GB | General reasoning, complex tasks |
-| codellama:7b | ~4GB | Quick code tasks, lower resources |
-| llama3.2:3b | ~2GB | Fast responses, limited complexity |
+Default selection:
 
-Default: `codellama:34b` (or first available code model)
+1. First installed model whose name contains `code` or `coder` (case-insensitive)
+2. Otherwise, first installed model
+3. Otherwise, no default
 
-**If selected model is not downloaded:**
+Ask the user which installed model to use. Mark the default selection as
+recommended. Include a Custom option only if the user wants to enter a model
+name that is not currently installed.
 
-Ask user: "Model `<model>` is not downloaded (~<size>). Download it now?"
+If no local models are installed, say that no downloaded models were found and
+ask whether to pull a model before running the prompt. Example pull suggestions
+only:
+
+| Model | Best For |
+|-------|----------|
+| `qwen3-coder` | Agentic coding tasks and repository-scale context |
+| `qwen2.5-coder` | Code generation, reasoning, and repair |
+| `deepseek-coder-v2` | Code review and detailed analysis |
+
+**If the selected model is not downloaded:**
+
+Ask user: "Model `<model>` is not downloaded. Download it now?"
 
 If yes:
 ```bash

--- a/plugins/llm-tools/commands/review-loop.md
+++ b/plugins/llm-tools/commands/review-loop.md
@@ -1,7 +1,7 @@
 ---
 argument-hint: "[--llm codex|gemini|ollama|fable] [--max-passes <n>] [--quick] [--tier flex|standard|priority] [scope hint]"
 description: "Iterative LLM review loop: review, fix, verify, repeat until clean"
-allowed-tools: ["Bash(*setup-loop.sh*)", "Bash(*cleanup-loop.sh*)", "Bash(source:*)", "Bash(codex:*)", "Bash(gemini:*)", "Bash(ollama:*)", "Bash(npx:*)", "Bash(command:*)", "Bash(jq:*)", "Bash(git:*)", "Bash(gh:*)", "Bash(go:*)", "Bash(npm:*)", "Bash(timeout:*)", "Bash(gtimeout:*)", "Read", "Glob", "Grep", "Edit", "Write", "AskUserQuestion", "Agent"]
+allowed-tools: ["Bash(*setup-loop.sh*)", "Bash(*cleanup-loop.sh*)", "Bash(source:*)", "Bash(codex:*)", "Bash(gemini:*)", "Bash(ollama:*)", "Bash(npx:*)", "Bash(command:*)", "Bash(jq:*)", "Bash(git:*)", "Bash(gh:*)", "Bash(go:*)", "Bash(npm:*)", "Bash(timeout:*)", "Bash(gtimeout:*)", "Bash(sleep:*)", "Read", "Glob", "Grep", "Edit", "Write", "AskUserQuestion", "Agent"]
 ---
 
 # Iterative LLM Review Loop
@@ -78,7 +78,11 @@ Use a **single `AskUserQuestion` call** with two questions.
 
 - **codex:** Provider default (Recommended; latest recommended Codex model), Custom model ID
 - **gemini:** Auto (Recommended; CLI routes to the best current model), Custom model ID
-- **ollama:** run `ollama list` first; build options from installed models,
+- **ollama:** before building model choices, run `ollama ps 2>/dev/null`. If
+  the local server is not running, ask whether to start Ollama, choose another
+  LLM, or abort. If the user chooses to start it, run `ollama serve &`, wait
+  briefly with `sleep 2`, then retry `ollama ps 2>/dev/null`. Only after the
+  server is running, run `ollama list`; build options from installed models,
   recommending the first model whose name contains `code` or `coder`
   (case-insensitive), otherwise the first installed model. If no models are
   installed, offer Custom plus example pull suggestions such as `qwen3-coder`,

--- a/plugins/llm-tools/commands/review-loop.md
+++ b/plugins/llm-tools/commands/review-loop.md
@@ -78,7 +78,11 @@ Use a **single `AskUserQuestion` call** with two questions.
 
 - **codex:** Provider default (Recommended; latest recommended Codex model), Custom model ID
 - **gemini:** Auto (Recommended; CLI routes to the best current model), Custom model ID
-- **ollama:** `codellama` (Recommended), `llama3`, `deepseek-coder`, Custom
+- **ollama:** run `ollama list` first; build options from installed models,
+  recommending the first model whose name contains `code` or `coder`
+  (case-insensitive), otherwise the first installed model. If no models are
+  installed, offer Custom plus example pull suggestions such as `qwen3-coder`,
+  `qwen2.5-coder`, or `deepseek-coder-v2`.
 - **fable:** skip Q2 entirely — the review subagent inherits the session's Claude model
 
 ### 4c. Auto-Detect Base Branch & Conditional Follow-Up


### PR DESCRIPTION
## Summary
- Resolve Ollama model selection dynamically from `ollama list` instead of a hardcoded default.
- Prefer installed `code`/`coder` models, then the first installed model, and only use example pull suggestions when none are installed.
- Align `llm-compare` and `review-loop` Ollama wording with the dynamic behavior.

Fixes #195

## Test Plan
- `rg -n 'codellama|deepseek-coder:33b|qwen2\.5-coder:32b|llama3\.3:70b|llama3\.2:3b|Default:|Recommended|ollama list|qwen3-coder|deepseek-coder-v2' plugins/llm-tools/commands/ollama.md plugins/llm-tools/commands/llm-compare.md plugins/llm-tools/commands/review-loop.md`
- `git diff --check FETCH_HEAD...HEAD`
- `bash -lc 'export GOCACHE=/tmp/gopher-ai-go-cache; mkdir -p "$GOCACHE"; ./scripts/test-commands.sh && ./scripts/test-hooks.sh && ./scripts/test-ship-e2e-gate.sh && ./scripts/check-shared-sync.sh && shellcheck agent-skills/scripts/*.sh && for skill_dir in agent-skills/skills/*/; do skill_name=$(basename "$skill_dir"); skill_file="$skill_dir/SKILL.md"; test -f "$skill_file"; lines=$(wc -l < "$skill_file"); test "$lines" -lt 500; name=$(sed -n "/^---$/,/^---$/p" "$skill_file" | awk "/^name:/ {print \$2; exit}"); test "$name" = "$skill_name"; rg -q "^description:" "$skill_file"; done && ruby -ryaml -e "YAML.load_file(ARGV[0])" agent-skills/config/severity.yaml && (cd agent-skills/examples/demo-repo && go build -o /tmp/gopher-ai-demo . && go test ./...)'`