### PR TITLE
fix(llm-tools): use official Codex package

### DIFF
--- a/plugins/go-workflow/hooks/legacy-skill-hashes.txt
+++ b/plugins/go-workflow/hooks/legacy-skill-hashes.txt
@@ -7,7 +7,7 @@
 # this prevents accepting a hash from skill A as proof of ownership for skill B.
 # DO NOT EDIT BY HAND — re-run the regen script after committing SKILL.md changes.
 #
-# Total entries: 225
+# Total entries: 226
 017e2d820506e7bef4a89a4d65839150db1ffdc124852a43dc916023e6d37e16 review-deep
 0322d4a7ddc204a9bf5addfec4e512edaea92ab8f4ebdd0541ca099330a09408 worktree
 03dac3a27d6da4b0a0c64ff6511df17004747e20b47a1691b4f9f030478877b9 commit
@@ -155,6 +155,7 @@ a5e9bb1aaa7b1fbde738b804ad01a1edb7448e4130abff090f0e7c40ee8339a2 ship
 a64bb750af511ed9f5bc8b7f492baad47146cd5bbe3d3f9eaf98d04c64f97cdf second-opinion
 a79c84ad7980d3b8e811c9bf0ff77958e8a8fe13f949a4fcbf250ef177d15a49 remove-worktree
 a9a73f15973539a88cb33abf81d1bf08163b8ff42d22eb224bf327e4de64166f htmx
+aed3553a2b51270c865c7a3d6c62e6c791277013a2eee0ae557edce6b225eba0 complete-issue
 b0d7852d81313df1d1e9a5c4775f3290e03b021aed7929b0e1738eabd9a1e126 tmux-start
 b0ec8df817d86bc436736b5acd26b23cabf2431b4860021d0c65e397f67c6a19 e2e-verify
 b265ee9a7d936f3dee025805cbd71f81a788e8e8716f13073343b3d32daf7994 gopher-guides

--- a/plugins/go-workflow/lib/ship/local-review.md
+++ b/plugins/go-workflow/lib/ship/local-review.md
@@ -18,11 +18,12 @@ The pass counter is incremented in Step 8 (after commit), not here. This prevent
 if [ "$LLM_CHOICE" = "codex" ] && [ -z "${CODEX_CMD:-}" ]; then
   if command -v codex &>/dev/null; then
     CODEX_CMD="codex"
-  elif npx -y codex --version &>/dev/null 2>&1; then
-    CODEX_CMD="npx -y codex"
   fi
 fi
 ```
+
+If `CODEX_CMD` is still empty, return to the Step 4 prerequisite flow. Do not
+download or execute a package during re-entry detection.
 
 ### 5a. Generate Diff
 

--- a/plugins/go-workflow/lib/ship/prerequisites.md
+++ b/plugins/go-workflow/lib/ship/prerequisites.md
@@ -11,8 +11,6 @@ LLM_AVAILABLE=true
 if [ "$LLM_CHOICE" = "codex" ]; then
   if command -v codex &>/dev/null; then
     CODEX_CMD="codex"
-  elif npx -y codex --version &>/dev/null 2>&1; then
-    CODEX_CMD="npx -y codex"
   else
     LLM_AVAILABLE=false
   fi
@@ -39,8 +37,7 @@ echo "=== LLM CLI Diagnostic ==="
 echo "LLM selected: $LLM_CHOICE"
 if [ "$LLM_CHOICE" = "codex" ]; then
   echo "codex in PATH: $(command -v codex 2>/dev/null || echo 'NOT FOUND')"
-  echo "npx codex: $(npx -y codex --version 2>/dev/null || echo 'FAILED')"
-  echo "OPENAI_API_KEY set: $([ -n "${OPENAI_API_KEY:-}" ] && echo 'yes' || echo 'NO')"
+  echo "Codex authentication: run 'codex login' for ChatGPT sign-in or API-key authentication"
 elif [ "$LLM_CHOICE" = "gemini" ]; then
   echo "gemini in PATH: $(command -v gemini 2>/dev/null || echo 'NOT FOUND')"
 elif [ "$LLM_CHOICE" = "ollama" ]; then
@@ -70,7 +67,7 @@ jq '.llm_check_failed = "true"' "$STATE_FILE" > "$TMP" && mv "$TMP" "$STATE_FILE
 
 ### Retry
 
-Re-run `command -v` / `npx` from above. On success:
+Re-run `command -v` from above. On success:
 
 ```bash
 TMP="$STATE_FILE.tmp"
