### PR TITLE
fix(go-web): harden server lifecycle

### DIFF
--- a/plugins/go-web/commands/convert-to-go-project.md
+++ b/plugins/go-web/commands/convert-to-go-project.md
@@ -350,6 +350,8 @@ exist, such as `.gitignore` and `package.json`.
 | db/migration-initial.`<db>`.sql | internal/database/migrations/001_initial.sql | Replace the `examples` table with migrations generated from the existing schema |
 | db/database.`<db>`.go | internal/database/database.go | |
 | app/main.go | cmd/server/main.go | |
+| app/server.go | cmd/server/server.go | |
+| app/main_test.go | cmd/server/main_test.go | |
 | app/slog.go | cmd/server/slog.go | |
 | app/generate.go | cmd/server/generate.go | |
 | app/config.go | internal/config/config.go | |

--- a/plugins/go-web/commands/create-go-project.md
+++ b/plugins/go-web/commands/create-go-project.md
@@ -269,6 +269,8 @@ this order (dependencies matter). `<db>` is the selected database: `postgres`, `
 | db/migration-initial.`<db>`.sql | internal/database/migrations/001_initial.sql | |
 | db/database.`<db>`.go | internal/database/database.go | |
 | app/main.go | cmd/server/main.go | |
+| app/server.go | cmd/server/server.go | |
+| app/main_test.go | cmd/server/main_test.go | |
 | app/slog.go | cmd/server/slog.go | |
 | app/generate.go | cmd/server/generate.go | |
 | app/config.go | internal/config/config.go | |

--- a/plugins/go-web/templates/README.md
+++ b/plugins/go-web/templates/README.md
@@ -16,6 +16,9 @@ Everything else in a template is literal content — in particular, `${DATABASE_
 substitution), `$(BINARY_NAME)` / `$$DATABASE_URL` (Makefile), and `${PORT:-3000}` (.air.toml)
 are NOT placeholders and must be written verbatim.
 
+Generated HTTP servers use a 5-second read-header timeout, 15-second read timeout,
+30-second write timeout, 60-second idle timeout, and 10-second graceful-shutdown deadline.
+
 Some template filenames drop the leading dot (`gitignore`, `envrc.*`, `air.toml`,
 `golangci.yml`) so they stay inert inside this repo; the target paths below are authoritative.
 
@@ -58,6 +61,8 @@ writing the file — spaces break Make.
 | Template | Target |
 |----------|--------|
 | app/main.go | `cmd/server/main.go` |
+| app/server.go | `cmd/server/server.go` |
+| app/main_test.go | `cmd/server/main_test.go` |
 | app/slog.go | `cmd/server/slog.go` |
 | app/generate.go | `cmd/server/generate.go` |
 | app/config.go | `internal/config/config.go` |

--- a/plugins/go-web/templates/app/main.go
+++ b/plugins/go-web/templates/app/main.go
@@ -2,8 +2,10 @@ package main
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
+	"net/http"
 	"os"
 	"os/signal"
 	"syscall"
@@ -26,11 +28,19 @@ func (s echoServer) Start(address string) error {
 }
 
 func (s echoServer) Shutdown(ctx context.Context) error {
-	return s.e.Server.Shutdown(ctx)
+	err := s.e.Shutdown(ctx)
+	if errors.Is(err, http.ErrServerClosed) {
+		return s.e.Server.Shutdown(ctx)
+	}
+	return err
 }
 
 func (s echoServer) Close() error {
-	return s.e.Server.Close()
+	err := s.e.Close()
+	if errors.Is(err, http.ErrServerClosed) {
+		return s.e.Server.Close()
+	}
+	return err
 }
 
 var _ server = echoServer{}

--- a/plugins/go-web/templates/app/main.go
+++ b/plugins/go-web/templates/app/main.go
@@ -1,117 +1,89 @@
 package main
 
 import (
-    "context"
-    "errors"
-    "fmt"
-    "log/slog"
-    "net"
-    "os"
-    "os/signal"
-    "strconv"
-    "strings"
-    "syscall"
-    "time"
+	"context"
+	"fmt"
+	"log/slog"
+	"os"
+	"os/signal"
+	"syscall"
 
-    "{{PROJECT_NAME}}/internal/config"
-    "{{PROJECT_NAME}}/internal/database"
-    "{{PROJECT_NAME}}/internal/handler"
-    "{{PROJECT_NAME}}/internal/middleware"
+	"{{PROJECT_NAME}}/internal/config"
+	"{{PROJECT_NAME}}/internal/database"
+	"{{PROJECT_NAME}}/internal/handler"
+	"{{PROJECT_NAME}}/internal/middleware"
 
-    chimw "github.com/go-chi/chi/v5/middleware"
-    "github.com/labstack/echo/v4"
+	chimw "github.com/go-chi/chi/v5/middleware"
+	"github.com/labstack/echo/v4"
 )
 
