### PR TITLE
feat(review): add adaptive planning

### DIFF
--- a/plugins/go-workflow/hooks/legacy-skill-hashes.txt
+++ b/plugins/go-workflow/hooks/legacy-skill-hashes.txt
@@ -7,7 +7,7 @@
 # this prevents accepting a hash from skill A as proof of ownership for skill B.
 # DO NOT EDIT BY HAND — re-run the regen script after committing SKILL.md changes.
 #
-# Total entries: 226
+# Total entries: 228
 017e2d820506e7bef4a89a4d65839150db1ffdc124852a43dc916023e6d37e16 review-deep
 0322d4a7ddc204a9bf5addfec4e512edaea92ab8f4ebdd0541ca099330a09408 worktree
 03dac3a27d6da4b0a0c64ff6511df17004747e20b47a1691b4f9f030478877b9 commit
@@ -212,6 +212,7 @@ e338c2bc546babcb73c9a8f9e1b15a1953a9203b7233cbfe089054472302f665 gopher-guides
 e7398cc9bf011c03689c56e89b5eba0c52f2d73bd2fcf4619180514f16e76874 complete-issue
 e9e3f59c460f8bff37ec6c7744012902611be5c9f5b63848bc929087cad9d5fe tmux-start
 ea5d1a65f4268ec942d60826f1c97912ad91abe3f39d415f3c4160beedfa3ccb gemini-image
+eb14317761223c517e5bff629e7e8933505f50eb10b3adf809eb08122456f311 review-deep
 ed50c1c5b29b003f54116cfe28f02b20c762dcc6ddba100ddbaef593ac3b72b4 go-error-handling
 edfed0bd039ddc1e1e2dd5399c8692e2cfed148fadd3a32122eba997c9623219 go-code-organization
 ef18dd0b566badecc14918a46ec9cb2a2a1d0a97a5804705571cd6847c894c03 go-profiling-optimization

--- a/plugins/go-workflow/lib/review-planning.md
+++ b/plugins/go-workflow/lib/review-planning.md
@@ -1,0 +1,48 @@
+# Adaptive Review Planning
+
+All review entry points use `scripts/review-plan.sh`; do not recreate size guards in callers.
+
+Run the planner before invoking a reviewer:
+
+```bash
+REVIEW_PLAN_ARGS=(
+  --base "$REVIEW_BASE"
+  --backend "$REVIEW_BACKEND"
+  --concurrency "$REVIEW_CONCURRENCY"
+)
+if [ -n "${SCOPE_HINT:-}" ]; then
+  REVIEW_PLAN_ARGS+=(--scope "$SCOPE_HINT")
+fi
+REVIEW_PLAN=$("${CLAUDE_PLUGIN_ROOT}/scripts/review-plan.sh" "${REVIEW_PLAN_ARGS[@]}")
+printf '%s\n' "$REVIEW_PLAN"
+REVIEW_PLAN_MODE=$(printf '%s\n' "$REVIEW_PLAN" | sed -n 's/^REVIEW_PLAN_MODE=//p')
+REVIEW_PLAN_REQUIRES_INPUT=$(printf '%s\n' "$REVIEW_PLAN" | sed -n 's/^REVIEW_PLAN_REQUIRES_INPUT=//p')
+REVIEW_PLAN_CONCURRENT=$(printf '%s\n' "$REVIEW_PLAN" | sed -n 's/^REVIEW_PLAN_CONCURRENT=//p')
+```
+
+The plan measures unified-diff lines separately from Git additions, deletions,
+files, and bytes. It classifies generated, vendored, lockfile, binary,
+deletion-only, and whitespace-only mechanical changes. Its effective scope
+combines semantic volume, relevant file count, topology, and backend capacity.
+
+Follow the displayed plan:
+
+1. For `full-context`, review the complete diff in one pass.
+2. For `partitioned`, give each review unit its listed files plus the full
+   issue/PR context and construct that unit's diff from those paths. Run units concurrently only when
+   `REVIEW_PLAN_CONCURRENT=yes`; otherwise process every unit sequentially.
+3. Treat low-information units intentionally: verify generated artifacts
+   against their source or generator, vendored and lockfile integrity against
+   the dependency change, binary provenance, deletion reachability, and
+   mechanical behavior preservation.
+4. Run the final coordinator pass over the full checkout. Check interfaces,
+   callers, shared state, dependency boundaries, and every changed source file
+   against the plan so no relevant file is omitted.
+5. Verify every candidate finding against the current checkout and requirements.
+   Discard stale or speculative findings, deduplicate by root cause and code
+   location, then rank the remaining findings by priority and confidence.
+
+An unusually large plan is review-risk information, not an interruption. Ask
+the user only when `REVIEW_PLAN_REQUIRES_INPUT=yes` or partitioning exposes a
+material product decision. An explicit `--scope` changes emphasis, not baseline
+coverage.

