### PR TITLE
fix(ship): default merge strategy to squash

### DIFF
--- a/plugins/go-workflow/hooks/legacy-skill-hashes.txt
+++ b/plugins/go-workflow/hooks/legacy-skill-hashes.txt
@@ -7,7 +7,7 @@
 # this prevents accepting a hash from skill A as proof of ownership for skill B.
 # DO NOT EDIT BY HAND — re-run the regen script after committing SKILL.md changes.
 #
-# Total entries: 232
+# Total entries: 233
 017e2d820506e7bef4a89a4d65839150db1ffdc124852a43dc916023e6d37e16 review-deep
 0322d4a7ddc204a9bf5addfec4e512edaea92ab8f4ebdd0541ca099330a09408 worktree
 03dac3a27d6da4b0a0c64ff6511df17004747e20b47a1691b4f9f030478877b9 commit
@@ -238,5 +238,6 @@ fba7e012a27a37cc5adc0c7c1b165a39367ff9718069d848a7530ea9893ceffa start-issue
 fbdec027766fa0a9ff4db653bf798163e4152def6ecfdcab90ec2c7313716562 ship
 fd406fb3c75d1c7a52213d6a76671bfdafdf2e189d0c1aeeaa3baeaf14903418 templui
 fe04f2c0e2f9443c094569956f56cbb4a429c480a063017aa14efccfd8d05e34 gopher-guides
+fe65ab6e9a73dda7e1c5a106ae0b61ba70e4023ce0a0358fc9a833c15637d3d2 ship
 fe9d92a44b8384540e6e98a8657acf7403338d716b3502300eea4d411ec27bb4 go-profiling-optimization
 ff3e7bea631be4948e237cb9a9654e31f5194274831494df45c939004c3660c2 remove-worktree

--- a/plugins/go-workflow/lib/ship/merge.md
+++ b/plugins/go-workflow/lib/ship/merge.md
@@ -91,12 +91,14 @@ if [ -n "$MERGE_METHOD" ]; then
     merge|squash|rebase) ;;
     *)
       echo "Invalid SHIP_MERGE_STRATEGY '$MERGE_METHOD'. Expected merge, squash, or rebase."
+      "${CLAUDE_PLUGIN_ROOT}/scripts/cleanup-loop.sh" "ship"
       exit 1
       ;;
   esac
 
   if ! echo "$MERGE_SETTINGS" | jq -e --arg method "$MERGE_METHOD" '.[$method] == true' >/dev/null 2>&1; then
     echo "Configured merge strategy '$MERGE_METHOD' is not allowed by $OWNER/$REPO."
+    "${CLAUDE_PLUGIN_ROOT}/scripts/cleanup-loop.sh" "ship"
     exit 1
   fi
 elif echo "$MERGE_SETTINGS" | jq -e '.squash == true' >/dev/null 2>&1; then
@@ -107,6 +109,7 @@ elif echo "$MERGE_SETTINGS" | jq -e '.merge == true' >/dev/null 2>&1; then
   MERGE_METHOD="merge"
 else
   echo "No allowed merge strategy is configured for $OWNER/$REPO."
+  "${CLAUDE_PLUGIN_ROOT}/scripts/cleanup-loop.sh" "ship"
   exit 1
 fi
 

--- a/plugins/go-workflow/lib/ship/merge.md
+++ b/plugins/go-workflow/lib/ship/merge.md
@@ -85,17 +85,38 @@ OWNER=$(gh repo view --json owner --jq '.owner.login')
 REPO=$(gh repo view --json name --jq '.name')
 MERGE_SETTINGS=$(gh api "repos/$OWNER/$REPO" --jq '{merge: .allow_merge_commit, squash: .allow_squash_merge, rebase: .allow_rebase_merge}' 2>/dev/null || echo '{}')
 
-MERGE_FLAG="--merge"
-if echo "$MERGE_SETTINGS" | jq -e '.merge == true' >/dev/null 2>&1; then
-  MERGE_FLAG="--merge"
+MERGE_METHOD="${SHIP_MERGE_STRATEGY:-}"
+if [ -n "$MERGE_METHOD" ]; then
+  case "$MERGE_METHOD" in
+    merge|squash|rebase) ;;
+    *)
+      echo "Invalid SHIP_MERGE_STRATEGY '$MERGE_METHOD'. Expected merge, squash, or rebase."
+      exit 1
+      ;;
+  esac
+
+  if ! echo "$MERGE_SETTINGS" | jq -e --arg method "$MERGE_METHOD" '.[$method] == true' >/dev/null 2>&1; then
+    echo "Configured merge strategy '$MERGE_METHOD' is not allowed by $OWNER/$REPO."
+    exit 1
+  fi
 elif echo "$MERGE_SETTINGS" | jq -e '.squash == true' >/dev/null 2>&1; then
