### PR TITLE
fix(codex): preserve active plugin cache roots

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -64,13 +64,13 @@ To add these plugins to **your own repo**:
 
 ### Global (Personal) Use
 
-For Codex, "global" means installing plugins to `~/.codex/plugins/<name>/` so they load in every Codex session, regardless of the working directory. This is what `install-all.sh` uses for the curl one-liner.
+For Codex, "global" means installing plugins through the Codex marketplace cache so they load in every Codex session, regardless of the working directory. This is what `install-all.sh` uses for the curl one-liner.
 
 ```bash
 ./scripts/install-codex.sh --user
 ```
 
-Each plugin gets a `.gopher-ai-installed` marker recording version + install timestamp, so the SessionStart cleanup hook can distinguish our installs from user-authored plugins of the same name. `--user` is idempotent: re-running cleanly replaces a prior install.
+`--user` stages each new commit-hash root before activating it and retains previously published roots so active Codex sessions keep working through an update.
 
 The universal installer handles every detected platform in one step:
 
@@ -80,6 +80,14 @@ bash -c "$(curl -fsSL https://raw.githubusercontent.com/gopherguides/gopher-ai/m
 
 It builds, installs Claude Code and Gemini, runs `install-codex.sh --user` for Codex, and cleans up after itself. Restart Codex after running it; use `/plugins` to verify.
 
+After all Codex sessions have exited, stale marketplace cache roots can be removed explicitly:
+
+```bash
+./scripts/install-codex.sh --prune-cache
+```
+
+Do not prune while a Codex session is active. Running sessions retain absolute hook and skill paths into their original cache roots. The prune command keeps the latest installed commit.
+
 ### Migration
 
 Two earlier states are auto-handled by the SessionStart hook + `--user`:
@@ -87,7 +95,7 @@ Two earlier states are auto-handled by the SessionStart hook + `--user`:
 - Flat skills at `~/.codex/skills/<name>/` from the original (broken) `--user` mode that double-loaded against the marketplace.
 - Unmarked plugin directories at `~/.codex/plugins/<name>/` from when the README said "manually copy `dist/codex/plugins/` to `~/.codex/plugins/`".
 
-To migrate manually: `./scripts/install-codex.sh --user` (clean reinstall) or `./scripts/install-codex.sh --cleanup` (remove leftover skills only).
+To migrate manually: `./scripts/install-codex.sh --user` (refresh the marketplace install) or `./scripts/install-codex.sh --cleanup` (remove leftover skills only).
 
 ## Architecture
 

