### PR TITLE
fix(ship): select installed Ollama model

### DIFF
--- a/plugins/go-workflow/hooks/legacy-skill-hashes.txt
+++ b/plugins/go-workflow/hooks/legacy-skill-hashes.txt
@@ -7,7 +7,7 @@
 # this prevents accepting a hash from skill A as proof of ownership for skill B.
 # DO NOT EDIT BY HAND — re-run the regen script after committing SKILL.md changes.
 #
-# Total entries: 228
+# Total entries: 229
 017e2d820506e7bef4a89a4d65839150db1ffdc124852a43dc916023e6d37e16 review-deep
 0322d4a7ddc204a9bf5addfec4e512edaea92ab8f4ebdd0541ca099330a09408 worktree
 03dac3a27d6da4b0a0c64ff6511df17004747e20b47a1691b4f9f030478877b9 commit
@@ -67,6 +67,7 @@
 4a3ca6fdf4b5472fa9f7fe01d22417b902c2fe1e9c332634efcb0d309fe0f6d3 go-error-handling
 4aa381d6fffa28499a0f4ec7b14e5c7b803a795581040e339a395471c1e618f5 go-profiling-optimization
 4ab5ff0022304d99cc9cc07408d83d6d359e3356de39466604b25f5608691f94 go-best-practices
+4c024d7d465cc5d0f0056721f11fd91b3264b39f70766ea4c5e47bf7a236cfa4 ship
 4c73d68a11a5344d79828be510c0477b1b117e5599e605dacb2bc9d6ee466032 go-testing
 4e2871f20d3df8c0f5e1e2009a429af162473b069c3ba2f9b7eca0ce73577c6c ship
 50e96364d86fc6aeb8cb6faac5cd072eaca29b3f4a6f8e0311cb49bd0f29fc66 go-profiling-optimization

--- a/plugins/go-workflow/lib/ship/local-review.md
+++ b/plugins/go-workflow/lib/ship/local-review.md
@@ -263,8 +263,23 @@ EOF
 
 ### Ollama
 
+Resolve the model once per ship run. On re-entry, restore `OLLAMA_MODEL` from
+the state file before resolving so every review pass uses the same model.
+
 ```bash
-ollama run codellama <<EOF
+OLLAMA_MODEL=${OLLAMA_MODEL:-$(jq -r '.ollama_model // empty' "$STATE_FILE")}
+if [ -z "$OLLAMA_MODEL" ]; then
+  if ! OLLAMA_MODEL=$("${CLAUDE_PLUGIN_ROOT}/scripts/select-ollama-model.sh"); then
+    echo "Ollama model selection failed. Fix the reported prerequisite, choose another review backend, or abort."
+    exit 1
+  fi
+
+  TMP="$STATE_FILE.tmp"
+  jq --arg model "$OLLAMA_MODEL" '.ollama_model = $model' "$STATE_FILE" > "$TMP" && mv "$TMP" "$STATE_FILE"
+fi
+
+echo "Using installed Ollama model: $OLLAMA_MODEL"
+ollama run "$OLLAMA_MODEL" <<EOF
 Review the following code changes for bugs, security issues, performance problems, and best practice violations.
 
 Report each finding with: file path, line number, severity (error/warning/suggestion), and description.
@@ -283,7 +298,7 @@ set +e
 if [ "$LLM_CHOICE" = "gemini" ]; then
   FINDINGS=$(gemini <<< "$REVIEW_PROMPT" 2>"/tmp/llm-review-stderr-$$")
 elif [ "$LLM_CHOICE" = "ollama" ]; then
-  FINDINGS=$(ollama run codellama <<< "$REVIEW_PROMPT" 2>"/tmp/llm-review-stderr-$$")
+  FINDINGS=$(ollama run "$OLLAMA_MODEL" <<< "$REVIEW_PROMPT" 2>"/tmp/llm-review-stderr-$$")
 fi
 LLM_EXIT_CODE=$?
 LLM_STDERR=$(cat "/tmp/llm-review-stderr-$$" 2>/dev/null)
@@ -291,7 +306,10 @@ rm -f "/tmp/llm-review-stderr-$$"
 set -e
 ```
 
-If exit code non-zero or output empty, display diagnostics. `AskUserQuestion` with **Retry** / **Debug / Fix** / **Use agent-based review** / **Abort**.
+If exit code non-zero or output empty, display diagnostics, including the
+selected Ollama model for an Ollama run failure. `AskUserQuestion` with
+**Retry** / **Debug / Fix** / **Use agent-based review** / **Abort**. Retry the
+same persisted model; do not silently select a different one.
 
 ### Agent-based review (only when `USE_AGENT_REVIEW=true`)
 

