### PR TITLE
fix(release): verify artifacts before publishing

### DIFF
--- a/plugins/productivity/commands/release.md
+++ b/plugins/productivity/commands/release.md
@@ -1,7 +1,7 @@
 ---
 argument-hint: "[patch|minor|major]"
 description: "Create a new release with version bump, changelog, and GitHub release"
-allowed-tools: ["Bash(git:*)", "Bash(gh:*)", "Bash(jq:*)", "Read", "Edit", "AskUserQuestion"]
+allowed-tools: ["Bash(git:*)", "Bash(gh:*)", "Bash(jq:*)", "Bash(bash:*)", "Bash(tar:*)", "Bash(sleep:*)", "Read", "Edit", "AskUserQuestion"]
 ---
 
 ## Context
@@ -31,6 +31,7 @@ Ask the user to confirm the bump type using AskUserQuestion before proceeding.
 1. **Validate State**
    - Ensure working directory is clean: `git status --porcelain`
    - Ensure we're on the main branch
+   - Fetch `origin/main` and require `HEAD` to equal `origin/main`
    - Ensure no uncommitted changes
 
 2. **Detect Changelog Strategy**
@@ -42,10 +43,10 @@ Ask the user to confirm the bump type using AskUserQuestion before proceeding.
    LAST_TAG=$(git describe --tags --abbrev=0 2>/dev/null || git rev-list --max-parents=0 HEAD)
 
    # Count total commits since last tag
-   TOTAL_COMMITS=$(git log ${LAST_TAG}..HEAD --oneline | wc -l | tr -d ' ')
+   TOTAL_COMMITS=$(git log "$LAST_TAG"..HEAD --oneline | wc -l | tr -d ' ')
 
    # Count commits with PR references like (#123)
-   PR_COMMITS=$(git log ${LAST_TAG}..HEAD --oneline | grep -E '\(#[0-9]+\)' | wc -l | tr -d ' ')
+   PR_COMMITS=$(git log "$LAST_TAG"..HEAD --oneline | awk '/\(#[0-9]+\)/ { count++ } END { print count+0 }')
 
    # Calculate percentage (avoid division by zero)
    if [ "$TOTAL_COMMITS" -gt 0 ]; then
@@ -82,28 +83,111 @@ Ask the user to confirm the bump type using AskUserQuestion before proceeding.
    done
    ```
 
-5. **Commit and Tag**
+   Verify every version source before continuing:
+
+   ```bash
+   jq -e --arg v "NEW_VERSION" '
+     .metadata.version == $v and all(.plugins[]; .version == $v)
+   ' .claude-plugin/marketplace.json >/dev/null
+
+   for pjson in plugins/*/.claude-plugin/plugin.json plugins/*/.codex-plugin/plugin.json; do
+     [ -f "$pjson" ] || continue
+     jq -e --arg v "NEW_VERSION" '.version == $v' "$pjson" >/dev/null
+   done
+   ```
+
+5. **Validate and Build**
+
+   Run the full repository gate before committing:
+
+   ```bash
+   bash -lc './scripts/test-installation.sh && ./scripts/test-commands.sh && ./scripts/test-hooks.sh && ./scripts/test-ship-e2e-gate.sh && ./scripts/check-shared-sync.sh && shellcheck agent-skills/scripts/*.sh && for skill_dir in agent-skills/skills/*/; do skill_name=$(basename "$skill_dir"); skill_file="$skill_dir/SKILL.md"; test -f "$skill_file"; lines=$(wc -l < "$skill_file"); test "$lines" -lt 500; name=$(sed -n "/^---$/,/^---$/p" "$skill_file" | awk "/^name:/ {print \$2; exit}"); test "$name" = "$skill_name"; rg -q "^description:" "$skill_file"; done && ruby -ryaml -e "YAML.load_file(ARGV[0])" agent-skills/config/severity.yaml && (cd agent-skills/examples/demo-repo && go build -o /tmp/gopher-ai-demo . && go test ./...)'
+   ./scripts/build-universal.sh
+   ```
+
+   Assert that the builder's exact archives exist and every packaged manifest
+   contains the requested version:
+
+   ```bash
+   VERSION="NEW_VERSION"
+   CODEX_ASSET="dist/gopher-ai-codex-plugins-v${VERSION}.tar.gz"
+   GEMINI_ASSET="dist/gopher-ai-gemini-extensions-v${VERSION}.tar.gz"
+
+   test -f "$CODEX_ASSET"
+   test -f "$GEMINI_ASSET"
+
+   CODEX_MANIFESTS=$(tar -tzf "$CODEX_ASSET" | rg '/\.codex-plugin/plugin\.json$')
+   test -n "$CODEX_MANIFESTS"
+   while IFS= read -r manifest; do
+     tar -xOzf "$CODEX_ASSET" "$manifest" | jq -e --arg v "$VERSION" '.version == $v' >/dev/null
+   done <<< "$CODEX_MANIFESTS"
+
+   GEMINI_MANIFESTS=$(tar -tzf "$GEMINI_ASSET" | rg '/gemini-extension\.json$')
+   test -n "$GEMINI_MANIFESTS"
+   while IFS= read -r manifest; do
+     tar -xOzf "$GEMINI_ASSET" "$manifest" | jq -e --arg v "$VERSION" '.version == $v' >/dev/null
+   done <<< "$GEMINI_MANIFESTS"
+   ```
+
+   Stop immediately if any command in this step fails. Do not commit, push,
+   tag, draft, or publish a release.
+
+6. **Commit and Push the Release Change**
+
    ```bash
    git add .claude-plugin/marketplace.json plugins/*/.claude-plugin/plugin.json plugins/*/.codex-plugin/plugin.json
    git commit -m "chore: release vX.Y.Z"
