### PR TITLE
fix(codex): honor native review models

### DIFF
--- a/plugins/go-workflow/lib/ship/local-review.md
+++ b/plugins/go-workflow/lib/ship/local-review.md
@@ -184,7 +184,7 @@ If `codex exec` returns non-JSON or empty output (and exit code 0), do NOT fall 
 ```bash
 CODEX_REVIEW_MODEL_ARGS=()
 if [ -n "${MODEL:-}" ]; then
-  CODEX_REVIEW_MODEL_ARGS=(-c "model=$MODEL")
+  CODEX_REVIEW_MODEL_ARGS=(-c "review_model=$MODEL")
 fi
 
 $CODEX_CMD review --base "$BASE_BRANCH" "${CODEX_REVIEW_MODEL_ARGS[@]}" -c model_reasoning_effort="high"

--- a/plugins/llm-tools/commands/codex.md
+++ b/plugins/llm-tools/commands/codex.md
@@ -34,7 +34,7 @@ Display usage and ask for input:
 | Option | Behavior |
 |--------|----------|
 | Provider default | Let Codex CLI choose the latest recommended Codex model |
-| Custom model ID | Pass an explicit model with `-m` or `-c model=...` |
+| Custom model ID | Pass an explicit model with `-m` for `codex exec` or `-c review_model=...` for `codex review` |
 
 Ask the user: "What would you like Codex to do?"
 

--- a/plugins/llm-tools/lib/codex/review-flow.md
+++ b/plugins/llm-tools/lib/codex/review-flow.md
@@ -49,7 +49,7 @@ Ask all review configuration questions in a **single `AskUserQuestion` call** wi
 | Option | Description |
 |--------|-------------|
 | Provider default (Recommended) | Let Codex CLI choose the latest recommended Codex model |
-| Custom model ID | Enter an exact model ID; only this choice passes `-m` or `-c model=...` |
+| Custom model ID | Enter an exact model ID; only this choice passes `-m` for exhaustive `codex exec` or `-c review_model=...` for native `codex review` |
 
 **Question 4 — "Review depth?"**
 
@@ -293,7 +293,7 @@ Build optional model config first. Leave `MODEL_CONFIG` empty for provider defau
 ```bash
 MODEL_CONFIG=()
 if [ -n "$MODEL" ]; then
-  MODEL_CONFIG=(-c "model=$MODEL")
+  MODEL_CONFIG=(-c "review_model=$MODEL")
 fi
 ```
 
@@ -472,7 +472,7 @@ Review these changes against the requirements above. Ensure the implementation a
 ```bash
 MODEL_CONFIG=()
 if [ -n "$MODEL" ]; then
-  MODEL_CONFIG=(-c "model=$MODEL")
+  MODEL_CONFIG=(-c "review_model=$MODEL")
 fi
 
 $CODEX_CMD review "${MODEL_CONFIG[@]}" -c model_reasoning_effort="high" - <<'EOF'