--- a/plugins/go-workflow/lib/ship/local-review.md
+++ b/plugins/go-workflow/lib/ship/local-review.md
@@ -269,14 +269,27 @@ the state file before resolving so every review pass uses the same model.
 ```bash
 OLLAMA_MODEL=${OLLAMA_MODEL:-$(jq -r '.ollama_model // empty' "$STATE_FILE")}
 if [ -z "$OLLAMA_MODEL" ]; then
-  if ! OLLAMA_MODEL=$("${CLAUDE_PLUGIN_ROOT}/scripts/select-ollama-model.sh"); then
-    echo "Ollama model selection failed. Fix the reported prerequisite, choose another review backend, or abort."
-    exit 1
-  fi
-
-  TMP="$STATE_FILE.tmp"
-  jq --arg model "$OLLAMA_MODEL" '.ollama_model = $model' "$STATE_FILE" > "$TMP" && mv "$TMP" "$STATE_FILE"
+  set +e
+  OLLAMA_MODEL=$("${CLAUDE_PLUGIN_ROOT}/scripts/select-ollama-model.sh" 2>"/tmp/ollama-select-stderr-$$")
+  OLLAMA_SELECT_EXIT_CODE=$?
+  OLLAMA_SELECT_STDERR=$(cat "/tmp/ollama-select-stderr-$$" 2>/dev/null)
+  rm -f "/tmp/ollama-select-stderr-$$"
+  set -e
 fi
+```
+
+If model selection exits non-zero or returns an empty model, display
+`OLLAMA_SELECT_STDERR` and `AskUserQuestion` with **Retry** / **Debug / Fix** /
+**Use agent-based review** / **Abort**, using the same outcomes as the
+Gemini/Ollama run recovery below. Retry selection; for agent-based review,
+persist `use_agent_review=true` before continuing to that section. Do not
+persist a model or continue to `ollama run` until selection succeeds.
+
+After successful selection, persist the model:
+
+```bash
+TMP="$STATE_FILE.tmp"
+jq --arg model "$OLLAMA_MODEL" '.ollama_model = $model' "$STATE_FILE" > "$TMP" && mv "$TMP" "$STATE_FILE"
 
 echo "Using installed Ollama model: $OLLAMA_MODEL"
 ollama run "$OLLAMA_MODEL" <<EOF

--- a/plugins/go-workflow/lib/ship/state-fields.md
+++ b/plugins/go-workflow/lib/ship/state-fields.md
@@ -16,7 +16,8 @@ jq --arg args "$ARGUMENTS" --arg llm "$LLM_CHOICE" --argjson pass 0 \
    --arg e2e_required "" --arg e2e_attempted "" --arg e2e_result "" \
    --arg e2e_skip_reason "" --argjson e2e_pages_tested 0 \
    --arg review_clean "" --arg head_sha "" --arg gemini_tier "$GEMINI_TIER" \
-   '. + {args: $args, llm: $llm, pass: $pass, no_merge: $no_merge, pr_number: $pr_number, base_branch: $base_branch, bot_review_baseline: $bot_review_baseline, discovered_bots: $discovered_bots, has_ci: $has_ci, skip_coverage: $skip_coverage, coverage_threshold: $coverage_threshold, coverage_result: $coverage_result, coverage_tests_generated: $coverage_tests_generated, e2e_required: $e2e_required, e2e_attempted: $e2e_attempted, e2e_result: $e2e_result, e2e_skip_reason: $e2e_skip_reason, e2e_pages_tested: $e2e_pages_tested, review_clean: $review_clean, head_sha: $head_sha, gemini_tier: $gemini_tier}' \
+   --arg ollama_model "" \
+   '. + {args: $args, llm: $llm, pass: $pass, no_merge: $no_merge, pr_number: $pr_number, base_branch: $base_branch, bot_review_baseline: $bot_review_baseline, discovered_bots: $discovered_bots, has_ci: $has_ci, skip_coverage: $skip_coverage, coverage_threshold: $coverage_threshold, coverage_result: $coverage_result, coverage_tests_generated: $coverage_tests_generated, e2e_required: $e2e_required, e2e_attempted: $e2e_attempted, e2e_result: $e2e_result, e2e_skip_reason: $e2e_skip_reason, e2e_pages_tested: $e2e_pages_tested, review_clean: $review_clean, head_sha: $head_sha, gemini_tier: $gemini_tier, ollama_model: $ollama_model}' \
    "$STATE_FILE" > "$TMP" && mv "$TMP" "$STATE_FILE"
 ```
 
@@ -49,6 +50,7 @@ routing and subsequent steps depend on these exact names.
 | `review_clean` | string | Step 5c | `"true"` when LLM returned no findings — fast-path past Step 6 on re-entry |
 | `head_sha` | string | Step 9c, 10e, 12c | Latest pushed commit; CI watch is anchored to this |
 | `gemini_tier` | string | Step 1 | `flex`/`standard`/`priority` (gemini only; warning rendered at review time) |