-   git tag -a vX.Y.Z -m "Release vX.Y.Z"
+   RELEASE_SHA=$(git rev-parse HEAD)
+   git push origin HEAD:main
    ```
 
-6. **Push to Remote**
+7. **Wait for Release-Commit CI**
+
+   Poll check runs through GitHub's REST API and require checks for the exact
+   release commit. An empty check set is not success.
+
    ```bash
-   git push origin main
-   git push origin vX.Y.Z
+   CHECKS=""
+   for attempt in $(seq 1 24); do
+     CHECKS=$(gh api "repos/{owner}/{repo}/commits/${RELEASE_SHA}/check-runs")
+     [ "$(jq '.total_count' <<< "$CHECKS")" -gt 0 ] && break
+     sleep 5
+   done
+   test "$(jq '.total_count' <<< "$CHECKS")" -gt 0
+
+   for attempt in $(seq 1 60); do
+     CHECKS=$(gh api "repos/{owner}/{repo}/commits/${RELEASE_SHA}/check-runs")
+     FAILED=$(jq '[.check_runs[] | select(.status == "completed" and (.conclusion | IN("success", "neutral", "skipped") | not))] | length' <<< "$CHECKS")
+     PENDING=$(jq '[.check_runs[] | select(.status != "completed")] | length' <<< "$CHECKS")
+     test "$FAILED" -eq 0
+     [ "$PENDING" -eq 0 ] && break
+     sleep 10
+   done
+
+   GREEN_COUNT=$(jq '.total_count' <<< "$CHECKS")
+   sleep 10
+   CHECKS=$(gh api "repos/{owner}/{repo}/commits/${RELEASE_SHA}/check-runs")
+   test "$(jq '[.check_runs[] | select(.status != "completed")] | length' <<< "$CHECKS")" -eq 0
+   test "$(jq '[.check_runs[] | select(.conclusion | IN("success", "neutral", "skipped") | not)] | length' <<< "$CHECKS")" -eq 0
+   test "$(jq '.total_count' <<< "$CHECKS")" -eq "$GREEN_COUNT"
+   test "$(git rev-parse HEAD)" = "$RELEASE_SHA"
+   test "$(git ls-remote origin refs/heads/main | awk '{print $1}')" = "$RELEASE_SHA"
    ```
 
-7. **Create GitHub Release**
+   Stop if checks do not register within two minutes, fail, remain incomplete,
+   or if `HEAD` changes. Do not create a tag, draft, or published release.
 
-   Use the strategy detected in step 2:
+8. **Create and Verify a Draft Release**
+
+   Use the strategy detected in step 2. Create a draft targeted at the exact
+   CI-verified commit and upload both already-verified archives in the same
+   command. GitHub creates the tag from that commit when the draft is published.
 
    #### Strategy A: PR-Based Workflow (≥50% PR references)
 
    Use GitHub's auto-generated notes which work well for PR-based repos:
    ```bash