--- a/plugins/go-workflow/lib/ship/local-review.md
+++ b/plugins/go-workflow/lib/ship/local-review.md
@@ -25,7 +25,7 @@ fi
 If `CODEX_CMD` is still empty, return to the Step 4 prerequisite flow. Do not
 download or execute a package during re-entry detection.
 
-### 5a. Generate Diff
+### 5a. Generate Diff and Coverage Plan
 
 ```bash
 git fetch origin "$BASE_BRANCH" 2>/dev/null || true
@@ -33,6 +33,12 @@ DIFF=$(git diff "origin/${BASE_BRANCH}...HEAD")
 ```
 
 If the diff is empty, skip the review loop entirely — proceed to Phase 2 (Step 9).
+
+Otherwise set `REVIEW_BASE="origin/${BASE_BRANCH}"`,
+`REVIEW_BACKEND="$LLM_CHOICE"`, and `REVIEW_CONCURRENCY=auto`. Read
+`../review-planning.md`, run the shared planner, display the coverage plan, and
+follow its units and final coordinator pass. The planner, not raw diff length,
+determines whether user input is necessary.
 
 ### 5b. Run LLM Review
 
@@ -43,7 +49,7 @@ perspective. When the diff was written by Claude (the usual case), keep the
 
 <!-- SYNC: codex-exec-review — keep aligned with review-loop.md Step 5b -->
 
-#### Codex — Diff Size Estimation and Adaptive Timeout
+#### Codex — Adaptive Timeout
 
 ```bash
 if command -v gtimeout >/dev/null 2>&1; then TIMEOUT_CMD="gtimeout"
@@ -52,26 +58,15 @@ else TIMEOUT_CMD=""
 fi
 
 DIFF_LINES=$(printf '%s\n' "$DIFF" | wc -l)
-DIFF_FILES=$(printf '%s\n' "$DIFF" | grep -c '^diff --git' || echo 0)
-echo "Diff size: $DIFF_LINES lines across $DIFF_FILES files"
 
 # Adaptive timeout sized for high reasoning effort: 300s base + 4s per 100 lines, capped at 900s
 CODEX_TIMEOUT=$(( 300 + (DIFF_LINES / 25) ))
 if [ "$CODEX_TIMEOUT" -gt 900 ]; then CODEX_TIMEOUT=900; fi
 ```
 
-If `DIFF_LINES > 3000`, ask via `AskUserQuestion`:
-
-> **"Large diff detected ($DIFF_LINES lines, $DIFF_FILES files). Codex exec may timeout on diffs this large. How would you like to proceed?"**
-
-| Option | Description |
-|--------|-------------|
-| **Proceed with codex exec** | Run with extended timeout (${CODEX_TIMEOUT}s) — may still timeout |
-| **Use `codex review --base`** | Faster but limited to 2-3 findings per pass (no structured output) |
-| **Use agent-based review** | Claude agent review (no external LLM) |
-| **Skip review** | Proceed to push without LLM review |
-
-For `codex review --base`: set `QUICK_MODE=true`. For agent-based: set `USE_AGENT_REVIEW=true` and `CODEX_EXEC_FALLBACK=true`.
+Use the shared coverage plan for full-context or partitioned execution. If it
+reports `REVIEW_PLAN_REQUIRES_INPUT=yes`, ask whether to narrow coverage,
+change backend, or abort. Never offer to skip review solely due to size.
 
 #### Codex Exhaustive (`codex exec --output-schema`)
 

--- a/plugins/go-workflow/scripts/review-plan.sh
+++ b/plugins/go-workflow/scripts/review-plan.sh
@@ -58,10 +58,20 @@ DIFF_BYTES=$(git diff --no-ext-diff --binary "$RANGE" | wc -c | tr -d ' ')
 FILES=0 ADDITIONS=0 DELETIONS=0 SEMANTIC=0 GENERATED=0 VENDORED=0
 LOCKFILES=0 BINARY=0 DELETION_ONLY=0 MECHANICAL=0 RELEVANT=0 EFFECTIVE_CHANGES=0
 
-while IFS="$(printf '\t')" read -r added deleted path; do
+while IFS= read -r -d '' record; do
+  IFS="$(printf '\t')" read -r added deleted path <<< "$record"
+  old_path=""
+  status=""
+  if [ -z "${path:-}" ]; then
+    IFS= read -r -d '' old_path
+    IFS= read -r -d '' path
+    status=R
+  fi
   [ -n "${path:-}" ] || continue
   FILES=$((FILES + 1))
-  status=$(git diff --name-status "$RANGE" -- "$path" | awk 'NR == 1 { print $1 }')
+  if [ -z "$status" ]; then
+    status=$(git diff --name-status "$RANGE" -- "$path" | awk 'NR == 1 { print $1 }')
+  fi
   category=semantic
   relevant=yes
 