-  MERGE_FLAG="--squash"
+  MERGE_METHOD="squash"
 elif echo "$MERGE_SETTINGS" | jq -e '.rebase == true' >/dev/null 2>&1; then
-  MERGE_FLAG="--rebase"
+  MERGE_METHOD="rebase"
+elif echo "$MERGE_SETTINGS" | jq -e '.merge == true' >/dev/null 2>&1; then
+  MERGE_METHOD="merge"
+else
+  echo "No allowed merge strategy is configured for $OWNER/$REPO."
+  exit 1
 fi
+
+MERGE_FLAG="--$MERGE_METHOD"
 ```
 
-Prefer merge > squash > rebase (matches GitHub's default fallback chain).
+`SHIP_MERGE_STRATEGY` is the explicit per-project policy and must be `merge`,
+`squash`, or `rebase`. Ship uses it exactly when the repository allows it and
+stops with an error otherwise. Without an explicit policy, prefer squash >
+rebase > merge.
 
 ## 13d. Branch protection mergeability check
 

--- a/plugins/go-workflow/skills/ship/SKILL.md
+++ b/plugins/go-workflow/skills/ship/SKILL.md
@@ -321,7 +321,7 @@ privileges.
 
 → Read `${CLAUDE_PLUGIN_ROOT}/lib/ship/merge.md` for: final-checks (CI green, no
 unresolved threads, no human `CHANGES_REQUESTED`), `--no-merge` early exit,
-merge-strategy auto-detection (`--merge` > `--squash` > `--rebase`), the full
+merge-strategy selection (`SHIP_MERGE_STRATEGY`, then `--squash` > `--rebase` > `--merge`), the full
 `mergeStateStatus` decision tree (`UNKNOWN`/`CONFLICTING`/`BLOCKED`/`CLEAN`/
 `HAS_HOOKS`/`BEHIND`/`UNSTABLE`/other), merge-queue handling, and the
 summary-line rendering (uses `coverage_skip_reason` to avoid `N/A%`). Output

--- a/scripts/legacy-skill-hashes.txt
+++ b/scripts/legacy-skill-hashes.txt
@@ -7,7 +7,7 @@
 # this prevents accepting a hash from skill A as proof of ownership for skill B.
 # DO NOT EDIT BY HAND — re-run the regen script after committing SKILL.md changes.
 #
-# Total entries: 232
+# Total entries: 233
 017e2d820506e7bef4a89a4d65839150db1ffdc124852a43dc916023e6d37e16 review-deep
 0322d4a7ddc204a9bf5addfec4e512edaea92ab8f4ebdd0541ca099330a09408 worktree
 03dac3a27d6da4b0a0c64ff6511df17004747e20b47a1691b4f9f030478877b9 commit
@@ -238,5 +238,6 @@ fba7e012a27a37cc5adc0c7c1b165a39367ff9718069d848a7530ea9893ceffa start-issue
 fbdec027766fa0a9ff4db653bf798163e4152def6ecfdcab90ec2c7313716562 ship
 fd406fb3c75d1c7a52213d6a76671bfdafdf2e189d0c1aeeaa3baeaf14903418 templui
 fe04f2c0e2f9443c094569956f56cbb4a429c480a063017aa14efccfd8d05e34 gopher-guides
+fe65ab6e9a73dda7e1c5a106ae0b61ba70e4023ce0a0358fc9a833c15637d3d2 ship
 fe9d92a44b8384540e6e98a8657acf7403338d716b3502300eea4d411ec27bb4 go-profiling-optimization
 ff3e7bea631be4948e237cb9a9654e31f5194274831494df45c939004c3660c2 remove-worktree

--- a/scripts/test-ship-e2e-gate.sh
+++ b/scripts/test-ship-e2e-gate.sh
@@ -75,11 +75,11 @@ require_text "$MERGE_DOC" "E2E PREREQUISITE MISSING" \
   "ship merge phase must stop on blocked E2E state"
 require_text "$MERGE_DOC" "Verification partial" \
   "ship summary must avoid unqualified verification-complete wording for partial E2E"
-require_text "$MERGE_DOC" 'MERGE_METHOD="\${SHIP_MERGE_STRATEGY:-}"' \
+require_text "$MERGE_DOC" "MERGE_METHOD=\"\\\${SHIP_MERGE_STRATEGY:-}\"" \
   "ship merge phase must honor explicit merge strategy configuration"
 require_text "$MERGE_DOC" "Configured merge strategy.*is not allowed" \
   "ship merge phase must fail when an explicit strategy is forbidden"
-require_text "$MERGE_DOC" 'gh pr merge "\$PR_NUM" --delete-branch' \
+require_text "$MERGE_DOC" "gh pr merge \"\\\$PR_NUM\" --delete-branch" \
   "ship merge queues must omit the merge-strategy flag"
 
 MERGE_STRATEGY_BLOCK=$(mktemp /tmp/gopher-ai-merge-strategy-XXXXXX)

--- a/scripts/test-ship-e2e-gate.sh
+++ b/scripts/test-ship-e2e-gate.sh
@@ -83,6 +83,10 @@ require_text "$MERGE_DOC" "gh pr merge \"\\\$PR_NUM\" --delete-branch" \
   "ship merge queues must omit the merge-strategy flag"
 
 MERGE_STRATEGY_BLOCK=$(mktemp /tmp/gopher-ai-merge-strategy-XXXXXX)
+MERGE_FIXTURE_PLUGIN_ROOT=$(mktemp -d /tmp/gopher-ai-merge-fixture-XXXXXX)
+MERGE_FIXTURE_WORKTREE=$(mktemp -d /tmp/gopher-ai-merge-worktree-XXXXXX)
+mkdir -p "$MERGE_FIXTURE_PLUGIN_ROOT/scripts"
+cp "$ROOT_DIR/plugins/go-workflow/scripts/cleanup-loop.sh" "$MERGE_FIXTURE_PLUGIN_ROOT/scripts/cleanup-loop.sh"
 awk '
   /^## 13c\./ { section=1 }
   section && /^```bash$/ { block=1; next }