-   gh release create vX.Y.Z --title "vX.Y.Z" --generate-notes
+   gh release create vX.Y.Z --draft --target "$RELEASE_SHA" --title "vX.Y.Z" --generate-notes "$CODEX_ASSET" "$GEMINI_ASSET"
    ```
 
    #### Strategy B: Conventional Commits (<50% PR references)
@@ -120,7 +204,7 @@ Ask the user to confirm the bump type using AskUserQuestion before proceeding.
    4. Pass via `--notes` flag:
 
    ```bash
-   gh release create vX.Y.Z --title "vX.Y.Z" --notes "$(cat <<'EOF'
+   gh release create vX.Y.Z --draft --target "$RELEASE_SHA" --title "vX.Y.Z" --notes "$(cat <<'EOF'
    ## What's Changed
 
    ### Features
@@ -131,7 +215,7 @@ Ask the user to confirm the bump type using AskUserQuestion before proceeding.
 
    **Full Changelog**: https://github.com/OWNER/REPO/compare/vOLD...vNEW
    EOF
-   )"
+   )" "$CODEX_ASSET" "$GEMINI_ASSET"
    ```
 
    **Formatting rules for conventional commits:**
@@ -140,21 +224,39 @@ Ask the user to confirm the bump type using AskUserQuestion before proceeding.
    - Skip the release commit itself (`chore: release`)
    - Omit empty sections
 
-8. **Build Universal Distribution**
+   Verify the release is still a draft, targets the checked commit, and has
+   exactly the expected assets:
+
    ```bash
-   ./scripts/build-universal.sh
+   RELEASE=$(gh api --paginate --slurp "repos/{owner}/{repo}/releases" | jq --arg tag "vX.Y.Z" 'add | map(select(.tag_name == $tag)) | first')
+   test "$(jq -r '.draft' <<< "$RELEASE")" = "true"
+   test "$(jq -r '.target_commitish' <<< "$RELEASE")" = "$RELEASE_SHA"
+   jq -e --arg codex "${CODEX_ASSET##*/}" --arg gemini "${GEMINI_ASSET##*/}" '
+     (.assets | length) == 2 and
+     ([.assets[].name] | sort) == ([$codex, $gemini] | sort)
+   ' <<< "$RELEASE" >/dev/null
+   RELEASE_ID=$(jq -r '.id' <<< "$RELEASE")
    ```
 
-   Upload platform-specific archives as release assets:
+9. **Publish**
+
+   Publish only the fully verified draft:
+
    ```bash