--- a/README.md
+++ b/README.md
@@ -307,13 +307,15 @@ Plugins are distributed via the [Codex plugin system](https://developers.openai.
 
 **GitHub one-liner:** `bash -c "$(curl -fsSL https://raw.githubusercontent.com/gopherguides/gopher-ai/main/scripts/install-all.sh)"` auto-detects all platforms — installs Claude Code and Gemini, and installs Codex plugins globally via Codex's marketplace mechanism (so skills load in every Codex session). The Codex install runs `codex plugin marketplace add gopherguides/gopher-ai`, populates `~/.codex/plugins/cache/gopher-ai/<plugin>/<commit>/` from the marketplace clone, and writes `[plugins."<name>@gopher-ai"]\nenabled = true` entries to `~/.codex/config.toml`. The marketplace cache is the only path Codex actually loads from — direct copies to `~/.codex/plugins/<name>/` are silently ignored.
 
+**Cache lifecycle:** `install-codex.sh --user` stages each new commit-hash root before activating it and leaves older roots available to Codex sessions that started before the update. After all Codex sessions have exited, remove superseded roots with `./scripts/install-codex.sh --prune-cache`. Do not prune while Codex is running; active sessions retain absolute hook and skill paths into their original roots. The prune command keeps the latest installed commit and requires confirmation unless `--yes` is supplied.
+
 **Migration from older versions:** Three earlier states needed cleanup, all handled automatically by the SessionStart hook (no command required) plus by `install-codex.sh --user` whenever you run install-all:
 - Flat skills at `~/.codex/skills/<name>/` from the original (broken) `--user` mode — overflowed Codex's [skill metadata budget](https://developers.openai.com/codex/skills).
 - Unmarked plugin directories at `~/.codex/plugins/<name>/` from when the README said "manually copy `dist/codex/plugins/` to `~/.codex/plugins/`" — also caused double-loading.
 
 - Direct plugin copies at `~/.codex/plugins/<name>/` from a previous (also broken) `--user` mode that wrote files Codex never loaded. The current `--user` mode installs via the marketplace cache instead, where Codex actually reads from.
 
-To migrate manually: `./scripts/install-codex.sh --user` (clean reinstall via marketplace) or `./scripts/install-codex.sh --cleanup` (remove leftover skills only).
+To migrate manually: `./scripts/install-codex.sh --user` (refresh the marketplace install) or `./scripts/install-codex.sh --cleanup` (remove leftover skills only).
 
 **Workflow skills** (from `go-workflow` plugin):
 

--- a/scripts/install-codex.sh
+++ b/scripts/install-codex.sh
@@ -610,20 +610,8 @@ prune_user_plugin_cache() {
         return 1
     fi
 
-    local plugin_dir plugin_name current_root
-    for plugin_dir in "$marketplace_clone"/plugins/*; do
-        [[ -f "$plugin_dir/.codex-plugin/plugin.json" ]] || continue
-        plugin_name="$(basename "$plugin_dir")"
-        current_root="$cache_root/$plugin_name/$commit_hash"
-        if [[ ! -e "$current_root" && ! -L "$current_root" ]]; then
-            echo "error: latest cache root is missing for $plugin_name at $current_root" >&2
-            echo "       run --user before pruning the cache." >&2
-            return 1
-        fi
-    done
-
     local candidates=()
-    local plugin_cache cache_entry
+    local plugin_cache plugin_name cache_entry
     for plugin_cache in "$cache_root"/*; do
         [[ -d "$plugin_cache" ]] || continue
         plugin_name="$(basename "$plugin_cache")"

--- a/scripts/install-codex.sh
+++ b/scripts/install-codex.sh
@@ -15,19 +15,17 @@ Usage:
   scripts/install-codex.sh --user
   scripts/install-codex.sh --repo /path/to/repo
   scripts/install-codex.sh --cleanup [--yes]
+  scripts/install-codex.sh --prune-cache [--yes]
 
 gopher-ai for Codex can be installed in two ways:
 
-  --user        Install plugins globally to ~/.codex/plugins/<name>/ so they
-                load in EVERY Codex session, regardless of the working
-                directory. This is what install-all.sh uses for the curl
-                one-liner. Idempotent: re-running cleanly replaces any
-                existing install. Each plugin gets a marker file
-                .gopher-ai-installed/ recording version + install timestamp,
-                so the cleanup hook can distinguish our installs from
-                user-authored plugins of the same name. Also removes legacy
-                ~/.codex/skills/ entries left over from older installs
-                (with --yes semantics — assumes the user wants the migration).
+  --user        Install plugins globally through the Codex marketplace cache
+                so they load in EVERY Codex session, regardless of the working
+                directory. New commit-hash roots are staged before activation.
+                Previously published roots are retained for active sessions.
+                Also removes legacy ~/.codex/skills/ entries left over from
+                older installs (with --yes semantics — assumes the user wants
+                the migration).
 
   --repo PATH   Install plugins into PATH/plugins and merge entries into
                 PATH/.agents/plugins/marketplace.json. Use this for project-
@@ -44,8 +42,12 @@ gopher-ai for Codex can be installed in two ways:
                 authored skill at a generic name like `commit` or `ship` will
                 fail the content check and be kept.
 
-  --yes         Skip interactive confirmation in --cleanup (used by
-                install-all.sh and CI flows).
+  --prune-cache Remove superseded Gopher AI marketplace cache roots. Close all
+                Codex sessions before running this command; active sessions
+                retain absolute paths into these roots. The latest installed
+                commit is always kept.
+
+  --yes         Skip interactive confirmation in --cleanup or --prune-cache.
   --help        Show this help text
 EOF
 }
@@ -433,7 +435,8 @@ plugin_json_author_email() {
 #   3. ~/.codex/config.toml must contain [plugins."<name>@gopher-ai"]
 #      enabled = true entries.
 #
-# Idempotent: re-running cleanly replaces stale cache + marker entries.
+# Published commit-hash roots are immutable because active Codex sessions keep
+# absolute paths into them. Superseded roots are removed only by --prune-cache.
 install_user_plugins() {
     require_cmd codex
     require_cmd git
@@ -472,23 +475,38 @@ install_user_plugins() {
     fi
     echo "populating cache (commit $commit_hash)..."
 
-    # Wipe any stale cache for this marketplace before repopulating — old
-    # commit-hash subdirs would otherwise linger forever and we'd accumulate.
-    rm -rf "$cache_root"
-
     local installed=0
     local plugin_dir
     for plugin_dir in "$marketplace_clone"/plugins/*; do
         [[ -d "$plugin_dir" ]] || continue
         [[ -f "$plugin_dir/.codex-plugin/plugin.json" ]] || continue
-        local plugin_name dest
+        local plugin_name plugin_cache dest staging
         plugin_name="$(basename "$plugin_dir")"
-        dest="$cache_root/$plugin_name/$commit_hash"
+        plugin_cache="$cache_root/$plugin_name"
+        dest="$plugin_cache/$commit_hash"
 
-        mkdir -p "$dest"
-        cp -R "$plugin_dir"/. "$dest/"
-        # Codex doesn't need the .claude-plugin/ subdir — drop it from the cache.
-        rm -rf "$dest/.claude-plugin"
+        if [[ -d "$dest" ]]; then
+            if [[ ! -f "$dest/.codex-plugin/plugin.json" ]]; then
+                echo "error: incomplete published cache root at $dest" >&2
+                echo "       close Codex, run --prune-cache, then retry --user." >&2
+                return 1
+            fi
+            echo "  retained: $plugin_name (already cached at $dest)"
+            installed=$((installed + 1))
+            continue
+        fi
+
+        mkdir -p "$plugin_cache"
+        staging="$(mktemp -d "$plugin_cache/.${commit_hash}.tmp.XXXXXX")"
+        if ! cp -R "$plugin_dir"/. "$staging/"; then
+            rm -rf "${staging:?}"
+            return 1
+        fi
+        rm -rf "$staging/.claude-plugin"
+        if ! mv "$staging" "$dest"; then
+            rm -rf "${staging:?}"
+            return 1
+        fi
         echo "  installed: $plugin_name (cached at $dest)"
         installed=$((installed + 1))
     done
@@ -547,6 +565,93 @@ install_user_plugins() {
     echo "Restart Codex; gopher-ai skills will load globally."
 }
 
+prune_user_plugin_cache() {
+    local assume_yes="${1:-false}"
+    local marketplace_clone="$HOME/.codex/.tmp/marketplaces/gopher-ai"
+    local cache_root="$HOME/.codex/plugins/cache/gopher-ai"
+
+    if [[ ! -d "$cache_root" ]]; then
+        echo "no Gopher AI Codex cache found — nothing to prune"
+        return 0
+    fi
+
+    require_cmd git
+    if [[ ! -d "$marketplace_clone" ]]; then
+        echo "error: marketplace clone missing at $marketplace_clone" >&2
+        echo "       run --user before pruning the cache." >&2
+        return 1
+    fi
+
+    local commit_hash
+    commit_hash="$(git -C "$marketplace_clone" rev-parse --short=8 HEAD 2>/dev/null)"
+    if [[ -z "$commit_hash" ]]; then
+        echo "error: could not read commit hash from $marketplace_clone" >&2
+        return 1
+    fi
+
+    local plugin_dir plugin_name current_root
+    for plugin_dir in "$marketplace_clone"/plugins/*; do
+        [[ -f "$plugin_dir/.codex-plugin/plugin.json" ]] || continue
+        plugin_name="$(basename "$plugin_dir")"
+        current_root="$cache_root/$plugin_name/$commit_hash"
+        if [[ ! -e "$current_root" && ! -L "$current_root" ]]; then
+            echo "error: latest cache root is missing for $plugin_name at $current_root" >&2
+            echo "       run --user before pruning the cache." >&2
+            return 1
+        fi
+    done
+
+    local candidates=()
+    local plugin_cache cache_entry
+    for plugin_cache in "$cache_root"/*; do
+        [[ -d "$plugin_cache" ]] || continue
+        plugin_name="$(basename "$plugin_cache")"
+        for cache_entry in "$plugin_cache"/* "$plugin_cache"/.[!.]* "$plugin_cache"/..?*; do
+            [[ -e "$cache_entry" || -L "$cache_entry" ]] || continue
+            if [[ -f "$marketplace_clone/plugins/$plugin_name/.codex-plugin/plugin.json" \
+                && "$cache_entry" == "$plugin_cache/$commit_hash" \
+                && -f "$cache_entry/.codex-plugin/plugin.json" ]]; then
+                continue
+            fi
+            candidates+=("$cache_entry")
+        done
+    done
+
+    if [[ ${#candidates[@]} -eq 0 ]]; then
+        echo "no superseded Gopher AI Codex cache roots found"
+        return 0
+    fi
+
+    echo "close all Codex sessions before removing superseded cache roots:"
+    local candidate
+    for candidate in "${candidates[@]}"; do
+        echo "  $candidate"
+    done
+
+    if [[ "$assume_yes" != "true" ]]; then
+        if [[ ! -t 0 ]]; then
+            echo ""
+            echo "stdin is not a terminal — close all Codex sessions, then re-run with --yes."
+            return 1
+        fi
+        local answer=""
+        printf "all Codex sessions are closed; remove these roots? [y/N] "
+        read -r answer
+        case "$answer" in
+            [Yy]|[Yy][Ee][Ss]) ;;
+            *) echo "aborted — nothing removed."; return 0 ;;
+        esac
+    fi
+
+    local removed=0
+    for candidate in "${candidates[@]}"; do
+        rm -rf "${candidate:?}"
+        echo "removed: $candidate"
+        removed=$((removed + 1))
+    done
+    echo "pruned $removed superseded cache root$([ "$removed" -eq 1 ] || echo "s")"
+}
+
 copy_repo_plugins() {
     local target_repo="$1"
     mkdir -p "$target_repo/plugins"
@@ -602,6 +707,13 @@ main() {
                 assume_yes=true
             fi
             cleanup_legacy_user_skills "$assume_yes"
+            ;;
+        --prune-cache)
+            local assume_yes=false
+            if [[ "${2:-}" == "--yes" || "${2:-}" == "-y" ]]; then
+                assume_yes=true
+            fi
+            prune_user_plugin_cache "$assume_yes"
             ;;
         --repo)
             if [[ $# -lt 2 ]]; then

--- a/scripts/install-codex.sh
+++ b/scripts/install-codex.sh
@@ -421,6 +421,27 @@ plugin_json_author_email() {
     ' "$f"
 }
 
+cache_root_matches_plugin() {
+    local source_root="$1"
+    local cache_root="$2"
+    [[ -d "$cache_root" ]] || return 1
+
+    local source_file relative cache_file
+    while IFS= read -r -d '' source_file; do
+        relative="${source_file#"$source_root"/}"
+        case "$relative" in
+            .claude-plugin/*) continue ;;
+        esac
+        cache_file="$cache_root/$relative"
+        [[ -f "$cache_file" ]] || return 1
+        cmp -s "$source_file" "$cache_file" || return 1
+        if [[ -x "$source_file" && ! -x "$cache_file" ]]; then
+            return 1
+        fi
+    done < <(find "$source_root" -type f -print0)
+    return 0
+}
+
 # Install plugins globally for Codex via the marketplace + cache mechanism
 # Codex actually uses (verified empirically — direct copies to
 # ~/.codex/plugins/<name>/ are silently ignored by Codex).
@@ -486,7 +507,7 @@ install_user_plugins() {
         dest="$plugin_cache/$commit_hash"
 
         if [[ -d "$dest" ]]; then
-            if [[ ! -f "$dest/.codex-plugin/plugin.json" ]]; then
+            if ! cache_root_matches_plugin "$plugin_dir" "$dest"; then
                 echo "error: incomplete published cache root at $dest" >&2
                 echo "       close Codex, run --prune-cache, then retry --user." >&2
                 return 1
@@ -609,9 +630,10 @@ prune_user_plugin_cache() {
         for cache_entry in "$plugin_cache"/* "$plugin_cache"/.[!.]* "$plugin_cache"/..?*; do
             [[ -e "$cache_entry" || -L "$cache_entry" ]] || continue
             if [[ -f "$marketplace_clone/plugins/$plugin_name/.codex-plugin/plugin.json" \
-                && "$cache_entry" == "$plugin_cache/$commit_hash" \
-                && -f "$cache_entry/.codex-plugin/plugin.json" ]]; then
-                continue
+                && "$cache_entry" == "$plugin_cache/$commit_hash" ]]; then
+                if cache_root_matches_plugin "$marketplace_clone/plugins/$plugin_name" "$cache_entry"; then
+                    continue
+                fi
             fi
             candidates+=("$cache_entry")
         done

--- a/scripts/install-codex.sh
+++ b/scripts/install-codex.sh
@@ -611,15 +611,28 @@ prune_user_plugin_cache() {
     fi
 
     local candidates=()
-    local plugin_cache plugin_name cache_entry
+    local deferred=()
+    local plugin_cache plugin_name plugin_source current_root current_ready cache_entry
     for plugin_cache in "$cache_root"/*; do
         [[ -d "$plugin_cache" ]] || continue
         plugin_name="$(basename "$plugin_cache")"
+        plugin_source="$marketplace_clone/plugins/$plugin_name"
+        current_root="$plugin_cache/$commit_hash"
+        current_ready=false
+        if [[ -f "$plugin_source/.codex-plugin/plugin.json" ]] \
+            && cache_root_matches_plugin "$plugin_source" "$current_root"; then
+            current_ready=true
+        elif [[ -f "$plugin_source/.codex-plugin/plugin.json" ]]; then
+            deferred+=("$plugin_cache")
+        fi
         for cache_entry in "$plugin_cache"/* "$plugin_cache"/.[!.]* "$plugin_cache"/..?*; do
             [[ -e "$cache_entry" || -L "$cache_entry" ]] || continue
-            if [[ -f "$marketplace_clone/plugins/$plugin_name/.codex-plugin/plugin.json" \
-                && "$cache_entry" == "$plugin_cache/$commit_hash" ]]; then
-                if cache_root_matches_plugin "$marketplace_clone/plugins/$plugin_name" "$cache_entry"; then
+            if [[ -f "$plugin_source/.codex-plugin/plugin.json" ]]; then
+                if [[ "$current_ready" == "true" && "$cache_entry" == "$current_root" ]]; then
+                    continue
+                fi
+                if [[ "$current_ready" != "true" && "$cache_entry" != "$current_root" \
+                    && "$(basename "$cache_entry")" != ".${commit_hash}.tmp."* ]]; then
                     continue
                 fi
             fi
@@ -629,6 +642,9 @@ prune_user_plugin_cache() {
 
     if [[ ${#candidates[@]} -eq 0 ]]; then
         echo "no superseded Gopher AI Codex cache roots found"
+        if [[ ${#deferred[@]} -gt 0 ]]; then
+            echo "latest roots are missing or incomplete; retained older roots. Run --user, then prune again."
+        fi
         return 0
     fi
 
@@ -660,6 +676,9 @@ prune_user_plugin_cache() {
         removed=$((removed + 1))
     done
     echo "pruned $removed superseded cache root$([ "$removed" -eq 1 ] || echo "s")"
+    if [[ ${#deferred[@]} -gt 0 ]]; then
+        echo "retained older roots for plugins without a complete latest root. Run --user, then prune again."
+    fi
 }
 
 copy_repo_plugins() {

--- a/scripts/test-installation.sh
+++ b/scripts/test-installation.sh
@@ -1072,6 +1072,24 @@ else
   echo "OK ($OLD_HASH retained, $NEW_HASH activated)"
 fi
 
+echo -n "Codex --prune-cache retains old roots until the latest root exists... "
+rm -rf "$NEW_ROOT"
+if ! HOME="$TMP_HOME" PATH="$STUB_PATH" bash "$ROOT_DIR/scripts/install-codex.sh" --prune-cache --yes >/dev/null 2>&1; then
+  echo "FAIL (--prune-cache exited non-zero)"
+  ERRORS=$((ERRORS + 1))
+elif [ ! -d "$OLD_ROOT" ]; then
+  echo "FAIL (old root was removed before the latest root existed)"
+  ERRORS=$((ERRORS + 1))
+elif ! HOME="$TMP_HOME" PATH="$STUB_PATH" bash "$ROOT_DIR/scripts/install-codex.sh" --user >/dev/null 2>&1; then
+  echo "FAIL (--user did not restore the latest root)"
+  ERRORS=$((ERRORS + 1))
+elif [ ! -f "$NEW_ROOT/.codex-plugin/plugin.json" ]; then
+  echo "FAIL (latest root was not restored)"
+  ERRORS=$((ERRORS + 1))
+else
+  echo "OK"
+fi
+
 echo -n "Codex --prune-cache requires explicit non-interactive confirmation... "
 PRUNE_NOCONFIRM_LOG=$(mktemp)
 set +e

--- a/scripts/test-installation.sh
+++ b/scripts/test-installation.sh
@@ -932,7 +932,7 @@ build_stub_path() {
 exit 0
 STUB
   chmod +x "$stub_dir/codex"
-  for cmd in bash sh awk sed grep find mkdir rm cp mv mktemp printf cat dirname basename tr head tail xargs sleep date wc sha256sum git sort uniq stat ln readlink jq comm touch chmod cut id env true false echo test; do
+  for cmd in bash sh awk sed grep find mkdir rm cp mv cmp mktemp printf cat dirname basename tr head tail xargs sleep date wc sha256sum git sort uniq stat ln readlink jq comm touch chmod cut id env true false echo test; do
     cmd_path="$(command -v "$cmd" 2>/dev/null || true)"
     [ -n "$cmd_path" ] && ln -s "$cmd_path" "$stub_dir/$cmd"
   done
@@ -1008,7 +1008,7 @@ else
 fi
 
 echo -n "Codex --prune-cache recovers an incomplete current root... "
-rm -f "$PUBLISHED_ROOT/.codex-plugin/plugin.json"
+rm -f "$PUBLISHED_ROOT/skills/go/SKILL.md"
 set +e
 HOME="$TMP_HOME" PATH="$STUB_PATH" bash "$ROOT_DIR/scripts/install-codex.sh" --user >/dev/null 2>&1
 INCOMPLETE_EXIT=$?

--- a/scripts/test-installation.sh
+++ b/scripts/test-installation.sh
@@ -932,7 +932,7 @@ build_stub_path() {
 exit 0
 STUB
   chmod +x "$stub_dir/codex"
-  for cmd in bash sh awk sed grep find mkdir rm cp mktemp printf cat dirname basename tr head tail xargs sleep date wc sha256sum git sort uniq stat ln readlink jq comm touch chmod cut id env true false echo test; do
+  for cmd in bash sh awk sed grep find mkdir rm cp mv mktemp printf cat dirname basename tr head tail xargs sleep date wc sha256sum git sort uniq stat ln readlink jq comm touch chmod cut id env true false echo test; do
     cmd_path="$(command -v "$cmd" 2>/dev/null || true)"
     [ -n "$cmd_path" ] && ln -s "$cmd_path" "$stub_dir/$cmd"
   done
@@ -988,25 +988,110 @@ else
 fi
 rm -rf "$TMP_HOME" "$STUB_PATH"
 
-echo -n "Codex --user is idempotent (re-running rebuilds cache cleanly)... "
+echo -n "Codex --user preserves a published root on the same commit... "
 TMP_HOME=$(mktemp -d)
 seed_fake_marketplace_clone "$TMP_HOME" >/dev/null
 STUB_PATH=$(build_stub_path "$TMP_HOME")
 HOME="$TMP_HOME" PATH="$STUB_PATH" bash "$ROOT_DIR/scripts/install-codex.sh" --user >/dev/null 2>&1
 HASH=$(git -C "$TMP_HOME/.codex/.tmp/marketplaces/gopher-ai" rev-parse --short=8 HEAD)
-echo "stale" > "$TMP_HOME/.codex/plugins/cache/gopher-ai/go-dev/$HASH/STALE_FILE"
-# Also create an old commit-hash dir to verify it gets cleaned up.
-mkdir -p "$TMP_HOME/.codex/plugins/cache/gopher-ai/go-dev/deadbeef"
-echo "old version" > "$TMP_HOME/.codex/plugins/cache/gopher-ai/go-dev/deadbeef/SKILL.md"
+PUBLISHED_ROOT="$TMP_HOME/.codex/plugins/cache/gopher-ai/go-dev/$HASH"
+echo "active session" > "$PUBLISHED_ROOT/ACTIVE_SESSION"
 HOME="$TMP_HOME" PATH="$STUB_PATH" bash "$ROOT_DIR/scripts/install-codex.sh" --user >/dev/null 2>&1
-if [ -f "$TMP_HOME/.codex/plugins/cache/gopher-ai/go-dev/$HASH/STALE_FILE" ]; then
-  echo "FAIL (stale file survived re-install)"
+if [ ! -f "$PUBLISHED_ROOT/ACTIVE_SESSION" ]; then
+  echo "FAIL (published root was rewritten on re-install)"
   ERRORS=$((ERRORS + 1))
-elif [ -d "$TMP_HOME/.codex/plugins/cache/gopher-ai/go-dev/deadbeef" ]; then
-  echo "FAIL (old commit-hash dir not cleaned up)"
-  ERRORS=$((ERRORS + 1))
-elif [ ! -f "$TMP_HOME/.codex/plugins/cache/gopher-ai/go-dev/$HASH/.codex-plugin/plugin.json" ]; then
+elif [ ! -f "$PUBLISHED_ROOT/.codex-plugin/plugin.json" ]; then
   echo "FAIL (re-install did not repopulate cache)"
+  ERRORS=$((ERRORS + 1))
+else
+  echo "OK"
+fi
+
+echo -n "Codex --prune-cache recovers an incomplete current root... "
+rm -f "$PUBLISHED_ROOT/.codex-plugin/plugin.json"
+set +e
+HOME="$TMP_HOME" PATH="$STUB_PATH" bash "$ROOT_DIR/scripts/install-codex.sh" --user >/dev/null 2>&1
+INCOMPLETE_EXIT=$?
+set -e
+if [ "$INCOMPLETE_EXIT" -eq 0 ]; then
+  echo "FAIL (--user should reject an incomplete published root)"
+  ERRORS=$((ERRORS + 1))
+elif ! HOME="$TMP_HOME" PATH="$STUB_PATH" bash "$ROOT_DIR/scripts/install-codex.sh" --prune-cache --yes >/dev/null 2>&1; then
+  echo "FAIL (--prune-cache rejected the incomplete root)"
+  ERRORS=$((ERRORS + 1))
+elif ! HOME="$TMP_HOME" PATH="$STUB_PATH" bash "$ROOT_DIR/scripts/install-codex.sh" --user >/dev/null 2>&1; then
+  echo "FAIL (--user did not republish the pruned root)"
+  ERRORS=$((ERRORS + 1))
+elif [ ! -f "$PUBLISHED_ROOT/.codex-plugin/plugin.json" ]; then
+  echo "FAIL (current root was not restored)"
+  ERRORS=$((ERRORS + 1))
+else
+  echo "OK"
+fi
+rm -rf "$TMP_HOME" "$STUB_PATH"
+
+echo -n "Codex --user retains active hooks and skills across an update... "
+TMP_HOME=$(mktemp -d)
+seed_fake_marketplace_clone "$TMP_HOME" >/dev/null
+STUB_PATH=$(build_stub_path "$TMP_HOME")
+HOME="$TMP_HOME" PATH="$STUB_PATH" bash "$ROOT_DIR/scripts/install-codex.sh" --user >/dev/null 2>&1
+MARKETPLACE_CLONE="$TMP_HOME/.codex/.tmp/marketplaces/gopher-ai"
+OLD_HASH=$(git -C "$MARKETPLACE_CLONE" rev-parse --short=8 HEAD)
+OLD_ROOT="$TMP_HOME/.codex/plugins/cache/gopher-ai/go-workflow/$OLD_HASH"
+git -C "$MARKETPLACE_CLONE" commit --quiet --allow-empty -m "test update"
+NEW_HASH=$(git -C "$MARKETPLACE_CLONE" rev-parse --short=8 HEAD)
+HOME="$TMP_HOME" PATH="$STUB_PATH" bash "$ROOT_DIR/scripts/install-codex.sh" --user >/dev/null 2>&1
+NEW_ROOT="$TMP_HOME/.codex/plugins/cache/gopher-ai/go-workflow/$NEW_HASH"
+if [ "$OLD_HASH" = "$NEW_HASH" ]; then
+  echo "FAIL (fixture did not create a new marketplace commit)"
+  ERRORS=$((ERRORS + 1))
+elif [ ! -x "$OLD_ROOT/hooks/pre-tool-use.sh" ] \
+  || [ ! -x "$OLD_ROOT/hooks/post-tool-use.sh" ] \
+  || [ ! -x "$OLD_ROOT/hooks/stop-hook.sh" ]; then
+  echo "FAIL (an active hook path was removed or lost execute permission)"
+  ERRORS=$((ERRORS + 1))
+elif ! bash -n "$OLD_ROOT/hooks/pre-tool-use.sh" \
+  "$OLD_ROOT/hooks/post-tool-use.sh" "$OLD_ROOT/hooks/stop-hook.sh"; then
+  echo "FAIL (an active hook path is no longer readable by bash)"
+  ERRORS=$((ERRORS + 1))
+elif [ ! -r "$OLD_ROOT/skills/ship/SKILL.md" ]; then
+  echo "FAIL (an active skill path was removed or became unreadable)"
+  ERRORS=$((ERRORS + 1))
+elif [ ! -f "$NEW_ROOT/.codex-plugin/plugin.json" ]; then
+  echo "FAIL (new marketplace commit was not activated)"
+  ERRORS=$((ERRORS + 1))
+elif [ -n "$(compgen -G "$TMP_HOME/.codex/plugins/cache/gopher-ai/*/.*.tmp.*" || true)" ]; then
+  echo "FAIL (staging directory remained after activation)"
+  ERRORS=$((ERRORS + 1))
+else
+  echo "OK ($OLD_HASH retained, $NEW_HASH activated)"
+fi
+
+echo -n "Codex --prune-cache requires explicit non-interactive confirmation... "
+set +e
+HOME="$TMP_HOME" PATH="$STUB_PATH" bash "$ROOT_DIR/scripts/install-codex.sh" --prune-cache \
+  </dev/null >"$TMPDIR/gopher-ai-prune-noconfirm.log" 2>&1
+PRUNE_EXIT=$?
+set -e
+if [ "$PRUNE_EXIT" -eq 0 ]; then
+  echo "FAIL (--prune-cache should require --yes without a terminal)"
+  ERRORS=$((ERRORS + 1))
+elif [ ! -d "$OLD_ROOT" ]; then
+  echo "FAIL (superseded root was removed without confirmation)"
+  ERRORS=$((ERRORS + 1))
+else
+  echo "OK"
+fi
+
+echo -n "Codex --prune-cache removes only superseded roots... "
+if ! HOME="$TMP_HOME" PATH="$STUB_PATH" bash "$ROOT_DIR/scripts/install-codex.sh" --prune-cache --yes >/dev/null 2>&1; then
+  echo "FAIL (--prune-cache exited non-zero)"
+  ERRORS=$((ERRORS + 1))
+elif [ -d "$OLD_ROOT" ]; then
+  echo "FAIL (superseded cache root was not removed)"
+  ERRORS=$((ERRORS + 1))
+elif [ ! -f "$NEW_ROOT/.codex-plugin/plugin.json" ]; then
+  echo "FAIL (latest cache root was removed)"
   ERRORS=$((ERRORS + 1))
 else
   echo "OK"

--- a/scripts/test-installation.sh
+++ b/scripts/test-installation.sh
@@ -1009,6 +1009,9 @@ fi
 
 echo -n "Codex --prune-cache recovers an incomplete current root... "
 rm -f "$PUBLISHED_ROOT/skills/go/SKILL.md"
+for p in go-web go-workflow gopher-guides llm-tools tailwind; do
+  rm -rf "$TMP_HOME/.codex/plugins/cache/gopher-ai/$p/$HASH"
+done
 set +e
 HOME="$TMP_HOME" PATH="$STUB_PATH" bash "$ROOT_DIR/scripts/install-codex.sh" --user >/dev/null 2>&1
 INCOMPLETE_EXIT=$?
@@ -1022,8 +1025,9 @@ elif ! HOME="$TMP_HOME" PATH="$STUB_PATH" bash "$ROOT_DIR/scripts/install-codex.
 elif ! HOME="$TMP_HOME" PATH="$STUB_PATH" bash "$ROOT_DIR/scripts/install-codex.sh" --user >/dev/null 2>&1; then
   echo "FAIL (--user did not republish the pruned root)"
   ERRORS=$((ERRORS + 1))
-elif [ ! -f "$PUBLISHED_ROOT/.codex-plugin/plugin.json" ]; then
-  echo "FAIL (current root was not restored)"
+elif [ ! -f "$PUBLISHED_ROOT/.codex-plugin/plugin.json" ] \
+  || [ ! -f "$TMP_HOME/.codex/plugins/cache/gopher-ai/go-web/$HASH/.codex-plugin/plugin.json" ]; then
+  echo "FAIL (missing or incomplete current roots were not restored)"
   ERRORS=$((ERRORS + 1))
 else
   echo "OK"
@@ -1051,7 +1055,8 @@ elif [ ! -x "$OLD_ROOT/hooks/pre-tool-use.sh" ] \
   echo "FAIL (an active hook path was removed or lost execute permission)"
   ERRORS=$((ERRORS + 1))
 elif ! bash -n "$OLD_ROOT/hooks/pre-tool-use.sh" \
-  "$OLD_ROOT/hooks/post-tool-use.sh" "$OLD_ROOT/hooks/stop-hook.sh"; then
+  || ! bash -n "$OLD_ROOT/hooks/post-tool-use.sh" \
+  || ! bash -n "$OLD_ROOT/hooks/stop-hook.sh"; then
   echo "FAIL (an active hook path is no longer readable by bash)"
   ERRORS=$((ERRORS + 1))
 elif [ ! -r "$OLD_ROOT/skills/ship/SKILL.md" ]; then

--- a/scripts/test-installation.sh
+++ b/scripts/test-installation.sh
@@ -1068,9 +1068,10 @@ else
 fi
 
 echo -n "Codex --prune-cache requires explicit non-interactive confirmation... "
+PRUNE_NOCONFIRM_LOG=$(mktemp)
 set +e
 HOME="$TMP_HOME" PATH="$STUB_PATH" bash "$ROOT_DIR/scripts/install-codex.sh" --prune-cache \
-  </dev/null >"$TMPDIR/gopher-ai-prune-noconfirm.log" 2>&1
+  </dev/null >"$PRUNE_NOCONFIRM_LOG" 2>&1
 PRUNE_EXIT=$?
 set -e
 if [ "$PRUNE_EXIT" -eq 0 ]; then
@@ -1082,6 +1083,7 @@ elif [ ! -d "$OLD_ROOT" ]; then
 else
   echo "OK"
 fi
+rm -f "$PRUNE_NOCONFIRM_LOG"
 
 echo -n "Codex --prune-cache removes only superseded roots... "
 if ! HOME="$TMP_HOME" PATH="$STUB_PATH" bash "$ROOT_DIR/scripts/install-codex.sh" --prune-cache --yes >/dev/null 2>&1; then


### PR DESCRIPTION
## Summary

- stage new Codex plugin cache roots before atomic activation
- retain published roots so active hooks and skills survive updates
- add explicit latest-preserving cache pruning after Codex exits
- replace destructive cache expectations with lifecycle regression coverage
- document the safe cache cleanup workflow

## Test Plan

- `bash -n scripts/install-codex.sh scripts/test-installation.sh`
- `shellcheck scripts/install-codex.sh scripts/test-installation.sh`
- `./scripts/test-installation.sh`
- configured repository validation gate

Fixes #248