--- a/plugins/llm-tools/lib/review-loop/review-phase.md
+++ b/plugins/llm-tools/lib/review-loop/review-phase.md
@@ -162,7 +162,7 @@ Standard `codex review`, faster but capped at 2-3 findings per pass.
 ```bash
 MODEL_CONFIG=()
 if [ -n "$MODEL" ]; then
-  MODEL_CONFIG=(-c "model=$MODEL")
+  MODEL_CONFIG=(-c "review_model=$MODEL")
 fi
 
 # For changes vs branch:

--- a/scripts/test-codex-review-model.sh
+++ b/scripts/test-codex-review-model.sh
@@ -13,7 +13,7 @@ assert_count() {
   local file="$3"
   local actual
 
-  actual=$(rg -c --fixed-strings "$pattern" "$file" || true)
+  actual=$(grep -cF -- "$pattern" "$file" || true)
   if [ "$actual" != "$expected" ]; then
     echo "FAILED: expected $expected occurrence(s) of '$pattern' in ${file#"$ROOT_DIR/"}, found $actual"
     exit 1
@@ -28,17 +28,17 @@ assert_count 2 'MODEL_CONFIG=()' "$REVIEW_FLOW"
 assert_count 1 'MODEL_CONFIG=()' "$REVIEW_LOOP"
 assert_count 1 'CODEX_REVIEW_MODEL_ARGS=()' "$SHIP_REVIEW"
 
-if rg -n --fixed-strings -- '-c "model=$MODEL"' "$REVIEW_FLOW" "$REVIEW_LOOP" "$SHIP_REVIEW"; then
+if grep -nF -- '-c "model=$MODEL"' "$REVIEW_FLOW" "$REVIEW_LOOP" "$SHIP_REVIEW"; then
   echo "FAILED: native codex review path uses the normal model configuration key"
   exit 1
 fi
 
-if ! rg -q --fixed-strings 'CODEX_MODEL_ARGS=(-m "$MODEL")' "$SHIP_REVIEW"; then
+if ! grep -qF -- 'CODEX_MODEL_ARGS=(-m "$MODEL")' "$SHIP_REVIEW"; then
   echo "FAILED: exhaustive codex exec custom-model override changed"
   exit 1
 fi
 
-if rg -n -- 'review --base.*(model|review_model)=' "$COMPLETE_FALLBACK"; then
+if grep -nE -- 'review --base.*(model|review_model)=' "$COMPLETE_FALLBACK"; then
   echo "FAILED: complete-issue default review fallback overrides a model"
   exit 1
 fi

--- a/scripts/test-codex-review-model.sh
+++ b/scripts/test-codex-review-model.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+REVIEW_FLOW="$ROOT_DIR/plugins/llm-tools/lib/codex/review-flow.md"
+REVIEW_LOOP="$ROOT_DIR/plugins/llm-tools/lib/review-loop/review-phase.md"
+SHIP_REVIEW="$ROOT_DIR/plugins/go-workflow/lib/ship/local-review.md"
+COMPLETE_FALLBACK="$ROOT_DIR/plugins/go-workflow/skills/complete-issue/phases.md"
+
+assert_count() {
+  local expected="$1"
+  local pattern="$2"
+  local file="$3"
+  local actual
+
+  actual=$(rg -c --fixed-strings "$pattern" "$file" || true)
+  if [ "$actual" != "$expected" ]; then
+    echo "FAILED: expected $expected occurrence(s) of '$pattern' in ${file#"$ROOT_DIR/"}, found $actual"
+    exit 1
+  fi
+}
+
+assert_count 2 'MODEL_CONFIG=(-c "review_model=$MODEL")' "$REVIEW_FLOW"
+assert_count 1 'MODEL_CONFIG=(-c "review_model=$MODEL")' "$REVIEW_LOOP"
+assert_count 1 'CODEX_REVIEW_MODEL_ARGS=(-c "review_model=$MODEL")' "$SHIP_REVIEW"
+
+assert_count 2 'MODEL_CONFIG=()' "$REVIEW_FLOW"
+assert_count 1 'MODEL_CONFIG=()' "$REVIEW_LOOP"
+assert_count 1 'CODEX_REVIEW_MODEL_ARGS=()' "$SHIP_REVIEW"
+
+if rg -n --fixed-strings -- '-c "model=$MODEL"' "$REVIEW_FLOW" "$REVIEW_LOOP" "$SHIP_REVIEW"; then
+  echo "FAILED: native codex review path uses the normal model configuration key"
+  exit 1
+fi
+
+if ! rg -q --fixed-strings 'CODEX_MODEL_ARGS=(-m "$MODEL")' "$SHIP_REVIEW"; then
+  echo "FAILED: exhaustive codex exec custom-model override changed"
+  exit 1
+fi
+
+if rg -n -- 'review --base.*(model|review_model)=' "$COMPLETE_FALLBACK"; then
+  echo "FAILED: complete-issue default review fallback overrides a model"
+  exit 1
+fi
+
+echo "All Codex review model tests passed."

--- a/scripts/test-commands.sh
+++ b/scripts/test-commands.sh
@@ -10,6 +10,7 @@ ERRORS=0
 echo "=== Command File Tests ==="
 
 "$ROOT_DIR/scripts/test-review-plan.sh"
+"$ROOT_DIR/scripts/test-codex-review-model.sh"
 "$ROOT_DIR/scripts/test-ship-ollama-model.sh"
 
 # Find all command .md files


### PR DESCRIPTION
## Summary

- use Codex `review_model` for explicit custom models in native review paths
- preserve model-free defaults and exhaustive `codex exec` model behavior
- add command-composition fixtures and a regression scan across review, review-loop, ship, and complete-issue fallback paths

## Test Plan

- `./scripts/test-codex-review-model.sh`
- `./scripts/test-commands.sh`
- full configured validation gate with `GOCACHE=/tmp/gopher-ai-go-cache`

Fixes #217