### PR TITLE
fix(gemini): close generated dependencies

### DIFF
--- a/scripts/build-universal.sh
+++ b/scripts/build-universal.sh
@@ -225,6 +225,8 @@ build_gemini() {
             done
         fi
 
+        copy_gemini_runtime_assets "$plugin_dir" "$ext_dir"
+
         if [[ -d "${plugin_dir}commands/" ]]; then
             for cmd_file in "${plugin_dir}commands/"*.md; do
                 if [[ -f "$cmd_file" ]]; then
@@ -233,9 +235,46 @@ build_gemini() {
                 fi
             done
         fi
+
+        rewrite_gemini_plugin_paths "$ext_dir" "gopher-ai-$plugin_name"
     done
 
+    "$ROOT_DIR/scripts/validate-gemini-extensions.sh" "$gemini_dir"
+
     echo "  Done: $gemini_dir"
+}
+
+copy_gemini_runtime_assets() {
+    local plugin_dir="$1"
+    local ext_dir="$2"
+    local runtime_dir
+
+    for runtime_dir in scripts lib templates references prompts schemas assets; do
+        if [[ -d "${plugin_dir}${runtime_dir}" ]]; then
+            cp -R "${plugin_dir}${runtime_dir}" "$ext_dir/"
+        fi
+    done
+}
+
+rewrite_gemini_plugin_paths() {
+    local ext_dir="$1"
+    local extension_name="$2"
+    local gemini_root="\$HOME/.gemini/extensions/$extension_name"
+    local file
+    local content
+
+    while IFS= read -r -d '' file; do
+        if ! grep -qE '\$\{?CLAUDE_PLUGIN_ROOT\}?' "$file" 2>/dev/null; then
+            continue
+        fi
+
+        content=$(cat "$file"; printf '\037')
+        content=${content%$'\037'}
+        content=${content//\$\{CLAUDE_PLUGIN_ROOT:-\}/$gemini_root}
+        content=${content//\$\{CLAUDE_PLUGIN_ROOT\}/$gemini_root}
+        content=${content//\$CLAUDE_PLUGIN_ROOT/$gemini_root}
+        printf '%s' "$content" > "$file"
+    done < <(find "$ext_dir" -type f -print0)
 }
 
 generate_gemini_extension_json() {

--- a/scripts/test-installation.sh
+++ b/scripts/test-installation.sh
@@ -260,6 +260,58 @@ else
   echo "OK ($GEMINI_COMMAND_COUNT commands)"
 fi
 
+echo -n "Gemini extensions are dependency-closed... "
+if ! "$ROOT_DIR/scripts/validate-gemini-extensions.sh" "$ROOT_DIR/dist/gemini" >/tmp/gopher-ai-gemini-validation.log 2>&1; then
+  echo "FAIL"
+  sed -n '1,120p' /tmp/gopher-ai-gemini-validation.log
+  ERRORS=$((ERRORS + 1))
+elif [ ! -x "$ROOT_DIR/dist/gemini/gopher-ai-go-workflow/scripts/worktree-create.sh" ] \
+  || [ ! -f "$ROOT_DIR/dist/gemini/gopher-ai-go-workflow/lib/ship/local-review.md" ] \
+  || [ ! -f "$ROOT_DIR/dist/gemini/gopher-ai-llm-tools/prompts/codex-review.md" ] \
+  || [ ! -f "$ROOT_DIR/dist/gemini/gopher-ai-go-web/templates/deploy/Dockerfile" ]; then
+  echo "FAIL (expected runtime asset is missing)"
+  ERRORS=$((ERRORS + 1))
+else
+  echo "OK"
+fi
+
+echo -n "Gemini validation rejects missing local assets... "
+TMP_GEMINI_DIST=$(mktemp -d)
+cp -R "$ROOT_DIR/dist/gemini/gopher-ai-go-workflow" "$TMP_GEMINI_DIST/"
+printf '%s\n' "\$HOME/.gemini/extensions/gopher-ai-go-workflow/scripts/not-present.sh" \
+  >> "$TMP_GEMINI_DIST/gopher-ai-go-workflow/commands/cancel-loop.toml"
+if "$ROOT_DIR/scripts/validate-gemini-extensions.sh" "$TMP_GEMINI_DIST" >/tmp/gopher-ai-gemini-missing.log 2>&1; then
+  echo "FAIL (missing asset was accepted)"
+  ERRORS=$((ERRORS + 1))
+elif ! grep -q 'scripts/not-present.sh' /tmp/gopher-ai-gemini-missing.log; then
+  echo "FAIL (missing asset diagnostic omitted the path)"
+  sed -n '1,40p' /tmp/gopher-ai-gemini-missing.log
+  ERRORS=$((ERRORS + 1))
+else
+  echo "OK"
+fi
+rm -rf "$TMP_GEMINI_DIST"
+
+echo -n "Installed Gemini helper-backed command runs... "
+TMP_GEMINI_HOME=$(mktemp -d)
+TMP_GEMINI_WORKSPACE=$(mktemp -d)
+mkdir -p "$TMP_GEMINI_HOME/.gemini/extensions"
+cp -R "$ROOT_DIR/dist/gemini/gopher-ai-go-workflow" "$TMP_GEMINI_HOME/.gemini/extensions/"
+GEMINI_CANCEL_TOML="$TMP_GEMINI_HOME/.gemini/extensions/gopher-ai-go-workflow/commands/cancel-loop.toml"
+GEMINI_CANCEL_COMMAND=$(awk '/^!\{if .*cleanup-loop[.]sh/ { sub(/^!\{/, ""); sub(/\}$/, ""); print; exit }' "$GEMINI_CANCEL_TOML")
+GEMINI_CANCEL_COMMAND=${GEMINI_CANCEL_COMMAND//\{\{args\}\}/gemini-smoke}
+if [ -z "$GEMINI_CANCEL_COMMAND" ]; then
+  echo "FAIL (generated helper command not found)"
+  ERRORS=$((ERRORS + 1))
+elif ! (cd "$TMP_GEMINI_WORKSPACE" && HOME="$TMP_GEMINI_HOME" bash -c "$GEMINI_CANCEL_COMMAND") >/tmp/gopher-ai-gemini-smoke.log 2>&1; then
+  echo "FAIL"
+  sed -n '1,40p' /tmp/gopher-ai-gemini-smoke.log
+  ERRORS=$((ERRORS + 1))
+else
+  echo "OK"
+fi
+rm -rf "$TMP_GEMINI_HOME" "$TMP_GEMINI_WORKSPACE"
+
 echo -n "Codex repo install writes matching marketplace entries... "
 TMP_REPO=$(mktemp -d)
 if ! "$ROOT_DIR/scripts/install-codex.sh" --repo "$TMP_REPO" >/tmp/gopher-ai-install-repo.log 2>&1; then

--- a/scripts/validate-gemini-extensions.sh
+++ b/scripts/validate-gemini-extensions.sh
@@ -1,0 +1,50 @@
+#!/bin/bash
+set -euo pipefail
+
+GEMINI_DIR="${1:?usage: validate-gemini-extensions.sh <gemini-dist-dir>}"
+ERRORS=0
+
+if grep -RInE '\$\{?CLAUDE_PLUGIN_ROOT\}?' "$GEMINI_DIR" 2>/dev/null; then
+  echo "Gemini artifacts contain unresolved CLAUDE_PLUGIN_ROOT references" >&2
+  ERRORS=$((ERRORS + 1))
+fi
+
+for extension_dir in "$GEMINI_DIR"/gopher-ai-*; do
+  [ -d "$extension_dir" ] || continue
+
+  manifest="$extension_dir/gemini-extension.json"
+  if [ ! -f "$manifest" ]; then
+    echo "Missing Gemini extension manifest: $manifest" >&2
+    ERRORS=$((ERRORS + 1))
+    continue
+  fi
+
+  extension_name=$(jq -r '.name // empty' "$manifest")
+  if [ -z "$extension_name" ]; then
+    echo "Gemini extension manifest has no name: $manifest" >&2
+    ERRORS=$((ERRORS + 1))
+    continue
+  fi
+
+  root_reference="\$HOME/.gemini/extensions/$extension_name/"
+  reference_pattern="\\\$HOME/\\.gemini/extensions/$extension_name/[A-Za-z0-9._/+*-]+"
+
+  while IFS= read -r reference; do
+    [ -n "$reference" ] || continue
+    relative_path=${reference#"$root_reference"}
+
+    if [[ "$relative_path" == *"*"* ]]; then
+      if ! compgen -G "$extension_dir/$relative_path" >/dev/null; then
+        echo "Missing Gemini extension glob target: $reference" >&2
+        ERRORS=$((ERRORS + 1))
+      fi
+    elif [ ! -e "$extension_dir/$relative_path" ]; then
+      echo "Missing Gemini extension asset: $reference" >&2
+      ERRORS=$((ERRORS + 1))
+    fi
+  done < <(grep -RhoE "$reference_pattern" "$extension_dir" 2>/dev/null | sort -u || true)
+done
+
+if [ "$ERRORS" -ne 0 ]; then
+  exit 1
+fi


### PR DESCRIPTION
## Summary

- Package plugin runtime assets in every generated Gemini extension.
- Rewrite Claude-only plugin roots to the documented Gemini installation path.
- Validate generated local references and smoke-test an installed helper-backed command.

## Test Plan

- `shellcheck scripts/build-universal.sh scripts/validate-gemini-extensions.sh scripts/test-installation.sh`
- `./scripts/build-universal.sh`
- `./scripts/test-installation.sh`
- Full configured Detent validation gate with `GOCACHE=/tmp/gopher-ai-207-gocache`

Fixes #207