@@ -80,7 +90,9 @@ while IFS="$(printf '\t')" read -r added deleted path; do
       *)
         if [ "${status#D}" != "$status" ] || { [ "$added" -eq 0 ] && [ "$deleted" -gt 0 ]; }; then
           category=deletion-only; DELETION_ONLY=$((DELETION_ONLY + 1))
-        elif git diff -w --quiet "$RANGE" -- "$path"; then
+        elif [ -n "$old_path" ] && git diff -w --quiet "$RANGE" -- "$old_path" "$path"; then
+          category=mechanical; MECHANICAL=$((MECHANICAL + 1))
+        elif [ -z "$old_path" ] && git diff -w --quiet "$RANGE" -- "$path"; then
           category=mechanical; MECHANICAL=$((MECHANICAL + 1))
         else
           SEMANTIC=$((SEMANTIC + 1))
@@ -107,7 +119,7 @@ while IFS="$(printf '\t')" read -r added deleted path; do
     concern="$category-verification"
   fi
   printf '%s\t%s\t%s\t%s\t%s\t%s\n' "$category" "$concern" "$added" "$deleted" "$status" "$path" >> "$RECORDS"
-done < <(git diff --numstat "$RANGE")
+done < <(git diff --numstat -z "$RANGE")
 
 TOPOLOGY=$(sort -u "$CONCERNS" | awk 'NF { count++ } END { print count + 0 }')
 EFFECTIVE_SCOPE=$((EFFECTIVE_CHANGES + (RELEVANT * 100) + (TOPOLOGY * 300)))