@@ -84,7 +81,7 @@ options again.
 
 Display:
 
-- **codex:** `npm install -g @openai/codex` (and ensure `OPENAI_API_KEY` is set)
+- **codex:** `npm install -g @openai/codex`, then run `codex login` for ChatGPT sign-in or API-key authentication
 - **gemini:** `npm install -g @google/gemini-cli`
 - **ollama:** `brew install ollama && ollama serve`
 

--- a/plugins/go-workflow/skills/complete-issue/SKILL.md
+++ b/plugins/go-workflow/skills/complete-issue/SKILL.md
@@ -111,9 +111,6 @@ CODEX_AVAILABLE=false
 if command -v codex &>/dev/null; then
   CODEX_CMD="codex"
   CODEX_AVAILABLE=true
-elif npx -y codex --version &>/dev/null 2>&1; then
-  CODEX_CMD="npx -y codex"
-  CODEX_AVAILABLE=true
 fi
 ```
 

--- a/plugins/go-workflow/skills/complete-issue/codex-fallback.md
+++ b/plugins/go-workflow/skills/complete-issue/codex-fallback.md
@@ -19,7 +19,7 @@ Use `AskUserQuestion`:
 Handle the user's choice:
 
 - **Retry** → Re-run the availability check from `SKILL.md` Phase 2.
-- **Install instructions** → Display: `npm install -g @openai/codex` and ensure `OPENAI_API_KEY` is set. Then re-check.
+- **Install instructions** → Display: `npm install -g @openai/codex`, then run `codex login` for ChatGPT sign-in or API-key authentication. Then re-check.
 - **Use Fable subagent review** → Dispatch a fresh-context Agent subagent with the same review prompt and JSON schema contract (see the Fable section in go-workflow `lib/ship/local-review.md`); parse findings through the same structured path. Never use `claude -p` — it bills metered API usage, not the subscription.
 - **Skip review** → Warn "Self-review skipped — proceeding to E2E verification without code review." and go directly to Phase 3.
 

--- a/plugins/llm-tools/commands/codex.md
+++ b/plugins/llm-tools/commands/codex.md
@@ -246,15 +246,33 @@ Then stop. If the user chooses fallback, continue below.
 
 ## 3. Detect Codex CLI Fallback
 
-Resolve the correct command for invoking Codex. This avoids exit code 127 on systems where `codex` is only available via `npx`:
+Prefer an installed Codex executable. Availability checks must not download or
+execute an npm package:
 
 ```bash
 if command -v codex &>/dev/null; then
   CODEX_CMD="codex"
 else
-  CODEX_CMD="npx -y codex"
+  CODEX_CMD=""
 fi
 ```
+
+If `CODEX_CMD` is empty, use `AskUserQuestion`:
+
+> **"Codex CLI is not installed. How would you like to continue?"**
+
+| Option | Description |
+|--------|-------------|
+| **Run official package once** | Explicitly consent to run `npx -y @openai/codex` for this request only |
+| **Install Codex** | Show `npm install -g @openai/codex`, then stop so the user can authenticate and retry |
+| **Abort** | Stop without running Codex or downloading a package |
+
+- **Run official package once** → first verify `npx` is available without
+  invoking Codex. If it is, set `CODEX_CMD="npx -y @openai/codex"` and continue.
+  If it is unavailable, show the install option and stop.
+- **Install Codex** → show `npm install -g @openai/codex`. Explain that
+  `codex login` supports ChatGPT sign-in and API-key authentication, then stop.
+- **Abort** → stop. Do not run Codex or invoke `npx`.
 
 **Use `$CODEX_CMD` in place of bare `codex` for all built-in fallback commands below.**
 

--- a/plugins/llm-tools/commands/llm-compare.md
+++ b/plugins/llm-tools/commands/llm-compare.md
@@ -36,12 +36,10 @@ Compare responses from multiple LLMs for: `$ARGUMENTS`.
 For each selected, verify availability:
 
 ```bash