+type echoServer struct {
+	e *echo.Echo
+}
+
+func (s echoServer) Start(address string) error {
+	return s.e.Start(address)
+}
+
+func (s echoServer) Shutdown(ctx context.Context) error {
+	return s.e.Server.Shutdown(ctx)
+}
+
+func (s echoServer) Close() error {
+	return s.e.Server.Close()
+}
+
+var _ server = echoServer{}
+
 func main() {
-    cfg := config.Load()
-
-    ctx := context.Background()
-    db, err := database.New(ctx, cfg.DatabaseURL)
-    if err != nil {
-        slog.Error("failed to connect to database", "error", err)
-        os.Exit(1)
-    }
-    defer db.Close()
-
-    e := echo.New()
-    e.HideBanner = true
-    e.HidePort = true
-
-    ln, actualPort, err := findAvailablePort(cfg.Port)
-    if err != nil {
-        slog.Error("failed to find available port", "error", err)
-        os.Exit(1)
-    }
-    e.Listener = ln
-
-    if actualPort != cfg.Port {
-        slog.Warn("configured port unavailable, using next available", "configured", cfg.Port, "actual", actualPort)
-        cfg.Port = actualPort
-        cfg.Site.URL = replacePort(cfg.Site.URL, actualPort)
-    }
-
-    middleware.Setup(e, cfg)
-
-    h := handler.New(cfg, db)
-    h.RegisterRoutes(e)
-
-    e.Use(echo.WrapMiddleware(chimw.Logger))
-
-    go func() {
-        slog.Info("starting server", "url", fmt.Sprintf("http://localhost:%s", cfg.Port), "env", cfg.Env)
-        if err := e.Start(""); err != nil {
-            slog.Info("shutting down server")
-        }
-    }()
-
-    quit := make(chan os.Signal, 1)
-    signal.Notify(quit, syscall.SIGINT, syscall.SIGTERM)
-    <-quit
-
-    ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
-    defer cancel()
-
-    if err := e.Shutdown(ctx); err != nil {
-        slog.Error("server shutdown error", "error", err)
-    }
-
-    slog.Info("server stopped")
+	if err := run(); err != nil {
+		slog.Error("server failed", "error", err)
+		os.Exit(1)
+	}
 }
 