--- a/plugins/go-workflow/scripts/review-plan.sh
+++ b/plugins/go-workflow/scripts/review-plan.sh
@@ -1,0 +1,161 @@
+#!/bin/bash
+set -euo pipefail
+
+BASE=""
+BACKEND="codex"
+CONCURRENCY="auto"
+SCOPE=""
+
+usage() {
+  echo "usage: review-plan.sh --base <revision> [--backend <name>] [--concurrency auto|yes|no] [--scope <hint>]" >&2
+  exit 2
+}
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --base) [ "$#" -ge 2 ] || usage; BASE="$2"; shift 2 ;;
+    --backend) [ "$#" -ge 2 ] || usage; BACKEND="$2"; shift 2 ;;
+    --concurrency) [ "$#" -ge 2 ] || usage; CONCURRENCY="$2"; shift 2 ;;
+    --scope) [ "$#" -ge 2 ] || usage; SCOPE="$2"; shift 2 ;;
+    *) usage ;;
+  esac
+done
+
+[ -n "$BASE" ] || usage
+git rev-parse --verify "$BASE^{commit}" >/dev/null 2>&1 || {
+  echo "review-plan: base revision not found: $BASE" >&2
+  exit 1
+}
+
+case "$CONCURRENCY" in auto|yes|no) ;; *) usage ;; esac
+case "$BACKEND" in
+  codex) CAPACITY=16000; MAX_UNITS=8; BACKEND_CONCURRENT=yes ;;
+  gemini) CAPACITY=14000; MAX_UNITS=8; BACKEND_CONCURRENT=yes ;;
+  fable) CAPACITY=12000; MAX_UNITS=6; BACKEND_CONCURRENT=yes ;;
+  agent) CAPACITY=10000; MAX_UNITS=6; BACKEND_CONCURRENT=yes ;;
+  ollama) CAPACITY=6000; MAX_UNITS=4; BACKEND_CONCURRENT=no ;;
+  *) CAPACITY=8000; MAX_UNITS=4; BACKEND_CONCURRENT=no ;;
+esac
+
+if [ "$CONCURRENCY" = auto ]; then
+  CONCURRENT="$BACKEND_CONCURRENT"
+elif [ "$CONCURRENCY" = yes ]; then
+  CONCURRENT=yes
+else
+  CONCURRENT=no
+fi
+
+RANGE="$BASE...HEAD"
+TMP_DIR=$(mktemp -d "${TMPDIR:-/tmp}/gopher-ai-review-plan.XXXXXX")
+trap 'rm -rf "$TMP_DIR"' EXIT
+RECORDS="$TMP_DIR/records.tsv"
+CONCERNS="$TMP_DIR/concerns.txt"
+: > "$RECORDS"
+: > "$CONCERNS"
+
+UNIFIED_LINES=$(git diff --no-ext-diff "$RANGE" | wc -l | tr -d ' ')
+DIFF_BYTES=$(git diff --no-ext-diff --binary "$RANGE" | wc -c | tr -d ' ')
+FILES=0 ADDITIONS=0 DELETIONS=0 SEMANTIC=0 GENERATED=0 VENDORED=0
+LOCKFILES=0 BINARY=0 DELETION_ONLY=0 MECHANICAL=0 RELEVANT=0 EFFECTIVE_CHANGES=0
+
+while IFS="$(printf '\t')" read -r added deleted path; do
+  [ -n "${path:-}" ] || continue
+  FILES=$((FILES + 1))
+  status=$(git diff --name-status "$RANGE" -- "$path" | awk 'NR == 1 { print $1 }')
+  category=semantic
+  relevant=yes
+
+  if [ "$added" = - ] || [ "$deleted" = - ]; then
+    category=binary; relevant=no; added=0; deleted=0; BINARY=$((BINARY + 1))
+  else
+    ADDITIONS=$((ADDITIONS + added))
+    DELETIONS=$((DELETIONS + deleted))
+    case "$path" in
+      vendor/*|*/vendor/*|third_party/*|*/third_party/*|node_modules/*|*/node_modules/*)
+        category=vendored; relevant=no; VENDORED=$((VENDORED + 1)) ;;
+      go.sum|*/go.sum|go.work.sum|*/go.work.sum|package-lock.json|*/package-lock.json|npm-shrinkwrap.json|*/npm-shrinkwrap.json|yarn.lock|*/yarn.lock|pnpm-lock.yaml|*/pnpm-lock.yaml|Cargo.lock|*/Cargo.lock|Gemfile.lock|*/Gemfile.lock|composer.lock|*/composer.lock|poetry.lock|*/poetry.lock|uv.lock|*/uv.lock)
+        category=lockfile; relevant=no; LOCKFILES=$((LOCKFILES + 1)) ;;
+      generated/*|*/generated/*|gen/*|*/gen/*|*.gen.*|*_generated.go|*zz_generated.*|*.pb.go|*.pb.cc|*.pb.h|*.min.js|*.min.css)
+        category=generated; relevant=no; GENERATED=$((GENERATED + 1)) ;;
+      *)
+        if [ "${status#D}" != "$status" ] || { [ "$added" -eq 0 ] && [ "$deleted" -gt 0 ]; }; then
+          category=deletion-only; DELETION_ONLY=$((DELETION_ONLY + 1))
+        elif git diff -w --quiet "$RANGE" -- "$path"; then
+          category=mechanical; MECHANICAL=$((MECHANICAL + 1))
+        else
+          SEMANTIC=$((SEMANTIC + 1))
+        fi
+        ;;
+    esac
+  fi
+
+  if [ "$relevant" = yes ]; then
+    RELEVANT=$((RELEVANT + 1))
+    if [ "$category" = deletion-only ]; then
+      EFFECTIVE_CHANGES=$((EFFECTIVE_CHANGES + ((added + deleted + 3) / 4)))
+    elif [ "$category" = mechanical ]; then
+      EFFECTIVE_CHANGES=$((EFFECTIVE_CHANGES + ((added + deleted + 7) / 8)))
+    else
+      EFFECTIVE_CHANGES=$((EFFECTIVE_CHANGES + added + deleted))
+    fi
+    case "$path" in
+      */*) concern=$(printf '%s' "$path" | awk -F/ '{ print (NF > 2 ? $1 "/" $2 : $1) }') ;;
+      *) concern=repository-root ;;
+    esac
+    printf '%s\n' "$concern" >> "$CONCERNS"
+  else
+    concern="$category-verification"
+  fi
+  printf '%s\t%s\t%s\t%s\t%s\t%s\n' "$category" "$concern" "$added" "$deleted" "$status" "$path" >> "$RECORDS"
+done < <(git diff --numstat "$RANGE")
+
+TOPOLOGY=$(sort -u "$CONCERNS" | awk 'NF { count++ } END { print count + 0 }')
+EFFECTIVE_SCOPE=$((EFFECTIVE_CHANGES + (RELEVANT * 100) + (TOPOLOGY * 300)))
+MODE=full-context
+if [ "$EFFECTIVE_SCOPE" -gt "$CAPACITY" ] || [ "$RELEVANT" -gt 30 ] || [ "$TOPOLOGY" -gt 4 ]; then MODE=partitioned; fi
+REQUIRES_INPUT=no
+if [ "$EFFECTIVE_SCOPE" -gt $((CAPACITY * MAX_UNITS)) ]; then REQUIRES_INPUT=yes; fi
+
+echo "Review statistics"
+echo "  unified diff: ${UNIFIED_LINES} lines, ${DIFF_BYTES} bytes"
+echo "  actual changes: +${ADDITIONS} -${DELETIONS} across ${FILES} files"
+echo "  classifications: semantic=${SEMANTIC}, generated=${GENERATED}, vendored=${VENDORED}, lockfile=${LOCKFILES}, binary=${BINARY}, deletion-only=${DELETION_ONLY}, mechanical=${MECHANICAL}"
+echo "Review coverage plan"
+echo "  backend: ${BACKEND} (capacity=${CAPACITY}, concurrent=${CONCURRENT})"
+echo "  effective scope: ${EFFECTIVE_SCOPE}; mode: ${MODE}; relevant files: ${RELEVANT}; topology groups: ${TOPOLOGY}"
+[ -z "$SCOPE" ] || echo "  explicit focus: $SCOPE (coverage remains repository-wide)"
+
+unit=0
+if [ "$MODE" = full-context ]; then
+  unit=$((unit + 1))
+  echo "  unit ${unit}: full relevant diff"
+  awk -F '\t' '$1 != "generated" && $1 != "vendored" && $1 != "lockfile" && $1 != "binary" { print "    - " $6 " [" $1 "]" }' "$RECORDS"
+else
+  while IFS= read -r concern; do
+    [ -n "$concern" ] || continue
+    unit=$((unit + 1))
+    echo "  unit ${unit}: ${concern}"
+    awk -F '\t' -v concern="$concern" '$2 == concern { print "    - " $6 " [" $1 "]" }' "$RECORDS"
+  done < <(sort -u "$CONCERNS")
+fi
+
+for category in generated vendored lockfile binary; do
+  count=$(awk -F '\t' -v category="$category" '$1 == category { count++ } END { print count + 0 }' "$RECORDS")
+  if [ "$count" -gt 0 ]; then
+    unit=$((unit + 1))
+    echo "  unit ${unit}: ${category} integrity verification"
+    awk -F '\t' -v category="$category" '$1 == category { print "    - " $6 }' "$RECORDS"
+  fi
+done
+
+echo "  final pass: cross-cutting interfaces, dependencies, and omitted-file audit"
+if [ "$REQUIRES_INPUT" = yes ]; then
+  echo "Coverage status: requires user input; effective scope exceeds ${MAX_UNITS} reliable ${BACKEND} review units"
+else
+  execution=sequential
+  [ "$CONCURRENT" = yes ] && execution=concurrent
+  echo "Coverage status: complete; execute units ${execution}, then verify and coordinate findings"
+fi
+echo "REVIEW_PLAN_MODE=$MODE"
+echo "REVIEW_PLAN_REQUIRES_INPUT=$REQUIRES_INPUT"
+echo "REVIEW_PLAN_CONCURRENT=$CONCURRENT"