-# Codex with npx fallback
+# Codex must already be installed for this automated comparison
 CODEX_AVAILABLE=false
 if command -v codex &>/dev/null; then
   CODEX_CMD="codex"; CODEX_AVAILABLE=true
-elif npx -y codex --version &>/dev/null 2>&1; then
-  CODEX_CMD="npx -y codex"; CODEX_AVAILABLE=true
 fi
 command -v gemini >/dev/null 2>&1 && GEMINI_AVAILABLE=true || GEMINI_AVAILABLE=false
 command -v ollama >/dev/null 2>&1 && OLLAMA_AVAILABLE=true || OLLAMA_AVAILABLE=false
@@ -59,6 +57,10 @@ If a user-selected LLM is unavailable, do NOT silently skip. Use `AskUserQuestio
 | **Abort** | Stop the comparison |
 
 Only skip if the user explicitly chooses "Skip this LLM".
+
+For Codex installation guidance, show `npm install -g @openai/codex`. Explain
+that `codex login` supports ChatGPT sign-in and API-key authentication. Do not
+download or execute a package as part of the availability check.
 
 ## 2. Select Models (Optional)
 

--- a/plugins/llm-tools/commands/review-loop.md
+++ b/plugins/llm-tools/commands/review-loop.md
@@ -32,7 +32,6 @@ Verify the selected LLM CLI is installed. **CRITICAL: Never silently fail or fal
 LLM_AVAILABLE=true
 case "$LLM_CHOICE" in
   codex)  command -v codex >/dev/null 2>&1 && CODEX_CMD="codex" \
-            || (npx -y codex --version >/dev/null 2>&1 && CODEX_CMD="npx -y codex") \
             || LLM_AVAILABLE=false ;;
   gemini) command -v gemini >/dev/null 2>&1 || LLM_AVAILABLE=false ;;
   ollama) command -v ollama >/dev/null 2>&1 || LLM_AVAILABLE=false ;;

--- a/plugins/llm-tools/lib/review-loop/prerequisites.md
+++ b/plugins/llm-tools/lib/review-loop/prerequisites.md
@@ -10,8 +10,7 @@ echo "=== LLM CLI Diagnostic ==="
 echo "LLM selected: $LLM_CHOICE"
 if [ "$LLM_CHOICE" = "codex" ]; then
   echo "codex in PATH: $(command -v codex 2>/dev/null || echo 'NOT FOUND')"
-  echo "npx codex: $(npx -y codex --version 2>/dev/null || echo 'FAILED')"
-  echo "OPENAI_API_KEY set: $([ -n "${OPENAI_API_KEY:-}" ] && echo 'yes' || echo 'NO')"
+  echo "Codex authentication: run 'codex login' for ChatGPT sign-in or API-key authentication"
 elif [ "$LLM_CHOICE" = "gemini" ]; then
   echo "gemini in PATH: $(command -v gemini 2>/dev/null || echo 'NOT FOUND')"
 elif [ "$LLM_CHOICE" = "ollama" ]; then
@@ -35,7 +34,7 @@ echo "========================="
 
 **Debug / Install instructions** → display:
 
-- **codex:** `npm install -g @openai/codex` and ensure `OPENAI_API_KEY` is set
+- **codex:** `npm install -g @openai/codex`, then run `codex login` for ChatGPT sign-in or API-key authentication
 - **gemini:** `npm install -g @google/gemini-cli`
 - **ollama:** `brew install ollama && ollama serve`
 

--- a/scripts/legacy-skill-hashes.txt
+++ b/scripts/legacy-skill-hashes.txt
@@ -7,7 +7,7 @@
 # this prevents accepting a hash from skill A as proof of ownership for skill B.
 # DO NOT EDIT BY HAND — re-run the regen script after committing SKILL.md changes.
 #
-# Total entries: 225
+# Total entries: 226
 017e2d820506e7bef4a89a4d65839150db1ffdc124852a43dc916023e6d37e16 review-deep
 0322d4a7ddc204a9bf5addfec4e512edaea92ab8f4ebdd0541ca099330a09408 worktree
 03dac3a27d6da4b0a0c64ff6511df17004747e20b47a1691b4f9f030478877b9 commit
@@ -155,6 +155,7 @@ a5e9bb1aaa7b1fbde738b804ad01a1edb7448e4130abff090f0e7c40ee8339a2 ship
 a64bb750af511ed9f5bc8b7f492baad47146cd5bbe3d3f9eaf98d04c64f97cdf second-opinion
 a79c84ad7980d3b8e811c9bf0ff77958e8a8fe13f949a4fcbf250ef177d15a49 remove-worktree
 a9a73f15973539a88cb33abf81d1bf08163b8ff42d22eb224bf327e4de64166f htmx
+aed3553a2b51270c865c7a3d6c62e6c791277013a2eee0ae557edce6b225eba0 complete-issue
 b0d7852d81313df1d1e9a5c4775f3290e03b021aed7929b0e1738eabd9a1e126 tmux-start
 b0ec8df817d86bc436736b5acd26b23cabf2431b4860021d0c65e397f67c6a19 e2e-verify
 b265ee9a7d936f3dee025805cbd71f81a788e8e8716f13073343b3d32daf7994 gopher-guides

--- a/scripts/test-commands.sh
+++ b/scripts/test-commands.sh
@@ -44,6 +44,59 @@ for file in $COMMAND_FILES; do
   fi
 done
 
+echo -n "Codex fallback commands use the official package safely... "
+UNSCOPED_CODEX=$(rg -n --pcre2 'npx[^`\n]*(?<!@openai/)\bcodex\b' "$ROOT_DIR/plugins" || true)
+CODEX_COMMAND="$ROOT_DIR/plugins/llm-tools/commands/codex.md"
+NONINTERACTIVE_CODEX_FILES=(
+  "$ROOT_DIR/plugins/llm-tools/commands/review-loop.md"
+  "$ROOT_DIR/plugins/llm-tools/commands/llm-compare.md"
+  "$ROOT_DIR/plugins/go-workflow/skills/complete-issue/SKILL.md"
+  "$ROOT_DIR/plugins/go-workflow/lib/ship/prerequisites.md"
+  "$ROOT_DIR/plugins/go-workflow/lib/ship/local-review.md"
+)
+MISSING_INSTALLED_CHECK=""
+for file in "${NONINTERACTIVE_CODEX_FILES[@]}"; do
+  if ! rg -q 'command -v codex' "$file"; then
+    MISSING_INSTALLED_CHECK="${file#"$ROOT_DIR"/}"
+    break
+  fi
+done
+MISSING_AUTH_GUIDANCE=""
+AUTH_GUIDANCE_FILES=(
+  "$ROOT_DIR/plugins/llm-tools/lib/review-loop/prerequisites.md"
+  "$ROOT_DIR/plugins/go-workflow/lib/ship/prerequisites.md"
+  "$ROOT_DIR/plugins/go-workflow/skills/complete-issue/codex-fallback.md"
+)
+for file in "${AUTH_GUIDANCE_FILES[@]}"; do
+  if ! rg -q 'ChatGPT sign-in or API-key authentication' "$file"; then
+    MISSING_AUTH_GUIDANCE="${file#"$ROOT_DIR"/}"
+    break
+  fi
+done
+
+if [ -n "$UNSCOPED_CODEX" ]; then
+  echo "FAIL (unscoped npm Codex invocation found)"
+  echo "$UNSCOPED_CODEX"
+  ERRORS=$((ERRORS + 1))
+elif [ -n "$MISSING_INSTALLED_CHECK" ]; then
+  echo "FAIL (installed Codex preference missing from $MISSING_INSTALLED_CHECK)"
+  ERRORS=$((ERRORS + 1))
+elif rg -q 'npx[^`\n]*@openai/codex' "${NONINTERACTIVE_CODEX_FILES[@]}"; then
+  echo "FAIL (non-interactive workflow downloads Codex)"
+  ERRORS=$((ERRORS + 1))
+elif ! rg -q 'CODEX_CMD="npx -y @openai/codex"' "$CODEX_COMMAND"; then
+  echo "FAIL (accepted run-once fallback missing)"
+  ERRORS=$((ERRORS + 1))
+elif ! rg -q '\*\*Abort\*\*.*without running Codex or downloading a package' "$CODEX_COMMAND"; then
+  echo "FAIL (declined run-once behavior missing)"
+  ERRORS=$((ERRORS + 1))
+elif [ -n "$MISSING_AUTH_GUIDANCE" ]; then
+  echo "FAIL (Codex authentication guidance missing from $MISSING_AUTH_GUIDANCE)"
+  ERRORS=$((ERRORS + 1))
+else
+  echo "OK"
+fi
+
 echo -n "Command files have valid YAML frontmatter... "
 if [ $ERRORS -gt 0 ]; then
   echo "FAIL ($ERRORS of $TOTAL)"

