### PR TITLE
feat(llm-tools): prefer official Codex plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,9 +204,11 @@ Requires `GOPHER_GUIDES_API_KEY` environment variable.
 
 Multi-LLM integration for second opinions and task delegation.
 
+For interactive Codex use in Claude Code, llm-tools prefers OpenAI's official `codex@openai-codex` plugin when installed and falls back to the built-in Codex CLI flow when it is missing or declined. Both paths share `~/.codex` auth/config; scripted gopher-ai review pipelines continue to use the CLI flow for structured automation.
+
 | Command | Description |
 |---------|-------------|
-| `/codex <prompt>` | Delegate tasks to OpenAI Codex CLI |
+| `/llm-tools:codex <prompt>` | Delegate tasks to Codex with official-plugin routing and CLI fallback |
 | `/gemini <prompt>` | Query Google Gemini for analysis |
 | `/ollama <prompt>` | Use local models (data stays on your machine) |
 | `/llm-compare <prompt>` | Compare responses from multiple LLMs |

--- a/plugins/go-workflow/hooks/legacy-skill-hashes.txt
+++ b/plugins/go-workflow/hooks/legacy-skill-hashes.txt
@@ -7,7 +7,7 @@
 # this prevents accepting a hash from skill A as proof of ownership for skill B.
 # DO NOT EDIT BY HAND — re-run the regen script after committing SKILL.md changes.
 #
-# Total entries: 224
+# Total entries: 225
 017e2d820506e7bef4a89a4d65839150db1ffdc124852a43dc916023e6d37e16 review-deep
 0322d4a7ddc204a9bf5addfec4e512edaea92ab8f4ebdd0541ca099330a09408 worktree
 03dac3a27d6da4b0a0c64ff6511df17004747e20b47a1691b4f9f030478877b9 commit
@@ -143,6 +143,7 @@
 987e6c4bc5ab7429668f8f7a34afc4b1a1dc3b72c162253b906da8b21e53378e gemini-image
 99815b40806a1a98fe32252f38641f1d116e0c95828dd30e74296c669456cad5 e2e-verify
 9a87d3e2d6c3590b71df03c524b3993a6dd2618e151cb227d29a59ae5bbdd9e8 go-code-organization
+9b00bc9c9a0ed642feacfde94fd3b540bc8a023ee28c76d3e5e3e764213f3e10 second-opinion
 9fd7491065e05d6c0a41db0c196d74069c24d305e2d069c8831d7a9729f18d07 gopher-guides
 a164e2b1f11394ae1ed9483327be26cabf4f6312ce041058a88e971be5806a6f e2e-verify
 a1a6f04b281f1bcfbe8fde80103929966af8f70bda1c911778aac492046cf46f start-issue

--- a/plugins/llm-tools/README.md
+++ b/plugins/llm-tools/README.md
@@ -17,7 +17,7 @@ Or install via marketplace:
 
 | Command | Description |
 |---------|-------------|
-| `/codex <prompt>` | Delegate tasks to OpenAI Codex CLI |
+| `/llm-tools:codex <prompt>` | Delegate tasks to Codex with official-plugin routing and CLI fallback |
 | `/gemini <prompt>` | Query Google Gemini for analysis |
 | `/ollama <prompt>` | Use local models (data stays on your machine) |
 | `/llm-compare <prompt>` | Compare responses from multiple LLMs |