--- a/plugins/go-workflow/skills/complete-issue/phases.md
+++ b/plugins/go-workflow/skills/complete-issue/phases.md
@@ -30,13 +30,16 @@ the `model` frontmatter in `agents/*.md` unless the user sets
 
 ## Phase 2: Codex Run
 
-After detection succeeds in `SKILL.md`, run codex review on the PR diff with
-an adaptive timeout sized to the diff:
+After detection succeeds in `SKILL.md`, plan and run codex review on the PR
+diff with an adaptive timeout:
 
 ```bash
 DEFAULT_BRANCH=$(git remote show origin 2>/dev/null | grep 'HEAD branch' | sed 's/.*: //' || echo "main")
 DIFF=$(git diff "origin/${DEFAULT_BRANCH}...HEAD")
 DIFF_LINES=$(printf '%s\n' "$DIFF" | wc -l)
+REVIEW_BASE="origin/${DEFAULT_BRANCH}"
+REVIEW_BACKEND=codex
+REVIEW_CONCURRENCY=auto
 # Adaptive timeout sized for high reasoning effort: 300s base + 4s per 100 lines, capped at 900s
 CODEX_TIMEOUT=$(( 300 + (DIFF_LINES / 25) ))
 if [ "$CODEX_TIMEOUT" -gt 900 ]; then CODEX_TIMEOUT=900; fi
@@ -52,22 +55,18 @@ No model flag is passed in either Codex path. A `model = "..."` pin in
 `~/.codex/config.toml` is respected; leaving it unset lets the Codex CLI choose
 its recommended default.
 
-If the diff exceeds 3000 lines, warn the user via `AskUserQuestion` BEFORE starting:
-
-> "Large diff ($DIFF_LINES lines) — codex exec may timeout. Proceed / Use `codex review --base` / Agent review / Skip?"
-
-Forward the user's choice to the appropriate code path:
-
-- **Proceed** → run codex with the adaptive timeout above.
-- **Use `codex review --base`** → swap the command for `codex review --base origin/${DEFAULT_BRANCH} -c model_reasoning_effort="high"`.
-- **Agent review** → dispatch an Agent subagent (sonnet) with the diff and the same review checklist.
-- **Skip** → warn and proceed directly to Phase 3.
+Read `../../lib/review-planning.md`, run the shared planner, display the coverage
+plan, and execute every unit plus the coordinator pass. Partition sequentially
+when the selected fallback lacks concurrent agents. Ask only when the planner
+reports that reliable coverage is unavailable or a material scope choice is
+required; do not stop solely because the raw diff is large.
 
 Any runtime failure (non-zero exit, timeout, no output) → see `codex-fallback.md`.
 
 ## Address Findings
 
-For each valid codex finding, make the fix. Skip findings that are:
+After verifying and deduplicating all unit findings against the checkout, make
+each valid fix in ranked order. Skip findings that are:
 
 - False positives (the code is correct)
 - Cosmetic-only and don't change observable behavior

--- a/plugins/go-workflow/skills/review-deep/SKILL.md
+++ b/plugins/go-workflow/skills/review-deep/SKILL.md
@@ -34,7 +34,7 @@ while [ -n "$ARGS" ]; do
     --issue\ *)
       ARGS="${ARGS#--issue }"
       ISSUE_ARG="${ARGS%% *}"
-      ARGS="${ARGS#$ISSUE_ARG}"
+      ARGS="${ARGS#"$ISSUE_ARG"}"
       ARGS="${ARGS# }"
       ;;
     --post*)
@@ -49,7 +49,7 @@ while [ -n "$ARGS" ]; do
       ;;
     [0-9]*)
       PR_ARG="${ARGS%% *}"
-      ARGS="${ARGS#$PR_ARG}"
+      ARGS="${ARGS#"$PR_ARG"}"
       ARGS="${ARGS# }"
       ;;
     *)
@@ -104,7 +104,7 @@ if [ -n "$PR_JSON" ]; then
   BASE_BRANCH=$(echo "$PR_JSON" | jq -r '.baseRefName')
   echo "Found PR #$PR_NUM (base: $BASE_BRANCH)"
 else
-  BASE_BRANCH=$((git symbolic-ref refs/remotes/origin/HEAD 2>/dev/null | sed 's|refs/remotes/origin/||' | grep .) || (git remote show -n origin 2>/dev/null | grep 'HEAD branch' | sed 's/.*: //' | grep .) || echo "main")
+  BASE_BRANCH=$( (git symbolic-ref refs/remotes/origin/HEAD 2>/dev/null | sed 's|refs/remotes/origin/||' | grep .) || (git remote show -n origin 2>/dev/null | grep 'HEAD branch' | sed 's/.*: //' | grep .) || echo "main" )
   echo "No PR found. Using base branch: $BASE_BRANCH"
 fi
 ```