+| `ollama_model` | string | Step 5b | Installed Ollama model selected once and reused for every review pass |
 | `llm_check_failed` | string | Step 4b | `"true"` after diagnostic; cleared on Retry success |
 | `use_agent_review` | string | Step 4b | `"true"` when user chose agent-based review fallback |
 | `quick_mode` | string | Step 5b | `"true"` when user picked `codex review --base` after large-diff warning or timeout |

--- a/plugins/go-workflow/scripts/select-ollama-model.sh
+++ b/plugins/go-workflow/scripts/select-ollama-model.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+set -euo pipefail
+
+if ! ollama ps >/dev/null 2>&1; then
+  echo "Ollama server is not running. Start it with: ollama serve" >&2
+  exit 2
+fi
+
+MODEL_LIST=$(ollama list 2>&1) || {
+  echo "Unable to list installed Ollama models: $MODEL_LIST" >&2
+  exit 3
+}
+
+MODELS=$(printf '%s\n' "$MODEL_LIST" | awk 'NR > 1 && NF > 0 { print $1 }')
+if [ -z "$MODELS" ]; then
+  echo "No Ollama models are installed. Pull one first, for example: ollama pull qwen3-coder" >&2
+  exit 4
+fi
+
+CODE_MODEL=$(printf '%s\n' "$MODELS" | awk 'tolower($0) ~ /(code|coder)/ { print; exit }')
+if [ -n "$CODE_MODEL" ]; then
+  printf '%s\n' "$CODE_MODEL"
+else
+  printf '%s\n' "$MODELS" | awk 'NR == 1 { print; exit }'
+fi

--- a/plugins/go-workflow/skills/ship/SKILL.md
+++ b/plugins/go-workflow/skills/ship/SKILL.md
@@ -85,6 +85,8 @@ stop-hook can recover all fields on re-entry. The full jq invocation lives in
 `coverage_threshold`, `coverage_result`, `coverage_tests_generated`,
 `e2e_required`, `e2e_attempted`, `e2e_result`, `e2e_skip_reason`,
 `e2e_pages_tested`, `review_clean`, `head_sha`, `gemini_tier`.
+For Ollama reviews, Step 5 also persists `ollama_model` after resolving it from
+the installed model list.
 
 ## 2. Re-entry Check
 

--- a/scripts/legacy-skill-hashes.txt
+++ b/scripts/legacy-skill-hashes.txt
@@ -7,7 +7,7 @@
 # this prevents accepting a hash from skill A as proof of ownership for skill B.
 # DO NOT EDIT BY HAND — re-run the regen script after committing SKILL.md changes.
 #
-# Total entries: 228
+# Total entries: 229
 017e2d820506e7bef4a89a4d65839150db1ffdc124852a43dc916023e6d37e16 review-deep
 0322d4a7ddc204a9bf5addfec4e512edaea92ab8f4ebdd0541ca099330a09408 worktree
 03dac3a27d6da4b0a0c64ff6511df17004747e20b47a1691b4f9f030478877b9 commit
@@ -67,6 +67,7 @@
 4a3ca6fdf4b5472fa9f7fe01d22417b902c2fe1e9c332634efcb0d309fe0f6d3 go-error-handling
 4aa381d6fffa28499a0f4ec7b14e5c7b803a795581040e339a395471c1e618f5 go-profiling-optimization
 4ab5ff0022304d99cc9cc07408d83d6d359e3356de39466604b25f5608691f94 go-best-practices
+4c024d7d465cc5d0f0056721f11fd91b3264b39f70766ea4c5e47bf7a236cfa4 ship
 4c73d68a11a5344d79828be510c0477b1b117e5599e605dacb2bc9d6ee466032 go-testing
 4e2871f20d3df8c0f5e1e2009a429af162473b069c3ba2f9b7eca0ce73577c6c ship
 50e96364d86fc6aeb8cb6faac5cd072eaca29b3f4a6f8e0311cb49bd0f29fc66 go-profiling-optimization

--- a/scripts/test-commands.sh
+++ b/scripts/test-commands.sh
@@ -10,6 +10,7 @@ ERRORS=0
 echo "=== Command File Tests ==="
 
 "$ROOT_DIR/scripts/test-review-plan.sh"
+"$ROOT_DIR/scripts/test-ship-ollama-model.sh"
 
 # Find all command .md files
 COMMAND_FILES=$(find "$ROOT_DIR/plugins" "$ROOT_DIR/shared" -path "*/commands/*.md" -type f 2>/dev/null | sort)

