### PR TITLE
fix(release): sync Codex manifests for v1.7.0

### DIFF
--- a/plugins/go-dev/.codex-plugin/plugin.json
+++ b/plugins/go-dev/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "go-dev",
-  "version": "1.6.0",
+  "version": "1.7.0",
   "description": "Go-specific development tools with idiomatic best practices",
   "author": {
     "name": "Gopher Guides",

--- a/plugins/go-web/.codex-plugin/plugin.json
+++ b/plugins/go-web/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "go-web",
-  "version": "1.6.0",
+  "version": "1.7.0",
   "description": "Opinionated Go web app scaffolding with Templ + HTMX + Alpine.js + Tailwind",
   "author": {
     "name": "Gopher Guides",

--- a/plugins/go-workflow/.codex-plugin/plugin.json
+++ b/plugins/go-workflow/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "go-workflow",
-  "version": "1.6.0",
+  "version": "1.7.0",
   "description": "Issue-to-PR workflow automation with git worktree management",
   "author": {
     "name": "Gopher Guides",

--- a/plugins/gopher-guides/.codex-plugin/plugin.json
+++ b/plugins/gopher-guides/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "gopher-guides",
-  "version": "1.6.0",
+  "version": "1.7.0",
   "description": "Gopher Guides training materials integration",
   "author": {
     "name": "Gopher Guides",

--- a/plugins/llm-tools/.codex-plugin/plugin.json
+++ b/plugins/llm-tools/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "llm-tools",
-  "version": "1.6.0",
+  "version": "1.7.0",
   "description": "Multi-LLM integration for second opinions and task delegation",
   "author": {
     "name": "Gopher Guides",

--- a/plugins/tailwind/.codex-plugin/plugin.json
+++ b/plugins/tailwind/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "tailwind",
-  "version": "1.6.0",
+  "version": "1.7.0",
   "description": "Tailwind CSS v4 tools for initialization, auditing, migration, and optimization",
   "author": {
     "name": "Gopher Guides",


### PR DESCRIPTION
## Summary

- sync all six Codex plugin manifests to v1.7.0
- restore Codex distribution and release archive version consistency

## Test Plan

- `./scripts/test-installation.sh`
- configured full validation gate with `GOCACHE=/tmp/gopher-ai-go-cache`

Fixes #242