@@ -126,7 +126,7 @@ If `--issue N` was provided instead of a PR, fetch just the issue context. If no
 
 `context-gathering.md` includes the size guard — if combined context exceeds ~6000 characters, use summary format.
 
-## Step 3: Generate Diff
+## Step 3: Generate Diff and Coverage Plan
 
 Based on detected scope:
 
@@ -136,12 +136,14 @@ Based on detected scope:
 
 ```bash
 DIFF=$(git diff "${BASE_BRANCH}...HEAD")
-DIFF_LINES=$(printf '%s\n' "$DIFF" | wc -l)
-DIFF_FILES=$(printf '%s\n' "$DIFF" | grep -c '^diff --git' || echo 0)
-echo "Diff size: $DIFF_LINES lines across $DIFF_FILES files"
+REVIEW_BASE="$BASE_BRANCH"
+REVIEW_BACKEND=agent
+REVIEW_CONCURRENCY=auto
 ```
 
-If diff exceeds 3000 lines, warn via `AskUserQuestion` and offer: continue full / Go-only / specify files.
+Read `../../lib/review-planning.md`, run the shared planner, display its coverage
+plan, and follow it through the final coordinated pass. Do not interrupt solely
+because of raw diff size. Preserve `SCOPE_HINT` as review emphasis.
 
 ## Step 4: Static Analysis
 
@@ -164,11 +166,12 @@ Read `review-criteria.md` for the full criteria, the Quality Score Rubric, the c
 
 Process:
 
-1. Review the diff line-by-line against every criterion in `review-criteria.md`.
+1. Review every unit from the Step 3 coverage plan against every criterion in `review-criteria.md`.
 2. Cross-reference with requirements (when PR/issue context is available): each acceptance criterion → implementation → tests; check for missing requirements and scope creep.
 3. For each existing review thread, mark whether it appears addressed in the current diff.
 4. Include the Step 4 static-analysis results.
 5. Detect breaking changes in exported symbols (grep recipe in `review-criteria.md`).
+6. Run the plan's cross-cutting pass, then verify, deduplicate, and rank findings against the checkout before Step 6.
 
 For the exact findings-table layout, spec-compliance table, review-comments-status table, and the recommendation values — Read `output-format.md`.
 
@@ -218,3 +221,4 @@ Default: `Done`.
 - `review-criteria.md` — full review criteria, Go idiom checks, Quality Score Rubric, confidence scoring, breaking-change detection
 - `fix-and-verify.md` — fix iteration, parallel dispatch, test generation, verification, commit
 - `output-format.md` — findings table, spec-compliance table, review-comments-status table, PR-comment template
+- `../../lib/review-planning.md` — shared adaptive coverage planning and finding coordination