--- a/scripts/test-ship-ollama-model.sh
+++ b/scripts/test-ship-ollama-model.sh
@@ -1,0 +1,70 @@
+#!/bin/bash
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+SELECTOR="$ROOT_DIR/plugins/go-workflow/scripts/select-ollama-model.sh"
+LOCAL_REVIEW="$ROOT_DIR/plugins/go-workflow/lib/ship/local-review.md"
+TEST_ROOT=$(mktemp -d "${TMPDIR:-/tmp}/gopher-ai-ship-ollama.XXXXXX")
+trap 'rm -rf "$TEST_ROOT"' EXIT
+
+fail() {
+  echo "FAIL: $1"
+  exit 1
+}
+
+run_fixture() {
+  local ps_exit="$1"
+  local list_exit="$2"
+  local fixture="$3"
+  local output_file="$4"
+  local error_file="$5"
+
+  mkdir -p "$TEST_ROOT/bin"
+  cat > "$TEST_ROOT/bin/ollama" <<EOF
+#!/bin/bash
+if [ "\$1" = "ps" ]; then
+  exit $ps_exit
+fi
+if [ "\$1" = "list" ]; then
+  printf '%s' '$fixture'
+  exit $list_exit
+fi
+exit 99
+EOF
+  chmod +x "$TEST_ROOT/bin/ollama"
+
+  PATH="$TEST_ROOT/bin:$PATH" "$SELECTOR" >"$output_file" 2>"$error_file"
+}
+
+echo "=== Ship Ollama Model Tests ==="
+
+run_fixture 0 0 $'NAME ID SIZE MODIFIED\nllama3:latest abc 4GB today\nQwen2.5-Coder:7b def 5GB today\ndeepseek-code:latest ghi 6GB today\n' "$TEST_ROOT/output" "$TEST_ROOT/error"
+[ "$(cat "$TEST_ROOT/output")" = "Qwen2.5-Coder:7b" ] || fail "first code-oriented model was not selected"
+
+run_fixture 0 0 $'NAME ID SIZE MODIFIED\nllama3:latest abc 4GB today\nmistral:latest def 5GB today\n' "$TEST_ROOT/output" "$TEST_ROOT/error"
+[ "$(cat "$TEST_ROOT/output")" = "llama3:latest" ] || fail "first installed fallback model was not selected"
+
+if run_fixture 0 0 $'NAME ID SIZE MODIFIED\n' "$TEST_ROOT/output" "$TEST_ROOT/error"; then
+  fail "empty model list succeeded"
+fi
+grep -q "No Ollama models are installed" "$TEST_ROOT/error" || fail "empty model guidance missing"
+
+if run_fixture 1 0 '' "$TEST_ROOT/output" "$TEST_ROOT/error"; then
+  fail "stopped server succeeded"
+fi
+grep -q "Ollama server is not running" "$TEST_ROOT/error" || fail "stopped server guidance missing"
+
+if run_fixture 0 1 'connection reset' "$TEST_ROOT/output" "$TEST_ROOT/error"; then
+  fail "failed model listing succeeded"
+fi
+grep -q "Unable to list installed Ollama models" "$TEST_ROOT/error" || fail "model-list failure guidance missing"
+
+if grep -q "ollama run codellama" "$LOCAL_REVIEW"; then
+  fail "hardcoded Ollama model remains in ship review"
+fi
+grep -q "ollama run \"\\\$OLLAMA_MODEL\"" "$LOCAL_REVIEW" || fail "resolved model is not used for Ollama runs"
+grep -q "same persisted model" "$LOCAL_REVIEW" || fail "Ollama run retry does not preserve the selected model"
+
+echo "All ship Ollama model tests passed."

--- a/scripts/test-ship-ollama-model.sh
+++ b/scripts/test-ship-ollama-model.sh
@@ -66,5 +66,6 @@ if grep -q "ollama run codellama" "$LOCAL_REVIEW"; then
 fi
 grep -q "ollama run \"\\\$OLLAMA_MODEL\"" "$LOCAL_REVIEW" || fail "resolved model is not used for Ollama runs"
 grep -q "same persisted model" "$LOCAL_REVIEW" || fail "Ollama run retry does not preserve the selected model"
+grep -q "Retry.*Debug / Fix.*Use agent-based review.*Abort" "$LOCAL_REVIEW" || fail "model-selection failure has no recovery path"
 
 echo "All ship Ollama model tests passed."


### PR DESCRIPTION
## Summary

- select the first installed code-oriented Ollama model, falling back to the first installed model
- persist and reuse the selected model across ship review passes and re-entry
- add fixture coverage for preferred, fallback, empty, unavailable, and failed-list cases

## Test Plan

- `./scripts/test-ship-ollama-model.sh`
- `shellcheck plugins/go-workflow/scripts/select-ollama-model.sh scripts/test-ship-ollama-model.sh`
- configured repository validation gate

Fixes #216