-func findAvailablePort(configuredPort string) (net.Listener, string, error) {
-    startPort, err := strconv.Atoi(configuredPort)
-    if err != nil {
-        return nil, "", fmt.Errorf("invalid port %q: %w", configuredPort, err)
-    }
+func run() error {
+	cfg := config.Load()
 
-    maxPort := startPort + 100
-    for port := startPort; port <= maxPort; port++ {
-        addr := ":" + strconv.Itoa(port)
-        ln, err := net.Listen("tcp", addr)
-        if err != nil {
-            // Only retry for "address in use" errors; return other errors immediately
-            if !errors.Is(err, syscall.EADDRINUSE) {
-                return nil, "", fmt.Errorf("failed to listen on port %d: %w", port, err)
-            }
-            continue
-        }
-        // Get actual bound port (important when port is 0)
-        actualPort := ln.Addr().(*net.TCPAddr).Port
-        return ln, strconv.Itoa(actualPort), nil
-    }
+	ctx := context.Background()
+	db, err := database.New(ctx, cfg.DatabaseURL)
+	if err != nil {
+		return fmt.Errorf("connect to database: %w", err)
+	}
+	defer db.Close()
 
-    return nil, "", fmt.Errorf("no available port found in range %d-%d", startPort, maxPort)
-}
+	e := echo.New()
+	e.HideBanner = true
+	e.HidePort = true
 
-func replacePort(rawURL string, newPort string) string {
-    const localhostPrefix = "://localhost:"
-    if idx := strings.Index(rawURL, localhostPrefix); idx >= 0 {
-        afterScheme := idx + len(localhostPrefix)
-        end := strings.IndexAny(rawURL[afterScheme:], "/?#")
-        if end == -1 {
-            return rawURL[:afterScheme] + newPort
-        }
-        return rawURL[:afterScheme] + newPort + rawURL[afterScheme+end:]
-    }
-    return rawURL
+	ln, actualPort, err := findAvailablePort(cfg.Port)
+	if err != nil {
+		return fmt.Errorf("find available port: %w", err)
+	}
+	e.Listener = ln
+	configureHTTPServer(e.Server)
+
+	if actualPort != cfg.Port {
+		slog.Warn("configured port unavailable, using next available", "configured", cfg.Port, "actual", actualPort)
+		cfg.Port = actualPort
+		cfg.Site.URL = replacePort(cfg.Site.URL, actualPort)
+	}
+
+	middleware.Setup(e, cfg)
+
+	h := handler.New(cfg, db)
+	h.RegisterRoutes(e)
+
+	e.Use(echo.WrapMiddleware(chimw.Logger))
+
+	signalCtx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	defer stop()
+
+	slog.Info("starting server", "url", fmt.Sprintf("http://localhost:%s", cfg.Port), "env", cfg.Env)
+	if err := serve(signalCtx, echoServer{e: e}, shutdownTimeout); err != nil {
+		return err
+	}
+
+	slog.Info("server stopped")
+	return nil
 }

--- a/plugins/go-web/templates/app/main_test.go
+++ b/plugins/go-web/templates/app/main_test.go
@@ -1,0 +1,150 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"testing"
+	"time"
+)
+
+type stubServer struct {
+	started  chan struct{}
+	stopped  chan struct{}
+	startErr error
+	shutdown func(context.Context) error
+	closeErr error
+	closed   chan struct{}
+}
+
+func newStubServer(startErr error) *stubServer {
+	return &stubServer{
+		started:  make(chan struct{}),
+		stopped:  make(chan struct{}),
+		startErr: startErr,
+		closed:   make(chan struct{}),
+	}
+}
+
+func (s *stubServer) Start(string) error {
+	close(s.started)
+	if s.startErr != nil {
+		return s.startErr
+	}
+	<-s.stopped
+	return http.ErrServerClosed
+}
+
+func (s *stubServer) Shutdown(ctx context.Context) error {
+	if s.shutdown != nil {
+		return s.shutdown(ctx)
+	}
+	close(s.stopped)
+	return nil
+}
+
+func (s *stubServer) Close() error {
+	close(s.closed)
+	select {
+	case <-s.stopped:
+	default:
+		close(s.stopped)
+	}
+	return s.closeErr
+}
+
+func TestServeGracefulShutdown(t *testing.T) {
+	srv := newStubServer(nil)
+	ctx, cancel := context.WithCancel(context.Background())
+	result := make(chan error, 1)
+	go func() {
+		result <- serve(ctx, srv, time.Second)
+	}()
+
+	<-srv.started
+	cancel()
+
+	if err := <-result; err != nil {
+		t.Fatalf("serve returned an error: %v", err)
+	}
+}
+
+func TestServeFailure(t *testing.T) {
+	wantErr := errors.New("listener failed")
+	srv := newStubServer(wantErr)
+
+	err := serve(context.Background(), srv, time.Second)
+
+	if !errors.Is(err, wantErr) {
+		t.Fatalf("serve error = %v, want %v", err, wantErr)
+	}
+}
+
+func TestServeShutdownTimeout(t *testing.T) {
+	srv := newStubServer(nil)
+	srv.shutdown = func(ctx context.Context) error {
+		<-ctx.Done()
+		return ctx.Err()
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	result := make(chan error, 1)
+	go func() {
+		result <- serve(ctx, srv, time.Millisecond)
+	}()
+
+	<-srv.started
+	cancel()
+	err := <-result
+
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("serve error = %v, want %v", err, context.DeadlineExceeded)
+	}
+	select {
+	case <-srv.closed:
+	default:
+		t.Fatal("serve did not force the server closed")
+	}
+}
+
+func TestServeExpectedServerClosed(t *testing.T) {
+	srv := newStubServer(http.ErrServerClosed)
+
+	if err := serve(context.Background(), srv, time.Second); err != nil {
+		t.Fatalf("serve returned an error: %v", err)
+	}
+}
+
+func TestConfigureHTTPServer(t *testing.T) {
+	srv := &http.Server{}
+
+	configureHTTPServer(srv)
+
+	if srv.ReadHeaderTimeout != readHeaderTimeout {
+		t.Errorf("ReadHeaderTimeout = %v, want %v", srv.ReadHeaderTimeout, readHeaderTimeout)
+	}
+	if srv.ReadTimeout != readTimeout {
+		t.Errorf("ReadTimeout = %v, want %v", srv.ReadTimeout, readTimeout)
+	}
+	if srv.WriteTimeout != writeTimeout {
+		t.Errorf("WriteTimeout = %v, want %v", srv.WriteTimeout, writeTimeout)
+	}
+	if srv.IdleTimeout != idleTimeout {
+		t.Errorf("IdleTimeout = %v, want %v", srv.IdleTimeout, idleTimeout)
+	}
+}
+
+func TestFindAvailablePortZero(t *testing.T) {
+	ln, port, err := findAvailablePort("0")
+	if err != nil {
+		t.Fatalf("find available port: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := ln.Close(); err != nil {
+			t.Errorf("close listener: %v", err)
+		}
+	})
+
+	if port == "0" {
+		t.Fatal("findAvailablePort returned port 0")
+	}
+}