--- a/scripts/legacy-skill-hashes.txt
+++ b/scripts/legacy-skill-hashes.txt
@@ -7,7 +7,7 @@
 # this prevents accepting a hash from skill A as proof of ownership for skill B.
 # DO NOT EDIT BY HAND — re-run the regen script after committing SKILL.md changes.
 #
-# Total entries: 226
+# Total entries: 228
 017e2d820506e7bef4a89a4d65839150db1ffdc124852a43dc916023e6d37e16 review-deep
 0322d4a7ddc204a9bf5addfec4e512edaea92ab8f4ebdd0541ca099330a09408 worktree
 03dac3a27d6da4b0a0c64ff6511df17004747e20b47a1691b4f9f030478877b9 commit
@@ -212,6 +212,7 @@ e338c2bc546babcb73c9a8f9e1b15a1953a9203b7233cbfe089054472302f665 gopher-guides
 e7398cc9bf011c03689c56e89b5eba0c52f2d73bd2fcf4619180514f16e76874 complete-issue
 e9e3f59c460f8bff37ec6c7744012902611be5c9f5b63848bc929087cad9d5fe tmux-start
 ea5d1a65f4268ec942d60826f1c97912ad91abe3f39d415f3c4160beedfa3ccb gemini-image
+eb14317761223c517e5bff629e7e8933505f50eb10b3adf809eb08122456f311 review-deep
 ed50c1c5b29b003f54116cfe28f02b20c762dcc6ddba100ddbaef593ac3b72b4 go-error-handling
 edfed0bd039ddc1e1e2dd5399c8692e2cfed148fadd3a32122eba997c9623219 go-code-organization
 ef18dd0b566badecc14918a46ec9cb2a2a1d0a97a5804705571cd6847c894c03 go-profiling-optimization

--- a/scripts/test-commands.sh
+++ b/scripts/test-commands.sh
@@ -9,6 +9,8 @@ ERRORS=0
 
 echo "=== Command File Tests ==="
 
+"$ROOT_DIR/scripts/test-review-plan.sh"
+
 # Find all command .md files
 COMMAND_FILES=$(find "$ROOT_DIR/plugins" "$ROOT_DIR/shared" -path "*/commands/*.md" -type f 2>/dev/null | sort)
 TOTAL=0

--- a/scripts/test-review-plan.sh
+++ b/scripts/test-review-plan.sh
@@ -8,6 +8,7 @@ trap 'rm -rf "$TEST_ROOT"' EXIT
 
 fail() { echo "FAIL: $1" >&2; exit 1; }
 assert_contains() { case "$1" in *"$2"*) ;; *) fail "$3 (missing: $2)" ;; esac; }