--- a/scripts/test-commands.sh
+++ b/scripts/test-commands.sh
@@ -45,7 +45,7 @@ for file in $COMMAND_FILES; do
 done
 
 echo -n "Codex fallback commands use the official package safely... "
-UNSCOPED_CODEX=$(rg -n --pcre2 'npx[^`\n]*(?<!@openai/)\bcodex\b' "$ROOT_DIR/plugins" || true)
+UNSCOPED_CODEX=$(grep -RInE 'npx[^`]*codex' "$ROOT_DIR/plugins" | grep -v '@openai/codex' || true)
 CODEX_COMMAND="$ROOT_DIR/plugins/llm-tools/commands/codex.md"
 NONINTERACTIVE_CODEX_FILES=(
   "$ROOT_DIR/plugins/llm-tools/commands/review-loop.md"
@@ -56,7 +56,7 @@ NONINTERACTIVE_CODEX_FILES=(
 )
 MISSING_INSTALLED_CHECK=""
 for file in "${NONINTERACTIVE_CODEX_FILES[@]}"; do
-  if ! rg -q 'command -v codex' "$file"; then
+  if ! grep -q 'command -v codex' "$file"; then
     MISSING_INSTALLED_CHECK="${file#"$ROOT_DIR"/}"
     break
   fi
@@ -68,7 +68,7 @@ AUTH_GUIDANCE_FILES=(
   "$ROOT_DIR/plugins/go-workflow/skills/complete-issue/codex-fallback.md"
 )
 for file in "${AUTH_GUIDANCE_FILES[@]}"; do
-  if ! rg -q 'ChatGPT sign-in or API-key authentication' "$file"; then
+  if ! grep -q 'ChatGPT sign-in or API-key authentication' "$file"; then
     MISSING_AUTH_GUIDANCE="${file#"$ROOT_DIR"/}"
     break
   fi
@@ -81,13 +81,13 @@ if [ -n "$UNSCOPED_CODEX" ]; then
 elif [ -n "$MISSING_INSTALLED_CHECK" ]; then
   echo "FAIL (installed Codex preference missing from $MISSING_INSTALLED_CHECK)"
   ERRORS=$((ERRORS + 1))
-elif rg -q 'npx[^`\n]*@openai/codex' "${NONINTERACTIVE_CODEX_FILES[@]}"; then
+elif grep -qE 'npx[^`]*@openai/codex' "${NONINTERACTIVE_CODEX_FILES[@]}"; then
   echo "FAIL (non-interactive workflow downloads Codex)"
   ERRORS=$((ERRORS + 1))
-elif ! rg -q 'CODEX_CMD="npx -y @openai/codex"' "$CODEX_COMMAND"; then
+elif ! grep -q 'CODEX_CMD="npx -y @openai/codex"' "$CODEX_COMMAND"; then
   echo "FAIL (accepted run-once fallback missing)"
   ERRORS=$((ERRORS + 1))
-elif ! rg -q '\*\*Abort\*\*.*without running Codex or downloading a package' "$CODEX_COMMAND"; then
+elif ! grep -q '\*\*Abort\*\*.*without running Codex or downloading a package' "$CODEX_COMMAND"; then
   echo "FAIL (declined run-once behavior missing)"
   ERRORS=$((ERRORS + 1))
 elif [ -n "$MISSING_AUTH_GUIDANCE" ]; then


### PR DESCRIPTION
## Summary

- require an installed Codex CLI in automated workflows instead of probing npm
- offer the official `@openai/codex` package only as an explicitly consented interactive run-once fallback
- document ChatGPT and API-key authentication paths and add regression coverage

## Test Plan

- `bash scripts/test-commands.sh`
- configured full validation gate with `GOCACHE=/tmp/gopher-ai-go-cache`
- regression scan for unscoped `npx ... codex` invocations

Fixes #210