### PR TITLE
fix(go-web): scope database initialization

### DIFF
--- a/plugins/go-web/templates/app/main.go
+++ b/plugins/go-web/templates/app/main.go
@@ -60,7 +60,11 @@ func run() error {
 	if err != nil {
 		return fmt.Errorf("connect to database: %w", err)
 	}
-	defer db.Close()
+	defer func() {
+		if err := db.Close(); err != nil {
+			slog.Error("failed to close database", "error", err)
+		}
+	}()
 
 	e := echo.New()
 	e.HideBanner = true

--- a/plugins/go-web/templates/app/testutil.mysql.go
+++ b/plugins/go-web/templates/app/testutil.mysql.go
@@ -23,7 +23,11 @@ func NewTestDB(t *testing.T) *database.DB {
 		t.Fatalf("failed to create test database: %v", err)
 	}
 
-	t.Cleanup(db.Close)
+	t.Cleanup(func() {
+		if err := db.Close(); err != nil {
+			t.Errorf("failed to close test database: %v", err)
+		}
+	})
 
 	return db
 }

--- a/plugins/go-web/templates/app/testutil.postgres.go
+++ b/plugins/go-web/templates/app/testutil.postgres.go
@@ -23,7 +23,11 @@ func NewTestDB(t *testing.T) *database.DB {
 		t.Fatalf("failed to create test database: %v", err)
 	}
 
-	t.Cleanup(db.Close)
+	t.Cleanup(func() {
+		if err := db.Close(); err != nil {
+			t.Errorf("failed to close test database: %v", err)
+		}
+	})
 
 	return db
 }

--- a/plugins/go-web/templates/app/testutil.sqlite.go
+++ b/plugins/go-web/templates/app/testutil.sqlite.go
@@ -18,7 +18,11 @@ func NewTestDB(t *testing.T) *database.DB {
 		t.Fatalf("failed to create test database: %v", err)
 	}
 
-	t.Cleanup(db.Close)
+	t.Cleanup(func() {
+		if err := db.Close(); err != nil {
+			t.Errorf("failed to close test database: %v", err)
+		}
+	})
 
 	return db
 }

--- a/plugins/go-web/templates/db/database.mysql.go
+++ b/plugins/go-web/templates/db/database.mysql.go
@@ -4,10 +4,12 @@ import (
     "context"
     "database/sql"
     "embed"
+    "errors"
     "fmt"
+    "io/fs"
 
-    "github.com/pressly/goose/v3"
     _ "github.com/go-sql-driver/mysql"
+    "github.com/pressly/goose/v3"
     "{{PROJECT_NAME}}/internal/database/sqlc"
 )
 
@@ -19,11 +21,18 @@ type DB struct {
     Queries *sqlc.Queries
 }
 
