### PR TITLE
go-web: refresh htmx extension CDN pins

### DIFF
--- a/plugins/go-web/skills/htmx/patterns-and-extensions.md
+++ b/plugins/go-web/skills/htmx/patterns-and-extensions.md
@@ -12,6 +12,8 @@ The server returns HTTP 200 with the form re-rendered showing inline errors. Thi
 
 **Option 2: response-targets extension**
 
+CDN versions in these examples are point-in-time; check the latest release on npm, jsDelivr, or unpkg before copying.
+
 ```html
 <script src="https://cdn.jsdelivr.net/npm/htmx-ext-response-targets@2.0.4"></script>
 <div hx-ext="response-targets">
@@ -289,7 +291,7 @@ Extended CSS selectors for `hx-target`:
 ### json-enc — Send JSON Bodies
 
 ```html
-<script src="https://cdn.jsdelivr.net/npm/htmx-ext-json-enc@2.0.1"></script>
+<script src="https://cdn.jsdelivr.net/npm/htmx-ext-json-enc@2.0.3"></script>
 <form hx-post="/api/users" hx-ext="json-enc">
     <input name="name" value="John">
     <button type="submit">Create</button>
@@ -324,9 +326,9 @@ Extended CSS selectors for `hx-target`:
 ### head-support, preload, loading-states
 
 ```html
-<script src="https://cdn.jsdelivr.net/npm/htmx-ext-head-support@2.0.3"></script>
-<script src="https://cdn.jsdelivr.net/npm/htmx-ext-preload@2.1.0"></script>
-<script src="https://cdn.jsdelivr.net/npm/htmx-ext-loading-states@2.0.0"></script>
+<script src="https://cdn.jsdelivr.net/npm/htmx-ext-head-support@2.0.5"></script>
+<script src="https://cdn.jsdelivr.net/npm/htmx-ext-preload@2.1.2"></script>
+<script src="https://cdn.jsdelivr.net/npm/htmx-ext-loading-states@2.0.2"></script>
 ```
 
 ---


### PR DESCRIPTION
## Summary
- refresh stale htmx extension CDN example pins
- add a point-in-time CDN version note near the first example

## Test Plan
- npm_config_cache=/tmp/gopher-ai-npm-cache npm view htmx-ext-response-targets version
- npm_config_cache=/tmp/gopher-ai-npm-cache npm view htmx-ext-json-enc version
- npm_config_cache=/tmp/gopher-ai-npm-cache npm view htmx-ext-sse version
- npm_config_cache=/tmp/gopher-ai-npm-cache npm view htmx-ext-ws version
- npm_config_cache=/tmp/gopher-ai-npm-cache npm view htmx-ext-head-support version
- npm_config_cache=/tmp/gopher-ai-npm-cache npm view htmx-ext-preload version
- npm_config_cache=/tmp/gopher-ai-npm-cache npm view htmx-ext-loading-states version
- git diff --check
- GOCACHE=/tmp/gopher-ai-go-build bash -lc './scripts/test-commands.sh && ./scripts/test-hooks.sh && ./scripts/test-ship-e2e-gate.sh && ./scripts/check-shared-sync.sh && shellcheck agent-skills/scripts/*.sh && for skill_dir in agent-skills/skills/*/; do skill_name=$(basename "$skill_dir"); skill_file="$skill_dir/SKILL.md"; test -f "$skill_file"; lines=$(wc -l < "$skill_file"); test "$lines" -lt 500; name=$(sed -n "/^---$/,/^---$/p" "$skill_file" | awk "/^name:/ {print \\$2; exit}"); test "$name" = "$skill_name"; rg -q "^description:" "$skill_file"; done && ruby -ryaml -e "YAML.load_file(ARGV[0])" agent-skills/config/severity.yaml && (cd agent-skills/examples/demo-repo && go build -o /tmp/gopher-ai-demo . && go test ./...)'\n\nFixes #196