@@ -44,6 +44,21 @@ npm install -g @google/gemini-cli
 # Ollama (local models)
 brew install ollama
 ```
+
+## Interactive Codex in Claude Code
+
+For interactive Codex review and delegation inside Claude Code, install OpenAI's official Codex plugin:
+
+```bash
+/plugin marketplace add openai/codex-plugin-cc
+/plugin install codex@openai-codex
+/reload-plugins
+/codex:setup
+```
+
+When `codex@openai-codex` is installed, `/llm-tools:codex` prefers the official `/codex:review`, `/codex:adversarial-review`, and `/codex:rescue` commands. If the official plugin is missing, `/llm-tools:codex` warns, offers those install steps, and can proceed with the built-in `codex exec` / `codex review` CLI fallback.
+
+Both paths use the same `~/.codex` authentication and configuration. Scripted gopher-ai pipelines such as `review-loop`, `complete-issue`, and `ship` stay on the CLI flow so they can continue using structured `codex exec --output-schema` automation.
 
 ## Codex Model Defaults
 

--- a/plugins/llm-tools/commands/codex.md
+++ b/plugins/llm-tools/commands/codex.md
@@ -70,7 +70,7 @@ Check if `$CODEX_PROMPT` contains "review" (case-insensitive). Then determine ro
 - **Review-oriented** — e.g., "review the auth changes", "review this PR" → route to **Review Flow**.
 - **Otherwise** → **Exec Flow**.
 
-Store `CODEX_ROUTE=review` for review-oriented prompts and `CODEX_ROUTE=exec` for fix-oriented or non-review prompts.
+Store `CODEX_ROUTE=review` for review-oriented prompts and `CODEX_ROUTE=exec` for fix-oriented or non-review prompts. Also store `REVIEW_FIX_MODE=true` for fix-oriented review prompts and `REVIEW_FIX_MODE=false` otherwise.
 
 Also detect whether the review asks for an adversarial/challenge review. Prompts that contain "adversarial", "challenge", "pressure-test", "question the approach", "trade-off", "risk", or similar wording alongside "review" route to the official `/codex:adversarial-review` command when the official plugin is installed.
 
@@ -81,6 +81,8 @@ For review-oriented prompts, detect a standalone `--base <ref>` and store its va
 For interactive Claude Code use, prefer the official OpenAI Codex plugin (`codex@openai-codex`) over this command's built-in CLI fallback. This step applies only to this `/llm-tools:codex` command. Scripted pipeline paths such as `review-loop`, `complete-issue`, and `ship` must keep using `codex exec --output-schema` and must not depend on the official plugin.
 
 If `INTERACTIVE_MODE=true`, the user explicitly requested the built-in flow's interactive configuration. Skip the rest of Step 2 and continue directly to Step 3. Do not silently discard `--ask` or route it to an official command that does not support the same review-depth and context questions.
+
+If `REVIEW_FIX_MODE=true`, skip the rest of Step 2 and continue directly to Step 3. Review-feedback fixes must stay on the built-in CLI path so Step 4 can capture the `_test.go` baseline, inject the test-generation requirement, and perform the post-run missing-test fallback before any fix is accepted.
 
 Detect the official plugin:
 
@@ -203,7 +205,7 @@ Include `--base <base-ref>` for branch reviews. Preserve only flags the official
 
 Do not add model flags by default; the official plugin and Codex share the user's `~/.codex` auth and config. Do not append focus text to `/codex:review`; that command is not steerable. If the user asks for a focused challenge, risk, trade-off, or pressure-test review, route to `/codex:adversarial-review` instead.
 
-If the user asks to review the current working tree or uncommitted changes and did not provide `--base`, do not add it; let `/codex:review` or `/codex:adversarial-review` use its working-tree review mode. If `REQUESTED_BASE` is set, preserve it. Otherwise, if the user asks for a branch review or the prompt is simply "review", use `--base "$BASE_BRANCH"`.
+Review-oriented prompts default to branch review, matching the built-in Review Flow's "Changes vs branch" default. If `REQUESTED_BASE` is set, preserve it. Otherwise use `--base "$BASE_BRANCH"` for prompts such as "review", "review the auth changes", or "review this PR". Only omit `--base` when the user explicitly asks to review the current working tree or uncommitted changes and did not provide `--base`.
 
 If this command runner cannot invoke another slash command from inside the current slash command, print the exact `/codex:*` command to run and stop. Also state that if the command is unavailable in the current session, the user should run `/reload-plugins` and retry, or rerun `/llm-tools:codex ... --ask` to choose the built-in CLI flow. Do not continue into the CLI fallback after a successful official-plugin route or after printing the official command.
 

--- a/plugins/llm-tools/commands/codex.md
+++ b/plugins/llm-tools/commands/codex.md
@@ -1,7 +1,7 @@
 ---
 argument-hint: "[--ask] <prompt>"
-description: "Delegate a task to OpenAI Codex CLI"
-allowed-tools: ["Bash(codex:*)", "Bash(npx:*)", "Bash(command:*)", "Bash(echo:*)", "Bash(git:*)", "Bash(gh:*)", "Bash(find:*)", "Bash(md5sum:*)", "Read", "AskUserQuestion"]
+description: "Delegate a task to Codex, preferring the official Codex Claude Code plugin when installed"
+allowed-tools: ["Bash(codex:*)", "Bash(claude:*)", "Bash(npx:*)", "Bash(command:*)", "Bash(echo:*)", "Bash(printf:*)", "Bash(git:*)", "Bash(gh:*)", "Bash(awk:*)", "Bash(jq:*)", "Bash(grep:*)", "Bash(sed:*)", "Bash(find:*)", "Bash(md5sum:*)", "Read", "AskUserQuestion"]
 ---
 
 # Delegate to Codex
@@ -10,24 +10,24 @@ allowed-tools: ["Bash(codex:*)", "Bash(npx:*)", "Bash(command:*)", "Bash(echo:*)
 
 Display usage and ask for input:
 
-> This command delegates tasks to OpenAI Codex CLI for autonomous execution.
+> This command delegates tasks to Codex. In Claude Code, it prefers the official `codex@openai-codex` plugin when installed and falls back to the built-in Codex CLI flow when it is missing or declined.
 >
-> **Usage:** `/codex [--ask] <prompt>`
+> **Usage:** `/llm-tools:codex [--ask] <prompt>`
 >
-> All commands use recommended defaults automatically. Add `--ask` to customize model, review depth, context, and other options interactively.
+> All commands use recommended defaults automatically. Add `--ask` to use the customizable built-in CLI flow for model, review depth, context, and other options.
 
 **Examples:**
 
 | Command | Description |
 |---------|-------------|
-| `/codex refactor the auth module` | Refactor existing code (uses defaults) |
-| `/codex write tests for utils.ts` | Generate test files (uses defaults) |
-| `/codex fix the bug in checkout flow` | Debug and fix issues (uses defaults) |
-| `/codex explain how the API routes work` | Code explanation (uses defaults) |
-| `/codex add dark mode support` | Implement new features (uses defaults) |
-| `/codex review the auth changes` | Review with recommended defaults |
-| `/codex review the auth changes --ask` | Review with interactive configuration |
-| `/codex refactor the module --ask` | Exec with interactive model/sandbox selection |
+| `/llm-tools:codex refactor the auth module` | Refactor existing code (uses defaults) |
+| `/llm-tools:codex write tests for utils.ts` | Generate test files (uses defaults) |
+| `/llm-tools:codex fix the bug in checkout flow` | Debug and fix issues (uses defaults) |
+| `/llm-tools:codex explain how the API routes work` | Code explanation (uses defaults) |
+| `/llm-tools:codex add dark mode support` | Implement new features (uses defaults) |
+| `/llm-tools:codex review the auth changes` | Review with recommended defaults |
+| `/llm-tools:codex review the auth changes --ask` | Review with interactive configuration |
+| `/llm-tools:codex refactor the module --ask` | Exec with interactive model/sandbox selection |
 
 **Codex Model Selection:**
 
@@ -42,23 +42,9 @@ Ask the user: "What would you like Codex to do?"
 
 **If `$ARGUMENTS` is provided:**
 
-Run a task using OpenAI Codex CLI with the prompt: `$CODEX_PROMPT`.
+Run a task using Codex with the prompt: `$CODEX_PROMPT`.
 
-## 0. Detect Codex CLI
-
-Resolve the correct command for invoking Codex. This avoids exit code 127 on systems where `codex` is only available via `npx`:
-
-```bash
-if command -v codex &>/dev/null; then
-  CODEX_CMD="codex"
-else
-  CODEX_CMD="npx -y codex"
-fi
-```
-
-**Use `$CODEX_CMD` in place of bare `codex` for ALL commands below.**
-
-## 0.5. Parse Flags
+## 0. Parse Flags
 
 Check if `$ARGUMENTS` starts or ends with `--ask` (as a standalone flag, not embedded in the prompt text). Only strip `--ask` from the leading or trailing position — if it appears mid-prompt (e.g., "explain what --ask does"), leave it intact and do NOT enable interactive mode:
 
@@ -84,7 +70,193 @@ Check if `$CODEX_PROMPT` contains "review" (case-insensitive). Then determine ro
 - **Review-oriented** — e.g., "review the auth changes", "review this PR" → route to **Review Flow**.
 - **Otherwise** → **Exec Flow**.
 
-## 2. Review-Fix Detection (applies to both flows)
+Store `CODEX_ROUTE=review` for review-oriented prompts and `CODEX_ROUTE=exec` for fix-oriented or non-review prompts.
+
+Also detect whether the review asks for an adversarial/challenge review. Prompts that contain "adversarial", "challenge", "pressure-test", "question the approach", "trade-off", "risk", or similar wording alongside "review" route to the official `/codex:adversarial-review` command when the official plugin is installed.
+
+For review-oriented prompts, detect a standalone `--base <ref>` and store its value as `REQUESTED_BASE`. Reject `--base` without a following ref. Preserve this explicit base for official review commands and do not include the flag or its value in adversarial-review focus text.
+
+## 2. Prefer Official Claude Code Plugin
+
+For interactive Claude Code use, prefer the official OpenAI Codex plugin (`codex@openai-codex`) over this command's built-in CLI fallback. This step applies only to this `/llm-tools:codex` command. Scripted pipeline paths such as `review-loop`, `complete-issue`, and `ship` must keep using `codex exec --output-schema` and must not depend on the official plugin.
+
+If `INTERACTIVE_MODE=true`, the user explicitly requested the built-in flow's interactive configuration. Skip the rest of Step 2 and continue directly to Step 3. Do not silently discard `--ask` or route it to an official command that does not support the same review-depth and context questions.
+
+Detect the official plugin:
+
+```bash
+CLAUDE_PLUGINS_DIR="${CLAUDE_PLUGINS_DIR:-$HOME/.claude/plugins}"
+INSTALLED_PLUGINS="$CLAUDE_PLUGINS_DIR/installed_plugins.json"
+CODEX_PLUGIN_INSTALLED=false
+CODEX_PLUGIN_LISTED=false
+CODEX_PLUGIN_ENABLED=false
+CODEX_PLUGIN_INSTALL_PATH=""
+
+if [ -f "$INSTALLED_PLUGINS" ]; then
+  if command -v jq >/dev/null 2>&1; then
+    if jq -e '.plugins["codex@openai-codex"] != null' "$INSTALLED_PLUGINS" >/dev/null 2>&1; then
+      CODEX_PLUGIN_LISTED=true
+    fi
+
+    CODEX_PLUGIN_INSTALL_PATH=$(
+      jq -r '
+        .plugins["codex@openai-codex"] // empty
+        | ..
+        | if type == "object" then (.installPath? // .path? // empty)
+          elif type == "string" then .
+          else empty
+          end
+      ' "$INSTALLED_PLUGINS" 2>/dev/null |
+      while IFS= read -r path; do
+        if [ -d "$path" ]; then
+          printf '%s\n' "$path"
+          break
+        fi
+      done
+    )
+  elif awk '/"codex@openai-codex"/ { found=1 } END { exit !found }' "$INSTALLED_PLUGINS"; then
+    CODEX_PLUGIN_LISTED=true
+  fi
+
+  if [ -n "$CODEX_PLUGIN_INSTALL_PATH" ] && [ -d "$CODEX_PLUGIN_INSTALL_PATH" ]; then
+    CODEX_PLUGIN_INSTALLED=true
+  fi
+fi
+
+if [ "$CODEX_PLUGIN_INSTALLED" != "true" ] && [ "$CODEX_PLUGIN_LISTED" = "true" ]; then
+  for plugin_json in "$CLAUDE_PLUGINS_DIR"/cache/openai-codex/codex/*/.claude-plugin/plugin.json; do
+    if [ -f "$plugin_json" ]; then
+      CODEX_PLUGIN_INSTALL_PATH=${plugin_json%/.claude-plugin/plugin.json}
+      CODEX_PLUGIN_INSTALLED=true
+      break
+    fi
+  done
+fi
+
+if command -v claude >/dev/null 2>&1; then
+  if command -v jq >/dev/null 2>&1; then
+    if CLAUDE_PLUGIN_LIST=$(claude plugin list --json 2>/dev/null); then
+      if printf '%s\n' "$CLAUDE_PLUGIN_LIST" | jq -e 'any(.[]; .id == "codex@openai-codex")' >/dev/null 2>&1; then
+        CODEX_PLUGIN_LISTED=true
+        CODEX_PLUGIN_INSTALLED=true
+      fi
+      if printf '%s\n' "$CLAUDE_PLUGIN_LIST" | jq -e 'any(.[]; .id == "codex@openai-codex" and .enabled == true)' >/dev/null 2>&1; then
+        CODEX_PLUGIN_ENABLED=true
+        CODEX_PLUGIN_INSTALL_PATH=$(printf '%s\n' "$CLAUDE_PLUGIN_LIST" | jq -r '[.[] | select(.id == "codex@openai-codex" and .enabled == true) | .installPath // empty][0] // empty')
+      fi
+    fi
+  elif CLAUDE_PLUGIN_LIST=$(claude plugin list 2>/dev/null); then
+    if printf '%s\n' "$CLAUDE_PLUGIN_LIST" | awk '/codex@openai-codex/ { found=1 } END { exit !found }'; then
+      CODEX_PLUGIN_LISTED=true
+      CODEX_PLUGIN_INSTALLED=true
+    fi
+    if printf '%s\n' "$CLAUDE_PLUGIN_LIST" | awk '
+      /codex@openai-codex/ { found=1; next }
+      found && /Status:/ { status_found=1; enabled=(index($0, "✔ enabled") > 0); exit }
+      END { exit !(status_found && enabled) }
+    '; then
+      CODEX_PLUGIN_ENABLED=true
+    fi
+  fi
+fi
+```
+
+Do not treat a marketplace checkout alone (`$CLAUDE_PLUGINS_DIR/marketplaces/openai-codex/...`) as installed; the commands are available only when `codex@openai-codex` is present in Claude Code's installed plugin registry. If enabled state cannot be queried, leave `CODEX_PLUGIN_ENABLED=false` and offer the inactive-plugin choice rather than assuming an installed plugin is active.
+
+### If `CODEX_PLUGIN_ENABLED=true`
+
+Route to the official plugin command and stop before the built-in CLI fallback:
+
+| Prompt type | Official route |
+|-------------|----------------|
+| Normal branch review | `/codex:review --base <base-ref> [--background|--wait]` |
+| Normal working-tree review | `/codex:review [--background|--wait]` |
+| Adversarial or challenge branch review | `/codex:adversarial-review --base <base-ref> [--background|--wait] <focus text>` |
+| Adversarial or challenge working-tree review | `/codex:adversarial-review [--background|--wait] <focus text>` |
+| Fix-oriented review or delegated task | `/codex:rescue [--background|--wait|--resume|--fresh|--model <id>|--effort <value>] <prompt>` |
+
+When routing reviews, auto-detect the base branch the same way Review Flow does:
+
+```bash
+BASE_BRANCH="${REQUESTED_BASE:-}"
+if [ -z "$BASE_BRANCH" ]; then
+  BASE_BRANCH=$(gh pr view --json baseRefName --jq '.baseRefName' 2>/dev/null || true)
+fi
+if [ -z "$BASE_BRANCH" ]; then
+  BASE_BRANCH=$(git symbolic-ref refs/remotes/origin/HEAD 2>/dev/null | sed 's|refs/remotes/origin/||' || true)
+fi
+if [ -z "$BASE_BRANCH" ]; then
+  BASE_BRANCH=$(git remote show origin 2>/dev/null | sed -n 's/.*HEAD branch: //p' | awk 'NF && $0 !~ /^\(.*\)$/ { print; exit }')
+fi
+if [ -z "$BASE_BRANCH" ]; then
+  BASE_BRANCH="main"
+fi
+```
+
+Include `--base <base-ref>` for branch reviews. Preserve only flags the official target command supports:
+
+| Official command | Preserve from prompt |
+|------------------|----------------------|
+| `/codex:review` | `--base <ref>`, `--background`, `--wait` |
+| `/codex:adversarial-review` | `--base <ref>`, `--background`, `--wait`, trailing focus text |
+| `/codex:rescue` | `--background`, `--wait`, `--resume`, `--fresh`, `--model`, `--effort` |
+
+Do not add model flags by default; the official plugin and Codex share the user's `~/.codex` auth and config. Do not append focus text to `/codex:review`; that command is not steerable. If the user asks for a focused challenge, risk, trade-off, or pressure-test review, route to `/codex:adversarial-review` instead.
+
+If the user asks to review the current working tree or uncommitted changes and did not provide `--base`, do not add it; let `/codex:review` or `/codex:adversarial-review` use its working-tree review mode. If `REQUESTED_BASE` is set, preserve it. Otherwise, if the user asks for a branch review or the prompt is simply "review", use `--base "$BASE_BRANCH"`.
+
+If this command runner cannot invoke another slash command from inside the current slash command, print the exact `/codex:*` command to run and stop. Also state that if the command is unavailable in the current session, the user should run `/reload-plugins` and retry, or rerun `/llm-tools:codex ... --ask` to choose the built-in CLI flow. Do not continue into the CLI fallback after a successful official-plugin route or after printing the official command.
+
+### If `CODEX_PLUGIN_INSTALLED=true` and `CODEX_PLUGIN_ENABLED=false`
+
+Warn the user that the official plugin is installed but disabled or not active in the current Claude Code configuration. Use `AskUserQuestion`: "The official Codex plugin is installed but inactive. How would you like to continue?"
+
+| Option | Description |
+|--------|-------------|
+| Enable or reload official plugin (Recommended) | Open `/plugin`, enable `codex@openai-codex`, run `/reload-plugins`, and retry |
+| Proceed with built-in CLI fallback | Continue to Step 3 and run the existing `codex exec` / `codex review` flow |
+
+If the user chooses the official plugin, print those enable/reload instructions and stop. If the user chooses fallback, continue below.
+
+### If `CODEX_PLUGIN_INSTALLED=false`
+
+Warn the user:
+
+> The official Codex Claude Code plugin (`codex@openai-codex`) is not installed. Interactive `/llm-tools:codex` use prefers that plugin for `/codex:review`, `/codex:adversarial-review`, and `/codex:rescue`. The built-in Codex CLI fallback is still available and unchanged.
+
+Use `AskUserQuestion`: "How would you like to continue?"
+
+| Option | Description |
+|--------|-------------|
+| Install official plugin (Recommended) | Show the install steps and stop so the user can reload plugins |
+| Proceed with built-in CLI fallback | Continue to Step 3 and run the existing `codex exec` / `codex review` flow |
+
+If the user chooses install, print exactly:
+
+```text
+/plugin marketplace add openai/codex-plugin-cc
+/plugin install codex@openai-codex
+/reload-plugins
+/codex:setup
+```
+
+Then stop. If the user chooses fallback, continue below.
+
+## 3. Detect Codex CLI Fallback
+
+Resolve the correct command for invoking Codex. This avoids exit code 127 on systems where `codex` is only available via `npx`:
+
+```bash
+if command -v codex &>/dev/null; then
+  CODEX_CMD="codex"
+else
+  CODEX_CMD="npx -y codex"
+fi
+```
+
+**Use `$CODEX_CMD` in place of bare `codex` for all built-in fallback commands below.**
+
+## 4. Review-Fix Detection (applies to both fallback flows)
 
 Before running Codex, detect if `$CODEX_PROMPT` is addressing review feedback (phrases like "fix review comment", "address feedback", "fix the issue from review", or the prompt originates from `/address-review`). If detected:
 
@@ -96,7 +268,7 @@ Before running Codex, detect if `$CODEX_PROMPT` is addressing review feedback (p
 
 ## Review Flow
 
-Used when the prompt is review-oriented (Step 1).
+Used by the built-in fallback when the prompt is review-oriented (Step 1).
 
 → Read `${CLAUDE_PLUGIN_ROOT}/lib/codex/review-flow.md` for the full procedure:
 
@@ -108,7 +280,7 @@ Used when the prompt is review-oriented (Step 1).
 
 ## Exec Flow
 
-Used for non-review tasks (and for fix-oriented review prompts from Step 1).
+Used by the built-in fallback for non-review tasks (and for fix-oriented review prompts from Step 1).
 
 → Read `${CLAUDE_PLUGIN_ROOT}/lib/codex/exec-flow.md` for the full procedure:
 

--- a/plugins/llm-tools/skills/second-opinion/SKILL.md
+++ b/plugins/llm-tools/skills/second-opinion/SKILL.md
@@ -47,7 +47,8 @@ When conditions are met, offer specific options:
 
 > This involves [type of decision]. Would you like a second opinion from another LLM?
 >
-> - `/codex review` - Get OpenAI's analysis
+> - `/codex:review` - Get OpenAI's analysis via the official Codex Claude Code plugin when installed
+> - `/llm-tools:codex review <scope>` - Use gopher-ai's Codex CLI fallback when the official plugin is missing or declined
 > - `/gemini <specific question>` - Ask Google Gemini
 > - `/ollama <question>` - Use a local model (keeps data private)
 > - `/llm-tools:review-loop --llm fable` - Fresh-context Claude subagent review (no external CLI, no extra cost)
@@ -55,16 +56,18 @@ When conditions are met, offer specific options:
 
 **Cross-model rule:** a second opinion is most valuable from a different model family than the one that wrote the code. If Claude wrote it, suggest codex/gemini/ollama first. If Codex wrote it (wtcodex flows), suggest the fable review. Never invoke Fable via `claude -p` — headless print mode bills metered API usage, not the subscription; use the subagent path (or a tmux-driven interactive Claude window when orchestrating from Codex).
 
+**Codex routing rule:** in Claude Code, prefer `/codex:review`, `/codex:adversarial-review`, or `/codex:rescue` from `codex@openai-codex` when that official plugin is installed. If it is not installed, use `/llm-tools:codex ...`; that command warns, prints the official plugin install steps, and can proceed with the existing Codex CLI fallback.
+
 **Tailor the suggestion to the context:**
 
 For security-sensitive code:
-> Since this involves authentication logic, you might want a second security review. Try `/codex review` or `/ollama` (keeps code local) for another perspective.
+> Since this involves authentication logic, you might want a second security review. Try `/codex:adversarial-review` if the official Codex plugin is installed, `/llm-tools:codex review` for the CLI fallback, or `/ollama` (keeps code local) for another perspective.
 
 For architectural decisions:
 > This is a significant architectural choice. Different models sometimes weigh trade-offs differently. Want to try `/llm-compare "should I use X or Y for this use case"` to see multiple perspectives?
 
 For complex algorithms:
-> This algorithm has some complexity. A second set of eyes might catch edge cases. Try `/codex explain the edge cases in this algorithm`.
+> This algorithm has some complexity. A second set of eyes might catch edge cases. Try `/codex:rescue explain the edge cases in this algorithm` if the official Codex plugin is installed, or `/llm-tools:codex explain the edge cases in this algorithm` for the CLI fallback.
 
 ## When NOT to Suggest
 
@@ -88,9 +91,10 @@ When suggesting, be specific about which command fits best:
 
 | Situation | Best Command |
 |-----------|--------------|
-| Code review | `/codex review` |
+| Code review | `/codex:review` when installed; otherwise `/llm-tools:codex review` |
+| Challenge review | `/codex:adversarial-review` when installed; otherwise `/llm-tools:codex review --ask` |
 | Code written by Codex | `/llm-tools:review-loop --llm fable` (cross-model: Claude reviews Codex's work) |
 | Quick question | `/gemini <question>` |
 | Sensitive/private code | `/ollama <question>` |
 | Want multiple views | `/llm-compare <question>` |
-| Complex reasoning task | `/codex` or `/ollama` with larger models |
+| Complex reasoning task | `/codex:rescue` when installed; otherwise `/llm-tools:codex` or `/ollama` with larger models |

--- a/scripts/legacy-skill-hashes.txt
+++ b/scripts/legacy-skill-hashes.txt
@@ -7,7 +7,7 @@
 # this prevents accepting a hash from skill A as proof of ownership for skill B.
 # DO NOT EDIT BY HAND — re-run the regen script after committing SKILL.md changes.
 #
-# Total entries: 224
+# Total entries: 225
 017e2d820506e7bef4a89a4d65839150db1ffdc124852a43dc916023e6d37e16 review-deep
 0322d4a7ddc204a9bf5addfec4e512edaea92ab8f4ebdd0541ca099330a09408 worktree
 03dac3a27d6da4b0a0c64ff6511df17004747e20b47a1691b4f9f030478877b9 commit
@@ -143,6 +143,7 @@
 987e6c4bc5ab7429668f8f7a34afc4b1a1dc3b72c162253b906da8b21e53378e gemini-image
 99815b40806a1a98fe32252f38641f1d116e0c95828dd30e74296c669456cad5 e2e-verify
 9a87d3e2d6c3590b71df03c524b3993a6dd2618e151cb227d29a59ae5bbdd9e8 go-code-organization
+9b00bc9c9a0ed642feacfde94fd3b540bc8a023ee28c76d3e5e3e764213f3e10 second-opinion
 9fd7491065e05d6c0a41db0c196d74069c24d305e2d069c8831d7a9729f18d07 gopher-guides
 a164e2b1f11394ae1ed9483327be26cabf4f6312ce041058a88e971be5806a6f e2e-verify
 a1a6f04b281f1bcfbe8fde80103929966af8f70bda1c911778aac492046cf46f start-issue


### PR DESCRIPTION
## Summary

- Prefer the official `codex@openai-codex` plugin for interactive review and delegation while retaining the existing Codex CLI fallback.
- Detect installed, enabled, inactive, and missing plugin states; preserve supported official-command flags and explicit review bases.
- Update second-opinion guidance and llm-tools documentation with official plugin setup, fallback behavior, and shared Codex auth/config.

## Test Plan

- `./scripts/test-commands.sh`
- Bash syntax and ShellCheck for every shell block in `plugins/llm-tools/commands/codex.md`
- Detection/routing fixtures for active, inactive, missing, no-jq/no-rg, explicit-base, placeholder-base, and non-main-default cases
- Full configured validation gate, including hook tests, ship E2E gate tests, shared sync, shellcheck, skill metadata/YAML checks, and demo Go build/tests

Fixes #200