-   gh release upload vX.Y.Z dist/gopher-ai-codex-skills-vX.Y.Z.tar.gz
-   gh release upload vX.Y.Z dist/gopher-ai-gemini-extensions-vX.Y.Z.tar.gz
+   gh api --method PATCH "repos/{owner}/{repo}/releases/${RELEASE_ID}" -F draft=false >/dev/null
+   PUBLISHED=$(gh api "repos/{owner}/{repo}/releases/${RELEASE_ID}")
+   jq -e --arg tag "vX.Y.Z" --arg codex "${CODEX_ASSET##*/}" --arg gemini "${GEMINI_ASSET##*/}" '
+     (.draft | not) and .tag_name == $tag and
+     ([.assets[].name] | sort) == ([$codex, $gemini] | sort)
+   ' <<< "$PUBLISHED" >/dev/null
+   test "$(gh api "repos/{owner}/{repo}/git/ref/tags/vX.Y.Z" --jq '.object.sha')" = "$RELEASE_SHA"
+   jq '{draft, tag_name, html_url, assets: [.assets[].name]}' <<< "$PUBLISHED"
    ```
 
-9. **Report Success**
+10. **Report Success**
    - Display the release URL
    - Show which changelog strategy was used
-   - List uploaded assets (Codex skills, Gemini extensions)
+   - List uploaded assets (Codex plugins, Gemini extensions)
    - Remind user to run `./scripts/refresh-plugins.sh` to update local cache
 
 ### Safety Checks
@@ -163,6 +265,8 @@ Ask the user to confirm the bump type using AskUserQuestion before proceeding.
 - Always confirm bump type with user before proceeding
 - Verify main branch before releasing
 - Check that new version is greater than current version
+- Never create a tag or published release before the release commit's exact CI checks pass
+- Never publish a draft until both verified builder-produced assets are attached
 
 ### Example Usage
 

--- a/scripts/test-installation.sh
+++ b/scripts/test-installation.sh
@@ -143,6 +143,62 @@ else
   echo "OK"
 fi
 
+EXPECTED_VERSION=$(jq -r '.metadata.version' "$ROOT_DIR/.claude-plugin/marketplace.json")
+CODEX_RELEASE_ASSET="$ROOT_DIR/dist/gopher-ai-codex-plugins-v${EXPECTED_VERSION}.tar.gz"
+GEMINI_RELEASE_ASSET="$ROOT_DIR/dist/gopher-ai-gemini-extensions-v${EXPECTED_VERSION}.tar.gz"
+
+echo -n "Release command uses builder-produced asset names... "
+if ! rg -qF 'dist/gopher-ai-codex-plugins-v${VERSION}.tar.gz' "$ROOT_DIR/plugins/productivity/commands/release.md" ||
+   ! rg -qF 'dist/gopher-ai-gemini-extensions-v${VERSION}.tar.gz' "$ROOT_DIR/plugins/productivity/commands/release.md" ||
+   rg -qF 'gopher-ai-codex-skills-' "$ROOT_DIR/plugins/productivity/commands/release.md"; then
+  echo "FAIL"
+  ERRORS=$((ERRORS + 1))
+else
+  echo "OK"
+fi
+
+echo -n "Release archives exist with expected names and versions... "
+RELEASE_ASSET_ERRORS=""
+if [ ! -f "$CODEX_RELEASE_ASSET" ]; then
+  RELEASE_ASSET_ERRORS="$RELEASE_ASSET_ERRORS\n  missing ${CODEX_RELEASE_ASSET#"$ROOT_DIR"/}"
+else
+  CODEX_MANIFESTS=$(tar -tzf "$CODEX_RELEASE_ASSET" | rg '/\.codex-plugin/plugin\.json$' || true)
+  if [ -z "$CODEX_MANIFESTS" ]; then
+    RELEASE_ASSET_ERRORS="$RELEASE_ASSET_ERRORS\n  Codex archive has no plugin manifests"
+  else
+    while IFS= read -r manifest; do
+      ACTUAL_VERSION=$(tar -xOzf "$CODEX_RELEASE_ASSET" "$manifest" | jq -r '.version // empty')
+      if [ "$ACTUAL_VERSION" != "$EXPECTED_VERSION" ]; then
+        RELEASE_ASSET_ERRORS="$RELEASE_ASSET_ERRORS\n  $manifest ($ACTUAL_VERSION != $EXPECTED_VERSION)"
+      fi
+    done <<< "$CODEX_MANIFESTS"
+  fi
+fi
+
+if [ ! -f "$GEMINI_RELEASE_ASSET" ]; then
+  RELEASE_ASSET_ERRORS="$RELEASE_ASSET_ERRORS\n  missing ${GEMINI_RELEASE_ASSET#"$ROOT_DIR"/}"
+else
+  GEMINI_MANIFESTS=$(tar -tzf "$GEMINI_RELEASE_ASSET" | rg '/gemini-extension\.json$' || true)
+  if [ -z "$GEMINI_MANIFESTS" ]; then
+    RELEASE_ASSET_ERRORS="$RELEASE_ASSET_ERRORS\n  Gemini archive has no extension manifests"
+  else
+    while IFS= read -r manifest; do
+      ACTUAL_VERSION=$(tar -xOzf "$GEMINI_RELEASE_ASSET" "$manifest" | jq -r '.version // empty')
+      if [ "$ACTUAL_VERSION" != "$EXPECTED_VERSION" ]; then
+        RELEASE_ASSET_ERRORS="$RELEASE_ASSET_ERRORS\n  $manifest ($ACTUAL_VERSION != $EXPECTED_VERSION)"
+      fi
+    done <<< "$GEMINI_MANIFESTS"
+  fi
+fi
+
+if [ -n "$RELEASE_ASSET_ERRORS" ]; then
+  echo "FAIL"
+  printf '%b\n' "$RELEASE_ASSET_ERRORS"
+  ERRORS=$((ERRORS + 1))
+else
+  echo "OK"
+fi
+
 CODEX_MARKETPLACE="$ROOT_DIR/dist/codex/plugins/marketplace.json"
 echo -n "Codex marketplace is valid JSON... "
 if ! jq . "$CODEX_MARKETPLACE" >/dev/null 2>&1; then

--- a/scripts/test-installation.sh
+++ b/scripts/test-installation.sh
@@ -148,9 +148,9 @@ CODEX_RELEASE_ASSET="$ROOT_DIR/dist/gopher-ai-codex-plugins-v${EXPECTED_VERSION}
 GEMINI_RELEASE_ASSET="$ROOT_DIR/dist/gopher-ai-gemini-extensions-v${EXPECTED_VERSION}.tar.gz"
 
 echo -n "Release command uses builder-produced asset names... "
-if ! rg -qF 'dist/gopher-ai-codex-plugins-v${VERSION}.tar.gz' "$ROOT_DIR/plugins/productivity/commands/release.md" ||
-   ! rg -qF 'dist/gopher-ai-gemini-extensions-v${VERSION}.tar.gz' "$ROOT_DIR/plugins/productivity/commands/release.md" ||
-   rg -qF 'gopher-ai-codex-skills-' "$ROOT_DIR/plugins/productivity/commands/release.md"; then
+if ! awk 'index($0, "dist/gopher-ai-codex-plugins-v${VERSION}.tar.gz") { found=1 } END { exit found ? 0 : 1 }' "$ROOT_DIR/plugins/productivity/commands/release.md" ||
+   ! awk 'index($0, "dist/gopher-ai-gemini-extensions-v${VERSION}.tar.gz") { found=1 } END { exit found ? 0 : 1 }' "$ROOT_DIR/plugins/productivity/commands/release.md" ||
+   awk 'index($0, "gopher-ai-codex-skills-") { found=1 } END { exit found ? 0 : 1 }' "$ROOT_DIR/plugins/productivity/commands/release.md"; then
   echo "FAIL"
   ERRORS=$((ERRORS + 1))
 else
@@ -162,7 +162,7 @@ RELEASE_ASSET_ERRORS=""
 if [ ! -f "$CODEX_RELEASE_ASSET" ]; then
   RELEASE_ASSET_ERRORS="$RELEASE_ASSET_ERRORS\n  missing ${CODEX_RELEASE_ASSET#"$ROOT_DIR"/}"
 else
-  CODEX_MANIFESTS=$(tar -tzf "$CODEX_RELEASE_ASSET" | rg '/\.codex-plugin/plugin\.json$' || true)
+  CODEX_MANIFESTS=$(tar -tzf "$CODEX_RELEASE_ASSET" | awk '/\/\.codex-plugin\/plugin\.json$/' || true)
   if [ -z "$CODEX_MANIFESTS" ]; then
     RELEASE_ASSET_ERRORS="$RELEASE_ASSET_ERRORS\n  Codex archive has no plugin manifests"
   else
@@ -178,7 +178,7 @@ fi
 if [ ! -f "$GEMINI_RELEASE_ASSET" ]; then
   RELEASE_ASSET_ERRORS="$RELEASE_ASSET_ERRORS\n  missing ${GEMINI_RELEASE_ASSET#"$ROOT_DIR"/}"
 else
-  GEMINI_MANIFESTS=$(tar -tzf "$GEMINI_RELEASE_ASSET" | rg '/gemini-extension\.json$' || true)
+  GEMINI_MANIFESTS=$(tar -tzf "$GEMINI_RELEASE_ASSET" | awk '/\/gemini-extension\.json$/' || true)
   if [ -z "$GEMINI_MANIFESTS" ]; then
     RELEASE_ASSET_ERRORS="$RELEASE_ASSET_ERRORS\n  Gemini archive has no extension manifests"
   else


### PR DESCRIPTION
## Summary

- validate all version sources, full tests, universal builds, and embedded artifact versions before release commits
- wait for CI on the exact release commit before drafting any release
- upload verified builder-produced archives to a draft and publish only after REST verification
- add regression coverage for archive names and packaged manifest versions

## Test Plan

- `./scripts/test-installation.sh`
- extracted release shell blocks: `bash -n` and `shellcheck`
- configured Detent validation gate with `GOCACHE=/tmp/gopher-ai-go-build-cache`

Fixes #208