-func New(ctx context.Context, dsn string) (*DB, error) {
+func New(ctx context.Context, dsn string) (_ *DB, err error) {
     conn, err := sql.Open("mysql", dsn)
     if err != nil {
         return nil, fmt.Errorf("unable to open database: %w", err)
     }
+    defer func() {
+        if err != nil {
+            if closeErr := conn.Close(); closeErr != nil {
+                err = errors.Join(err, fmt.Errorf("failed to close database: %w", closeErr))
+            }
+        }
+    }()
 
     if err := conn.PingContext(ctx); err != nil {
         return nil, fmt.Errorf("unable to ping database: %w", err)
@@ -34,25 +43,34 @@ func New(ctx context.Context, dsn string) (*DB, error) {
         Queries: sqlc.New(conn),
     }
 
-    if err := db.migrate(); err != nil {
+    if err := db.migrate(ctx); err != nil {
         return nil, fmt.Errorf("unable to run migrations: %w", err)
     }
 
     return db, nil
 }
 
-func (db *DB) Close() {
-    db.Conn.Close()
+func (db *DB) Close() error {
+    return db.Conn.Close()
 }
 
-func (db *DB) migrate() error {
-    goose.SetBaseFS(migrationsFS)
-
-    if err := goose.SetDialect("mysql"); err != nil {
-        return fmt.Errorf("failed to set goose dialect: %w", err)
+func (db *DB) migrate(ctx context.Context) error {
+    migrations, err := fs.Sub(migrationsFS, "migrations")
+    if err != nil {
+        return fmt.Errorf("failed to load migrations: %w", err)
     }
 
-    if err := goose.Up(db.Conn, "migrations"); err != nil {
+    provider, err := goose.NewProvider(
+        goose.DialectMySQL,
+        db.Conn,
+        migrations,
+        goose.WithDisableGlobalRegistry(true),
+    )
+    if err != nil {
+        return fmt.Errorf("failed to create goose provider: %w", err)
+    }
+
+    if _, err := provider.Up(ctx); err != nil {
         return fmt.Errorf("failed to run migrations: %w", err)
     }
 

--- a/plugins/go-web/templates/db/database.postgres.go
+++ b/plugins/go-web/templates/db/database.postgres.go
@@ -3,7 +3,9 @@ package database
 import (
     "context"
     "embed"
+    "errors"
     "fmt"
+    "io/fs"
 
     "github.com/jackc/pgx/v5/pgxpool"
     "github.com/jackc/pgx/v5/stdlib"
@@ -19,11 +21,16 @@ type DB struct {
     Queries *sqlc.Queries
 }
 
-func New(ctx context.Context, databaseURL string) (*DB, error) {
+func New(ctx context.Context, databaseURL string) (_ *DB, err error) {
     pool, err := pgxpool.New(ctx, databaseURL)
     if err != nil {
         return nil, fmt.Errorf("unable to create connection pool: %w", err)
     }
+    defer func() {
+        if err != nil {
+            pool.Close()
+        }
+    }()
 
     if err := pool.Ping(ctx); err != nil {
         return nil, fmt.Errorf("unable to ping database: %w", err)
@@ -34,29 +41,42 @@ func New(ctx context.Context, databaseURL string) (*DB, error) {
         Queries: sqlc.New(pool),
     }
 
-    if err := db.migrate(); err != nil {
+    if err := db.migrate(ctx); err != nil {
         return nil, fmt.Errorf("unable to run migrations: %w", err)
     }
 
     return db, nil
 }
 
-func (db *DB) Close() {
+func (db *DB) Close() error {
     db.Pool.Close()
+    return nil
 }
 
-func (db *DB) migrate() error {
-    goose.SetBaseFS(migrationsFS)
-
-    if err := goose.SetDialect("postgres"); err != nil {
-        return fmt.Errorf("failed to set goose dialect: %w", err)
+func (db *DB) migrate(ctx context.Context) (err error) {
+    migrations, err := fs.Sub(migrationsFS, "migrations")
+    if err != nil {
+        return fmt.Errorf("failed to load migrations: %w", err)
     }
 
-    // Get stdlib connection for goose
     conn := stdlib.OpenDBFromPool(db.Pool)
-    defer conn.Close()
+    defer func() {
+        if closeErr := conn.Close(); closeErr != nil {
+            err = errors.Join(err, fmt.Errorf("failed to close migration connection: %w", closeErr))
+        }
+    }()
 
-    if err := goose.Up(conn, "migrations"); err != nil {
+    provider, err := goose.NewProvider(
+        goose.DialectPostgres,
+        conn,
+        migrations,
+        goose.WithDisableGlobalRegistry(true),
+    )
+    if err != nil {
+        return fmt.Errorf("failed to create goose provider: %w", err)
+    }
+
+    if _, err := provider.Up(ctx); err != nil {
         return fmt.Errorf("failed to run migrations: %w", err)
     }
 

--- a/plugins/go-web/templates/db/database.sqlite.go
+++ b/plugins/go-web/templates/db/database.sqlite.go
@@ -4,7 +4,9 @@ import (
     "context"
     "database/sql"
     "embed"
+    "errors"
     "fmt"
+    "io/fs"
     "os"
     "path/filepath"
 
@@ -21,7 +23,7 @@ type DB struct {
     Queries *sqlc.Queries
 }
 
-func New(ctx context.Context, databasePath string) (*DB, error) {
+func New(ctx context.Context, databasePath string) (_ *DB, err error) {
     dir := filepath.Dir(databasePath)
     if err := os.MkdirAll(dir, 0755); err != nil {
         return nil, fmt.Errorf("unable to create database directory: %w", err)
@@ -31,6 +33,13 @@ func New(ctx context.Context, databasePath string) (*DB, error) {
     if err != nil {
         return nil, fmt.Errorf("unable to open database: %w", err)
     }
+    defer func() {
+        if err != nil {
+            if closeErr := conn.Close(); closeErr != nil {
+                err = errors.Join(err, fmt.Errorf("failed to close database: %w", closeErr))
+            }
+        }
+    }()
 
     if err := conn.PingContext(ctx); err != nil {
         return nil, fmt.Errorf("unable to ping database: %w", err)
@@ -41,25 +50,34 @@ func New(ctx context.Context, databasePath string) (*DB, error) {
         Queries: sqlc.New(conn),
     }
 
-    if err := db.migrate(); err != nil {
+    if err := db.migrate(ctx); err != nil {
         return nil, fmt.Errorf("unable to run migrations: %w", err)
     }
 
     return db, nil
 }
 
-func (db *DB) Close() {
-    db.Conn.Close()
+func (db *DB) Close() error {
+    return db.Conn.Close()
 }
 
-func (db *DB) migrate() error {
-    goose.SetBaseFS(migrationsFS)
-
-    if err := goose.SetDialect("sqlite3"); err != nil {
-        return fmt.Errorf("failed to set goose dialect: %w", err)
+func (db *DB) migrate(ctx context.Context) error {
+    migrations, err := fs.Sub(migrationsFS, "migrations")
+    if err != nil {
+        return fmt.Errorf("failed to load migrations: %w", err)
     }
 
-    if err := goose.Up(db.Conn, "migrations"); err != nil {
+    provider, err := goose.NewProvider(
+        goose.DialectSQLite3,
+        db.Conn,
+        migrations,
+        goose.WithDisableGlobalRegistry(true),
+    )
+    if err != nil {
+        return fmt.Errorf("failed to create goose provider: %w", err)
+    }
+
+    if _, err := provider.Up(ctx); err != nil {
         return fmt.Errorf("failed to run migrations: %w", err)
     }
 

--- a/scripts/test-commands.sh
+++ b/scripts/test-commands.sh
@@ -158,44 +158,44 @@ DB_TEMPLATES=(
 for entry in "${DB_TEMPLATES[@]}"; do
   file="${entry%%:*}"
   dialect="${entry#*:}"
-  open_line=$(rg -n 'pool, err := pgxpool.New|conn, err := sql.Open' "$file" | head -1 | cut -d: -f1)
-  cleanup_line=$(rg -n 'defer func\(\)' "$file" | head -1 | cut -d: -f1)
-  ping_line=$(rg -n 'Ping(Context)?\(ctx\)' "$file" | head -1 | cut -d: -f1)
-  migration_line=$(rg -n 'db\.migrate\(ctx\)' "$file" | head -1 | cut -d: -f1)
+  open_line=$(grep -nE 'pool, err := pgxpool.New|conn, err := sql.Open' "$file" | head -1 | cut -d: -f1)
+  cleanup_line=$(grep -nE 'defer func\(\)' "$file" | head -1 | cut -d: -f1)
+  ping_line=$(grep -nE 'Ping(Context)?\(ctx\)' "$file" | head -1 | cut -d: -f1)
+  migration_line=$(grep -nE 'db\.migrate\(ctx\)' "$file" | head -1 | cut -d: -f1)
 
   if [ -z "$open_line" ] || [ -z "$cleanup_line" ] || [ -z "$ping_line" ] || [ -z "$migration_line" ] ||
      [ "$cleanup_line" -le "$open_line" ] || [ "$cleanup_line" -ge "$ping_line" ] || [ "$cleanup_line" -ge "$migration_line" ]; then
     DB_TEMPLATE_FAILURE="${file#"$ROOT_DIR"/} does not guard every post-open failure with cleanup"
     break
   fi
-  if ! rg -Fq "goose.NewProvider(" "$file" ||
-     ! rg -Fq "$dialect" "$file" ||
-     ! rg -Fq 'goose.WithDisableGlobalRegistry(true)' "$file" ||
-     ! rg -Fq 'provider.Up(ctx)' "$file" ||
-     ! rg -Fq 'fs.Sub(migrationsFS, "migrations")' "$file"; then
+  if ! grep -Fq "goose.NewProvider(" "$file" ||
+     ! grep -Fq "$dialect" "$file" ||
+     ! grep -Fq 'goose.WithDisableGlobalRegistry(true)' "$file" ||
+     ! grep -Fq 'provider.Up(ctx)' "$file" ||
+     ! grep -Fq 'fs.Sub(migrationsFS, "migrations")' "$file"; then
     DB_TEMPLATE_FAILURE="${file#"$ROOT_DIR"/} does not use a context-aware instance provider"
     break
   fi
-  if ! rg -Fq 'func (db *DB) Close() error' "$file"; then
+  if ! grep -Fq 'func (db *DB) Close() error' "$file"; then
     DB_TEMPLATE_FAILURE="${file#"$ROOT_DIR"/} does not expose shutdown errors consistently"
     break
   fi
 done
 
-if [ -z "$DB_TEMPLATE_FAILURE" ] && rg -n 'goose\.(SetBaseFS|SetDialect|Up)\(' "${DB_TEMPLATES[@]%%:*}" >/dev/null; then
+if [ -z "$DB_TEMPLATE_FAILURE" ] && grep -nE 'goose\.(SetBaseFS|SetDialect|Up)\(' "${DB_TEMPLATES[@]%%:*}" >/dev/null; then
   DB_TEMPLATE_FAILURE="database templates still mutate goose package globals"
 fi
 if [ -z "$DB_TEMPLATE_FAILURE" ] &&
-   { ! rg -Fq 'errors.Join(err, fmt.Errorf("failed to close database: %w", closeErr))' "$ROOT_DIR/plugins/go-web/templates/db/database.sqlite.go" ||
-     ! rg -Fq 'errors.Join(err, fmt.Errorf("failed to close database: %w", closeErr))' "$ROOT_DIR/plugins/go-web/templates/db/database.mysql.go" ||
-     ! rg -Fq 'errors.Join(err, fmt.Errorf("failed to close migration connection: %w", closeErr))' "$ROOT_DIR/plugins/go-web/templates/db/database.postgres.go"; }; then
+   { ! grep -Fq 'errors.Join(err, fmt.Errorf("failed to close database: %w", closeErr))' "$ROOT_DIR/plugins/go-web/templates/db/database.sqlite.go" ||
+     ! grep -Fq 'errors.Join(err, fmt.Errorf("failed to close database: %w", closeErr))' "$ROOT_DIR/plugins/go-web/templates/db/database.mysql.go" ||
+     ! grep -Fq 'errors.Join(err, fmt.Errorf("failed to close migration connection: %w", closeErr))' "$ROOT_DIR/plugins/go-web/templates/db/database.postgres.go"; }; then
   DB_TEMPLATE_FAILURE="database close errors are not preserved"
 fi
 if [ -z "$DB_TEMPLATE_FAILURE" ] &&
-   { ! rg -Fq 'if err := db.Close(); err != nil {' "$ROOT_DIR/plugins/go-web/templates/app/main.go" ||
-     ! rg -Fq 'if err := db.Close(); err != nil {' "$ROOT_DIR/plugins/go-web/templates/app/testutil.postgres.go" ||
-     ! rg -Fq 'if err := db.Close(); err != nil {' "$ROOT_DIR/plugins/go-web/templates/app/testutil.sqlite.go" ||
-     ! rg -Fq 'if err := db.Close(); err != nil {' "$ROOT_DIR/plugins/go-web/templates/app/testutil.mysql.go"; }; then
+   { ! grep -Fq 'if err := db.Close(); err != nil {' "$ROOT_DIR/plugins/go-web/templates/app/main.go" ||
+     ! grep -Fq 'if err := db.Close(); err != nil {' "$ROOT_DIR/plugins/go-web/templates/app/testutil.postgres.go" ||
+     ! grep -Fq 'if err := db.Close(); err != nil {' "$ROOT_DIR/plugins/go-web/templates/app/testutil.sqlite.go" ||
+     ! grep -Fq 'if err := db.Close(); err != nil {' "$ROOT_DIR/plugins/go-web/templates/app/testutil.mysql.go"; }; then
   DB_TEMPLATE_FAILURE="generated shutdown call sites discard database close errors"
 fi
 

--- a/scripts/test-commands.sh
+++ b/scripts/test-commands.sh
@@ -147,6 +147,67 @@ fi
 
 echo ""
 
+echo -n "Database templates keep initialization instance-scoped and leak-free... "
+DB_TEMPLATE_FAILURE=""
+DB_TEMPLATES=(
+  "$ROOT_DIR/plugins/go-web/templates/db/database.postgres.go:goose.DialectPostgres"
+  "$ROOT_DIR/plugins/go-web/templates/db/database.sqlite.go:goose.DialectSQLite3"
+  "$ROOT_DIR/plugins/go-web/templates/db/database.mysql.go:goose.DialectMySQL"
+)
+
+for entry in "${DB_TEMPLATES[@]}"; do
+  file="${entry%%:*}"
+  dialect="${entry#*:}"
+  open_line=$(rg -n 'pool, err := pgxpool.New|conn, err := sql.Open' "$file" | head -1 | cut -d: -f1)
+  cleanup_line=$(rg -n 'defer func\(\)' "$file" | head -1 | cut -d: -f1)
+  ping_line=$(rg -n 'Ping(Context)?\(ctx\)' "$file" | head -1 | cut -d: -f1)
+  migration_line=$(rg -n 'db\.migrate\(ctx\)' "$file" | head -1 | cut -d: -f1)
+
+  if [ -z "$open_line" ] || [ -z "$cleanup_line" ] || [ -z "$ping_line" ] || [ -z "$migration_line" ] ||
+     [ "$cleanup_line" -le "$open_line" ] || [ "$cleanup_line" -ge "$ping_line" ] || [ "$cleanup_line" -ge "$migration_line" ]; then
+    DB_TEMPLATE_FAILURE="${file#"$ROOT_DIR"/} does not guard every post-open failure with cleanup"
+    break
+  fi
+  if ! rg -Fq "goose.NewProvider(" "$file" ||
+     ! rg -Fq "$dialect" "$file" ||
+     ! rg -Fq 'goose.WithDisableGlobalRegistry(true)' "$file" ||
+     ! rg -Fq 'provider.Up(ctx)' "$file" ||
+     ! rg -Fq 'fs.Sub(migrationsFS, "migrations")' "$file"; then
+    DB_TEMPLATE_FAILURE="${file#"$ROOT_DIR"/} does not use a context-aware instance provider"
+    break
+  fi
+  if ! rg -Fq 'func (db *DB) Close() error' "$file"; then
+    DB_TEMPLATE_FAILURE="${file#"$ROOT_DIR"/} does not expose shutdown errors consistently"
+    break
+  fi
+done
+
+if [ -z "$DB_TEMPLATE_FAILURE" ] && rg -n 'goose\.(SetBaseFS|SetDialect|Up)\(' "${DB_TEMPLATES[@]%%:*}" >/dev/null; then
+  DB_TEMPLATE_FAILURE="database templates still mutate goose package globals"
+fi
+if [ -z "$DB_TEMPLATE_FAILURE" ] &&
+   { ! rg -Fq 'errors.Join(err, fmt.Errorf("failed to close database: %w", closeErr))' "$ROOT_DIR/plugins/go-web/templates/db/database.sqlite.go" ||
+     ! rg -Fq 'errors.Join(err, fmt.Errorf("failed to close database: %w", closeErr))' "$ROOT_DIR/plugins/go-web/templates/db/database.mysql.go" ||
+     ! rg -Fq 'errors.Join(err, fmt.Errorf("failed to close migration connection: %w", closeErr))' "$ROOT_DIR/plugins/go-web/templates/db/database.postgres.go"; }; then
+  DB_TEMPLATE_FAILURE="database close errors are not preserved"
+fi
+if [ -z "$DB_TEMPLATE_FAILURE" ] &&
+   { ! rg -Fq 'if err := db.Close(); err != nil {' "$ROOT_DIR/plugins/go-web/templates/app/main.go" ||
+     ! rg -Fq 'if err := db.Close(); err != nil {' "$ROOT_DIR/plugins/go-web/templates/app/testutil.postgres.go" ||
+     ! rg -Fq 'if err := db.Close(); err != nil {' "$ROOT_DIR/plugins/go-web/templates/app/testutil.sqlite.go" ||
+     ! rg -Fq 'if err := db.Close(); err != nil {' "$ROOT_DIR/plugins/go-web/templates/app/testutil.mysql.go"; }; then
+  DB_TEMPLATE_FAILURE="generated shutdown call sites discard database close errors"
+fi
+
+if [ -n "$DB_TEMPLATE_FAILURE" ]; then
+  echo "FAIL ($DB_TEMPLATE_FAILURE)"
+  ERRORS=$((ERRORS + 1))
+else
+  echo "OK"
+fi
+
+echo ""
+
 echo -n "Gemini image defaults and request tiers are valid... "
 GEMINI_IMAGE_DIR="$ROOT_DIR/plugins/llm-tools/skills/gemini-image"
 GEMINI_COMMAND="$ROOT_DIR/plugins/llm-tools/commands/gemini-image.md"

--- a/scripts/test-go-web-templates.sh
+++ b/scripts/test-go-web-templates.sh
@@ -72,7 +72,7 @@ func New(_ context.Context, databaseURL string) (*DB, error) {
 	return &DB{URL: databaseURL}, nil
 }
 
-func (db *DB) Close() {}
+func (db *DB) Close() error { return nil }
 EOF
 }
 


### PR DESCRIPTION
## Summary

- close PostgreSQL, SQLite, and MySQL resources when database initialization fails
- run Goose migrations through instance-scoped providers instead of package globals
- handle generated database close errors and add template lifecycle contract checks

## Test Plan

- `./scripts/test-commands.sh`
- materialize each database backend template and run `go build ./...` and `go test ./...`
- current-head pull request CI

Fixes #214