+assert_not_contains() { case "$1" in *"$2"*) fail "$3 (unexpected: $2)" ;; *) ;; esac; }
 
 new_repo() {
   local repo="$1"
@@ -86,6 +87,24 @@ output=$(run_plan "$repo" --backend codex)
 assert_contains "$output" "deletion-only=1" "deletion-heavy classification"
 assert_contains "$output" "old.go [deletion-only]" "deletion-heavy assignment"
 echo "  deletion-heavy diff: OK"
+
+repo="$TEST_ROOT/rename"
+new_repo "$repo"
+mkdir -p "$repo/internal/old"
+awk 'BEGIN { print "package old"; for (i = 1; i <= 20; i++) print "var Value" i " = " i }' > "$repo/internal/old/service.go"
+git -C "$repo" add .
+git -C "$repo" commit -qm add-service
+mkdir -p "$repo/internal/new"
+git -C "$repo" mv internal/old/service.go internal/new/service.go
+printf '\nfunc Ready() bool { return true }\n' >> "$repo/internal/new/service.go"
+git -C "$repo" add .
+git -C "$repo" commit -qm rename-service
+output=$(run_plan "$repo" --backend codex)
+assert_contains "$output" "across 1 files" "edited rename stats"
+assert_contains "$output" "semantic=1" "edited rename classification"
+assert_contains "$output" "internal/new/service.go [semantic]" "edited rename assignment"
+assert_not_contains "$output" "=>" "edited rename synthetic path"
+echo "  edited rename diff: OK"
 
 output=$(run_plan "$TEST_ROOT/large" --backend ollama --concurrency no)
 assert_contains "$output" "concurrent=no" "non-concurrent backend capability"

--- a/scripts/test-review-plan.sh
+++ b/scripts/test-review-plan.sh
@@ -1,0 +1,95 @@
+#!/bin/bash
+set -euo pipefail
+
+ROOT_DIR=$(cd "$(dirname "$0")/.." && pwd)
+PLANNER="$ROOT_DIR/plugins/go-workflow/scripts/review-plan.sh"
+TEST_ROOT=$(mktemp -d "${TMPDIR:-/tmp}/gopher-ai-review-plan-test.XXXXXX")
+trap 'rm -rf "$TEST_ROOT"' EXIT
+
+fail() { echo "FAIL: $1" >&2; exit 1; }
+assert_contains() { case "$1" in *"$2"*) ;; *) fail "$3 (missing: $2)" ;; esac; }
+
+new_repo() {
+  local repo="$1"
+  mkdir -p "$repo"
+  git -C "$repo" init -q
+  git -C "$repo" config user.email test@example.com
+  git -C "$repo" config user.name "Review Planner Test"
+  printf 'baseline\n' > "$repo/README.md"
+  git -C "$repo" add README.md
+  git -C "$repo" commit -qm baseline
+}
+
+run_plan() {
+  local repo="$1"
+  shift
+  (cd "$repo" && "$PLANNER" --base HEAD^ "$@")
+}
+
+echo "=== Adaptive Review Planner Tests ==="
+
+repo="$TEST_ROOT/small"
+new_repo "$repo"
+mkdir -p "$repo/internal/service"
+printf 'package service\n\nfunc Ready() bool { return true }\n' > "$repo/internal/service/service.go"
+git -C "$repo" add .
+git -C "$repo" commit -qm semantic
+output=$(run_plan "$repo" --backend codex --scope "error handling")
+assert_contains "$output" "actual changes: +3 -0 across 1 files" "small semantic stats"
+assert_contains "$output" "semantic=1" "small semantic classification"
+assert_contains "$output" "mode: full-context" "small semantic plan"
+assert_contains "$output" "explicit focus: error handling" "scope with spaces"
+echo "  small semantic diff: OK"
+
+repo="$TEST_ROOT/large"
+new_repo "$repo"
+index=0
+for area in api auth billing cli data docs worker; do
+  mkdir -p "$repo/$area/component"
+  for file_number in $(seq 1 12); do
+    index=$((index + 1))
+    awk -v area="$area" -v idx="$index" 'BEGIN { print "package component"; for (i = 1; i <= 100; i++) print "var " area idx "Value" i " = " i }' > "$repo/$area/component/change-$file_number.go"
+  done
+done
+git -C "$repo" add .
+git -C "$repo" commit -qm large
+output=$(run_plan "$repo" --backend codex)
+assert_contains "$output" "mode: partitioned" "large multi-area plan"
+assert_contains "$output" "unit 1:" "large multi-area units"
+assert_contains "$output" "final pass: cross-cutting interfaces" "large multi-area coordinator"
+assert_contains "$output" "REVIEW_PLAN_REQUIRES_INPUT=no" "large review remains autonomous"
+echo "  large multi-area diff: OK"
+
+repo="$TEST_ROOT/generated"
+new_repo "$repo"
+mkdir -p "$repo/generated" "$repo/internal/source"
+awk 'BEGIN { for (i = 1; i <= 4000; i++) print "generated line " i }' > "$repo/generated/schema.gen.json"
+printf 'package source\n\nconst Version = 2\n' > "$repo/internal/source/source.go"
+git -C "$repo" add .
+git -C "$repo" commit -qm generated
+output=$(run_plan "$repo" --backend codex)
+assert_contains "$output" "generated=1" "generated-heavy classification"
+assert_contains "$output" "generated integrity verification" "generated-heavy coverage"
+assert_contains "$output" "mode: full-context" "generated volume discounted"
+echo "  generated-heavy diff: OK"
+
+repo="$TEST_ROOT/deletion"
+new_repo "$repo"
+mkdir -p "$repo/internal/old"
+awk 'BEGIN { print "package old"; for (i = 1; i <= 500; i++) print "var Old" i " = " i }' > "$repo/internal/old/old.go"
+git -C "$repo" add .
+git -C "$repo" commit -qm add-old
+rm "$repo/internal/old/old.go"
+git -C "$repo" add -u
+git -C "$repo" commit -qm delete-old
+output=$(run_plan "$repo" --backend codex)
+assert_contains "$output" "deletion-only=1" "deletion-heavy classification"
+assert_contains "$output" "old.go [deletion-only]" "deletion-heavy assignment"
+echo "  deletion-heavy diff: OK"
+
+output=$(run_plan "$TEST_ROOT/large" --backend ollama --concurrency no)
+assert_contains "$output" "concurrent=no" "non-concurrent backend capability"
+assert_contains "$output" "execute units sequential" "non-concurrent execution plan"
+echo "  backend without concurrent agents: OK"
+
+echo "All adaptive review planner tests passed."


### PR DESCRIPTION
## Summary

- replace raw diff-line interruption gates with Git-native adaptive review planning
- classify low-information changes and generate full-context or partitioned coverage units by backend capacity
- align review-deep, ship, and complete-issue on shared verification, deduplication, and coordinator behavior

## Test Plan

- fixture coverage for small semantic, 8,400-line/84-file multi-area, generated-heavy, deletion-heavy, and non-concurrent backend reviews
- embedded skill shell validation and ShellCheck
- full configured repository validation gate with sandbox-safe Go build cache

Fixes #223