--- a/plugins/go-web/templates/app/server.go
+++ b/plugins/go-web/templates/app/server.go
@@ -1,0 +1,108 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net"
+	"net/http"
+	"strconv"
+	"strings"
+	"syscall"
+	"time"
+)
+
+const (
+	readHeaderTimeout = 5 * time.Second
+	readTimeout       = 15 * time.Second
+	writeTimeout      = 30 * time.Second
+	idleTimeout       = 60 * time.Second
+	shutdownTimeout   = 10 * time.Second
+)
+
+type server interface {
+	Start(string) error
+	Shutdown(context.Context) error
+	Close() error
+}
+
+func configureHTTPServer(srv *http.Server) {
+	srv.ReadHeaderTimeout = readHeaderTimeout
+	srv.ReadTimeout = readTimeout
+	srv.WriteTimeout = writeTimeout
+	srv.IdleTimeout = idleTimeout
+}
+
+func serve(ctx context.Context, srv server, timeout time.Duration) error {
+	serveErr := make(chan error, 1)
+	go func() {
+		serveErr <- srv.Start("")
+	}()
+
+	select {
+	case err := <-serveErr:
+		if errors.Is(err, http.ErrServerClosed) {
+			return nil
+		}
+		if err == nil {
+			return errors.New("serve stopped unexpectedly")
+		}
+		return fmt.Errorf("serve: %w", err)
+	case <-ctx.Done():
+	}
+
+	shutdownCtx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+
+	shutdownErr := srv.Shutdown(shutdownCtx)
+	if shutdownErr != nil {
+		shutdownErr = fmt.Errorf("shutdown: %w", shutdownErr)
+		if err := srv.Close(); err != nil {
+			shutdownErr = errors.Join(shutdownErr, fmt.Errorf("close: %w", err))
+		}
+	}
+
+	err := <-serveErr
+	if err != nil && !errors.Is(err, http.ErrServerClosed) {
+		err = fmt.Errorf("serve: %w", err)
+	} else {
+		err = nil
+	}
+	return errors.Join(shutdownErr, err)
+}
+
+func findAvailablePort(configuredPort string) (net.Listener, string, error) {
+	startPort, err := strconv.Atoi(configuredPort)
+	if err != nil {
+		return nil, "", fmt.Errorf("invalid port %q: %w", configuredPort, err)
+	}
+
+	maxPort := startPort + 100
+	for port := startPort; port <= maxPort; port++ {
+		addr := ":" + strconv.Itoa(port)
+		ln, err := net.Listen("tcp", addr)
+		if err != nil {
+			if !errors.Is(err, syscall.EADDRINUSE) {
+				return nil, "", fmt.Errorf("failed to listen on port %d: %w", port, err)
+			}
+			continue
+		}
+		actualPort := ln.Addr().(*net.TCPAddr).Port
+		return ln, strconv.Itoa(actualPort), nil
+	}
+
+	return nil, "", fmt.Errorf("no available port found in range %d-%d", startPort, maxPort)
+}
+
+func replacePort(rawURL string, newPort string) string {
+	const localhostPrefix = "://localhost:"
+	if idx := strings.Index(rawURL, localhostPrefix); idx >= 0 {
+		afterScheme := idx + len(localhostPrefix)
+		end := strings.IndexAny(rawURL[afterScheme:], "/?#")
+		if end == -1 {
+			return rawURL[:afterScheme] + newPort
+		}
+		return rawURL[:afterScheme] + newPort + rawURL[afterScheme+end:]
+	}
+	return rawURL
+}


### PR DESCRIPTION
## Summary

- configure bounded HTTP server timeouts in generated projects
- coordinate signal cancellation, serve errors, graceful shutdown, forced close, and goroutine joining
- add deterministic lifecycle and port-zero tests to generated projects

## Test Plan

- `go test -race plugins/go-web/templates/app/server.go plugins/go-web/templates/app/main_test.go`
- configured repository validation gate with `GOCACHE=/tmp/gopher-ai-go-cache`

Fixes #215