@@ -100,7 +104,10 @@ run_merge_strategy_fixture() {
   local status
 
   set +e
-  output=$(MERGE_TEST_SETTINGS="$settings" SHIP_MERGE_STRATEGY="$configured_strategy" bash -c '
+  output=$(CLAUDE_PLUGIN_ROOT="$MERGE_FIXTURE_PLUGIN_ROOT" MERGE_FIXTURE_WORKTREE="$MERGE_FIXTURE_WORKTREE" MERGE_TEST_SETTINGS="$settings" SHIP_MERGE_STRATEGY="$configured_strategy" bash -c '
+    mkdir -p "$MERGE_FIXTURE_WORKTREE/.local/state"
+    touch "$MERGE_FIXTURE_WORKTREE/.local/state/ship.loop.local.json"
+    cd "$MERGE_FIXTURE_WORKTREE"
     gh() {
       if [ "$1" = "repo" ]; then
         if [[ "$*" == *".owner.login"* ]]; then
@@ -147,8 +154,28 @@ run_merge_strategy_fixture \
   '{"merge":false,"squash":true,"rebase":true}' \
   1 \
   "Configured merge strategy 'merge' is not allowed"
+run_merge_strategy_fixture \
+  "invalid explicit strategy must fail and clean up" \
+  "invalid" \
+  '{"merge":true,"squash":true,"rebase":true}' \
+  1 \
+  "Loop 'ship' cancelled"
+run_merge_strategy_fixture \
+  "forbidden explicit strategy must clean up" \
+  "merge" \
+  '{"merge":false,"squash":true,"rebase":true}' \
+  1 \
+  "Loop 'ship' cancelled"
+run_merge_strategy_fixture \
+  "repositories without an allowed strategy must fail and clean up" \
+  "" \
+  '{"merge":false,"squash":false,"rebase":false}' \
+  1 \
+  "Loop 'ship' cancelled"
 
 rm -f "$MERGE_STRATEGY_BLOCK"
+rm -rf "$MERGE_FIXTURE_PLUGIN_ROOT"
+rm -rf "$MERGE_FIXTURE_WORKTREE"
 
 require_text "$STATE_FIELDS" "blocked" \
   "ship state fields must document blocked E2E result"

--- a/scripts/test-ship-e2e-gate.sh
+++ b/scripts/test-ship-e2e-gate.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Verify $ship treats missing UI E2E prerequisites as a blocking condition.
+# Verify $ship enforces its E2E and merge-strategy gates.
 
 set -euo pipefail
 
@@ -66,12 +66,89 @@ reject_text "$SHIP_SKILL" "skip coverage \\+ e2e phases entirely" \
 reject_text "$SHIP_SKILL" "E2E smoke tests passed \\(or skipped .*[Mm]CP unavailable" \
   "ship completion criteria still allows MCP-unavailable E2E skip"
 
+require_text "$SHIP_SKILL" "SHIP_MERGE_STRATEGY.*--squash.*--rebase.*--merge" \
+  "ship skill must document explicit strategy before squash-first fallback"
+
 require_text "$MERGE_DOC" "e2e_result.*blocked" \
   "ship merge phase must read blocked E2E state"
 require_text "$MERGE_DOC" "E2E PREREQUISITE MISSING" \
   "ship merge phase must stop on blocked E2E state"
 require_text "$MERGE_DOC" "Verification partial" \
   "ship summary must avoid unqualified verification-complete wording for partial E2E"
+require_text "$MERGE_DOC" 'MERGE_METHOD="\${SHIP_MERGE_STRATEGY:-}"' \
+  "ship merge phase must honor explicit merge strategy configuration"
+require_text "$MERGE_DOC" "Configured merge strategy.*is not allowed" \
+  "ship merge phase must fail when an explicit strategy is forbidden"
+require_text "$MERGE_DOC" 'gh pr merge "\$PR_NUM" --delete-branch' \
+  "ship merge queues must omit the merge-strategy flag"
+
+MERGE_STRATEGY_BLOCK=$(mktemp /tmp/gopher-ai-merge-strategy-XXXXXX)
+awk '
+  /^## 13c\./ { section=1 }
+  section && /^```bash$/ { block=1; next }
+  block && /^```$/ { exit }
+  block { print }
+' "$MERGE_DOC" > "$MERGE_STRATEGY_BLOCK"
+
+run_merge_strategy_fixture() {
+  local label="$1"
+  local configured_strategy="$2"
+  local settings="$3"
+  local expected_status="$4"
+  local expected_output="$5"
+  local output
+  local status
+
+  set +e
+  output=$(MERGE_TEST_SETTINGS="$settings" SHIP_MERGE_STRATEGY="$configured_strategy" bash -c '
+    gh() {
+      if [ "$1" = "repo" ]; then
+        if [[ "$*" == *".owner.login"* ]]; then
+          echo "example"
+        else
+          echo "project"
+        fi
+      else
+        echo "$MERGE_TEST_SETTINGS"
+      fi
+    }
+    source "$1"
+    printf "%s" "$MERGE_METHOD"
+  ' _ "$MERGE_STRATEGY_BLOCK" 2>&1)
+  status=$?
+  set -e
+
+  if [ "$status" -ne "$expected_status" ] || [[ "$output" != *"$expected_output"* ]]; then
+    fail "$label (status $status, output: $output)"
+  fi
+}
+
+run_merge_strategy_fixture \
+  "explicit squash must be selected" \
+  "squash" \
+  '{"merge":true,"squash":true,"rebase":true}' \
+  0 \
+  "squash"
+run_merge_strategy_fixture \
+  "explicit merge must be selected" \
+  "merge" \
+  '{"merge":true,"squash":true,"rebase":true}' \
+  0 \
+  "merge"
+run_merge_strategy_fixture \
+  "unconfigured repositories must default to squash" \
+  "" \
+  '{"merge":true,"squash":true,"rebase":true}' \
+  0 \
+  "squash"
+run_merge_strategy_fixture \
+  "forbidden explicit strategy must fail" \
+  "merge" \
+  '{"merge":false,"squash":true,"rebase":true}' \
+  1 \
+  "Configured merge strategy 'merge' is not allowed"
+
+rm -f "$MERGE_STRATEGY_BLOCK"
 
 require_text "$STATE_FIELDS" "blocked" \
   "ship state fields must document blocked E2E result"


### PR DESCRIPTION
## Summary

- honor explicit `SHIP_MERGE_STRATEGY` values and reject invalid or forbidden strategies
- default unconfigured repositories to squash, then rebase, then merge
- preserve strategy-free merge queue invocation and add fixture coverage

## Test Plan

- `./scripts/test-ship-e2e-gate.sh`
- full configured validation gate

Fixes #234