### PR TITLE
fix(tmux-start): match issue windows exactly

### DIFF
--- a/plugins/go-workflow/scripts/tmux-start.sh
+++ b/plugins/go-workflow/scripts/tmux-start.sh
@@ -32,6 +32,28 @@ slugify_window() {
     | sed 's/-$//'
 }
 
+find_existing_window() {
+  local canonical_name="$1"
+  local legacy_name="$2"
+  local canonical_match=""
+  local legacy_match=""
+  local window_name
+
+  while IFS= read -r window_name; do
+    if [ "$window_name" = "$canonical_name" ] && [ -z "$canonical_match" ]; then
+      canonical_match="$window_name"
+    elif [ "$window_name" = "$legacy_name" ] && [ -z "$legacy_match" ]; then
+      legacy_match="$window_name"
+    fi
+  done
+
+  if [ -n "$canonical_match" ]; then
+    printf '%s\n' "$canonical_match"
+  elif [ -n "$legacy_match" ]; then
+    printf '%s\n' "$legacy_match"
+  fi
+}
+
 wait_for_claude_ready() {
   local window_name="$1"
   local launch_marker="$2"
@@ -57,6 +79,10 @@ wait_for_claude_ready() {
   done
   return 1
 }
+
+if [ "${GOPHER_AI_TMUX_START_SOURCE_ONLY:-false}" = "true" ]; then
+  return 0
+fi
 
 case "${1:-}" in
   -h|--help)
@@ -136,7 +162,8 @@ WINDOW_SLUG=$(slugify_window "$ITEM_TITLE")
 [ -n "$WINDOW_SLUG" ] || WINDOW_SLUG="$ISSUE_NUM"
 WINDOW_NAME="${REPO_NAME}-issue-${ISSUE_NUM}-${WINDOW_SLUG}"
 
-EXISTING_WINDOW=$(tmux list-windows -F '#{window_name}' 2>/dev/null | grep -F "${REPO_NAME}-issue-${ISSUE_NUM}" | head -1 || true)
+LEGACY_WINDOW_NAME="${REPO_NAME}-issue-${ISSUE_NUM}"
+EXISTING_WINDOW=$(tmux list-windows -F '#{window_name}' 2>/dev/null | find_existing_window "$WINDOW_NAME" "$LEGACY_WINDOW_NAME" || true)
 if [ -n "$EXISTING_WINDOW" ]; then
   tmux select-window -t "$EXISTING_WINDOW"
   echo "Switched to existing tmux window: $EXISTING_WINDOW"

--- a/scripts/test-commands.sh
+++ b/scripts/test-commands.sh
@@ -97,6 +97,38 @@ else
   echo "OK"
 fi
 
+echo -n "tmux-start matches issue windows exactly... "
+GOPHER_AI_TMUX_START_SOURCE_ONLY=true source "$ROOT_DIR/plugins/go-workflow/scripts/tmux-start.sh"
+TMUX_MATCH_FAILURE=""
+TMUX_CANONICAL="gopher-ai-issue-12-fix-window-match"
+TMUX_LEGACY="gopher-ai-issue-12"
+
+assert_tmux_match() {
+  local description="$1"
+  local expected="$2"
+  local windows="$3"
+  local actual
+
+  actual=$(printf '%s\n' "$windows" | find_existing_window "$TMUX_CANONICAL" "$TMUX_LEGACY")
+  if [ "$actual" != "$expected" ]; then
+    TMUX_MATCH_FAILURE="$description: expected '$expected', got '$actual'"
+  fi
+}
+
+assert_tmux_match "canonical match" "$TMUX_CANONICAL" "$TMUX_CANONICAL"
+assert_tmux_match "numeric prefix collision" "" $'gopher-ai-issue-1-old\ngopher-ai-issue-120-old\ngopher-ai-issue-123-old'
+assert_tmux_match "repository collision" "" "another-repo-issue-12-fix-window-match"
+assert_tmux_match "no match" "" "unrelated-window"
+assert_tmux_match "legacy match" "$TMUX_LEGACY" "$TMUX_LEGACY"
+assert_tmux_match "canonical priority" "$TMUX_CANONICAL" $'gopher-ai-issue-12\ngopher-ai-issue-12-fix-window-match'
+
+if [ -n "$TMUX_MATCH_FAILURE" ]; then
+  echo "FAIL ($TMUX_MATCH_FAILURE)"
+  ERRORS=$((ERRORS + 1))
+else
+  echo "OK"
+fi
+
 echo -n "Command files have valid YAML frontmatter... "
 if [ $ERRORS -gt 0 ]; then
   echo "FAIL ($ERRORS of $TOTAL)"


### PR DESCRIPTION
## Summary

- require exact canonical or legacy tmux issue-window names
- prefer the canonical slugged window when multiple valid matches exist
- cover prefix, repository, no-match, legacy, and multiple-match fixtures without a live tmux session

## Test plan

- `bash -n plugins/go-workflow/scripts/tmux-start.sh scripts/test-commands.sh`
- `shellcheck plugins/go-workflow/scripts/tmux-start.sh`
- `./scripts/test-commands.sh`
- configured full validation gate with a sandbox-safe `GOCACHE`

Fixes #212