### PR TITLE
fix(codex): migrate legacy marketplace

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,14 +6,14 @@
   },
   "metadata": {
     "description": "Go-specific and general-purpose AI coding assistant plugins - by Gopher Guides",
-    "version": "1.7.2"
+    "version": "1.7.3"
   },
   "plugins": [
     {
       "name": "go-workflow",
       "source": "./plugins/go-workflow",
       "description": "Issue-to-PR workflow automation with worktree management",
-      "version": "1.7.2",
+      "version": "1.7.3",
       "keywords": [
         "workflow",
         "github",
@@ -26,7 +26,7 @@
       "name": "go-dev",
       "source": "./plugins/go-dev",
       "description": "Go-specific development tools with best practices",
-      "version": "1.7.2",
+      "version": "1.7.3",
       "keywords": [
         "go",
         "testing",
@@ -39,7 +39,7 @@
       "name": "productivity",
       "source": "./plugins/productivity",
       "description": "Standup reports and git productivity helpers",
-      "version": "1.7.2",
+      "version": "1.7.3",
       "keywords": [
         "standup",
         "changelog",
@@ -52,7 +52,7 @@
       "name": "gopher-guides",
       "source": "./plugins/gopher-guides",
       "description": "Go best practices guidance powered by Gopher Guides training materials",
-      "version": "1.7.2",
+      "version": "1.7.3",
       "keywords": [
         "go",
         "training",
@@ -64,7 +64,7 @@
       "name": "llm-tools",
       "source": "./plugins/llm-tools",
       "description": "Multi-LLM integration for second opinions and task delegation",
-      "version": "1.7.2",
+      "version": "1.7.3",
       "keywords": [
         "llm",
         "openai",
@@ -81,7 +81,7 @@
       "name": "go-web",
       "source": "./plugins/go-web",
       "description": "Opinionated Go web app scaffolding with Templ + HTMX + Alpine.js + Tailwind",
-      "version": "1.7.2",
+      "version": "1.7.3",
       "keywords": [
         "go",
         "web",
@@ -97,7 +97,7 @@
       "name": "tailwind",
       "source": "./plugins/tailwind",
       "description": "Tailwind CSS v4 tools for initialization, auditing, migration, and optimization",
-      "version": "1.7.2",
+      "version": "1.7.3",
       "keywords": [
         "tailwind",
         "css",

--- a/docs/superpowers/plans/2026-07-22-codex-legacy-marketplace-migration.md
+++ b/docs/superpowers/plans/2026-07-22-codex-legacy-marketplace-migration.md
@@ -1,0 +1,818 @@
+# Codex Legacy Marketplace Migration Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Safely migrate the legacy user-local Gopher AI Codex marketplace to the Git-backed marketplace, publish v1.7.3, and verify the public installer locally and on Prometheus.
+
+**Architecture:** `scripts/install-codex.sh` will treat the legacy marketplace as a transaction: prove ownership, move it aside before Codex resolves duplicate marketplace names, restore it on any failure, and retire it only after every plugin installs successfully. Existing cache-root backup behavior remains intact and is rolled back alongside the marketplace file.
+
+**Tech Stack:** Bash 3-compatible shell scripting, `jq`, mocked Codex CLI fixtures, Git/GitHub CLI, shellcheck, existing repository release scripts.
+
+## Global Constraints
+
+- Preserve malformed, mixed, unknown, or user-authored marketplace files without modification.
+- Migrate only `~/.agents/plugins/marketplace.json` files named `gopher-ai` whose plugins are all current Codex-capable Gopher AI plugins and whose sources exactly match `./.codex/plugins/<plugin-name>`.
+- Restore the legacy marketplace byte-for-byte if marketplace registration, marketplace upgrade, or any plugin installation fails.
+- Preserve prior versioned Codex cache roots for active sessions.
+- Keep repository-scoped `--repo` behavior unchanged.
+- Synchronize every marketplace, Claude plugin, and Codex plugin manifest to 1.7.3.
+- Use PR-generated release notes and publish only after exact-main-commit CI succeeds.
+- Run the user's exact public installer command on both hosts after v1.7.3 is published.
+
+---
+
+## File Map
+
+- `scripts/install-codex.sh`: Owns legacy marketplace detection, transactional backup, rollback, commit, and Codex user installation.
+- `scripts/test-installation.sh`: Extends the Codex CLI stub and covers successful migration, failure rollback, and ownership refusal.
+- `.claude-plugin/marketplace.json`: Marketplace metadata and seven plugin version declarations.
+- `plugins/go-dev/.claude-plugin/plugin.json`: Claude plugin version.
+- `plugins/go-dev/.codex-plugin/plugin.json`: Codex plugin version.
+- `plugins/go-web/.claude-plugin/plugin.json`: Claude plugin version.
+- `plugins/go-web/.codex-plugin/plugin.json`: Codex plugin version.
+- `plugins/go-workflow/.claude-plugin/plugin.json`: Claude plugin version.
+- `plugins/go-workflow/.codex-plugin/plugin.json`: Codex plugin version.
+- `plugins/gopher-guides/.claude-plugin/plugin.json`: Claude plugin version.
+- `plugins/gopher-guides/.codex-plugin/plugin.json`: Codex plugin version.
+- `plugins/llm-tools/.claude-plugin/plugin.json`: Claude plugin version.
+- `plugins/llm-tools/.codex-plugin/plugin.json`: Codex plugin version.
+- `plugins/productivity/.claude-plugin/plugin.json`: Claude plugin version.
+- `plugins/tailwind/.claude-plugin/plugin.json`: Claude plugin version.
+- `plugins/tailwind/.codex-plugin/plugin.json`: Codex plugin version.
+
+---
+
+### Task 1: Add Transactional Legacy Marketplace Migration
+
+**Files:**
+- Modify: `scripts/test-installation.sh:893-1143`
+- Modify: `scripts/install-codex.sh:10-12`
+- Modify: `scripts/install-codex.sh:56-69`
+- Modify: `scripts/install-codex.sh:495-584`
+
+**Interfaces:**
+- Consumes: `ROOT_DIR`, `HOME`, current plugin directories containing `.codex-plugin/plugin.json`, `jq`, existing `backup_published_plugin_roots`, and existing `restore_removed_plugin_roots`.
+- Produces: `prepare_legacy_user_marketplace_migration()`, `restore_legacy_user_marketplace()`, and `commit_legacy_user_marketplace_migration()` with no arguments and shell status semantics.
+
+- [ ] **Step 1: Extend the Codex stub so duplicate resolution and rollback failures are reproducible**
+
+In `build_stub_path()` inside `scripts/test-installation.sh`, add this branch immediately after the existing marketplace-list branch:
+
+```sh
+if [ "${1:-}" = "plugin" ] && [ "${2:-}" = "marketplace" ] && [ "${3:-}" = "upgrade" ]; then
+  if [ "${CODEX_STUB_FAIL_MARKETPLACE_UPGRADE:-false}" = "true" ]; then
+    printf 'forced marketplace upgrade failure\n' >&2
+    exit 1
+  fi
+  exit
+fi
+if [ "${1:-}" = "plugin" ] && [ "${2:-}" = "marketplace" ] && [ "${3:-}" = "add" ]; then
+  if [ "${CODEX_STUB_FAIL_MARKETPLACE_ADD:-false}" = "true" ]; then
+    printf 'forced marketplace add failure\n' >&2
+    exit 1
+  fi
+  exit
+fi
+```
+
+Then replace the `plugin add` branch with:
+
+```sh
+if [ "${1:-}" = "plugin" ] && [ "${2:-}" = "add" ]; then
+  plugin="${3%@*}"
+  legacy_marketplace="$HOME/.agents/plugins/marketplace.json"
+  if [ -f "$legacy_marketplace" ] && [ "$(jq -r '.name // empty' "$legacy_marketplace")" = "gopher-ai" ]; then
+    legacy_path="$(jq -r --arg plugin "$plugin" '.plugins[]? | select(.name == $plugin) | .source.path // empty' "$legacy_marketplace")"
+    if [ -n "$legacy_path" ]; then
+      resolved_path="$HOME/${legacy_path#./}"
+      if [ ! -d "$resolved_path" ]; then
+        printf 'plugin source path is not a directory: %s\n' "$resolved_path" >&2
+        exit 1
+      fi
+    fi
+  fi
+  if [ "${CODEX_STUB_FAIL_ADD_PLUGIN:-}" = "$plugin" ]; then
+    printf 'forced plugin add failure: %s\n' "$plugin" >&2
+    exit 1
+  fi
+  source_root="${CODEX_STUB_SOURCE_ROOT:?}/plugins/$plugin"
+  version="$(jq -r '.version' "$source_root/.codex-plugin/plugin.json")"
+  plugin_cache="$HOME/.codex/plugins/cache/gopher-ai/$plugin"
+  destination="$plugin_cache/$version"
+  rm -rf "$plugin_cache"
+  mkdir -p "$destination"
+  cp -R "$source_root"/. "$destination/"
+  rm -rf "$destination/.claude-plugin"
+  exit
+fi
+```
+
+- [ ] **Step 2: Add the failing successful-migration regression test**
+
+Insert after the registered marketplace test at `scripts/test-installation.sh:992`:
+
+```sh
+echo -n "Codex --user migrates the owned legacy user marketplace... "
+LEGACY_MARKETPLACE="$TMP_HOME/.agents/plugins/marketplace.json"
+mkdir -p "$(dirname "$LEGACY_MARKETPLACE")"
+cp "$ROOT_DIR/dist/codex/plugins/marketplace.json" "$LEGACY_MARKETPLACE"
+: > "$STUB_LOG"
+if ! HOME="$TMP_HOME" PATH="$STUB_PATH" CODEX_STUB_LOG="$STUB_LOG" \
+  CODEX_STUB_SOURCE_ROOT="$ROOT_DIR" CODEX_STUB_MARKETPLACE_REGISTERED=true \
+  bash "$ROOT_DIR/scripts/install-codex.sh" --user >/tmp/gopher-ai-legacy-marketplace.log 2>&1; then
+  echo "FAIL (--user did not migrate the owned legacy marketplace)"
+  sed -n '1,40p' /tmp/gopher-ai-legacy-marketplace.log
+  ERRORS=$((ERRORS + 1))
+elif [ -e "$LEGACY_MARKETPLACE" ]; then
+  echo "FAIL (owned legacy marketplace remained after successful install)"
+  ERRORS=$((ERRORS + 1))
+elif ! grep -qx 'plugin marketplace upgrade gopher-ai' "$STUB_LOG"; then
+  echo "FAIL (Git marketplace was not upgraded after migration)"
+  ERRORS=$((ERRORS + 1))
+else
+  echo "OK"
+fi
+```
+
+- [ ] **Step 3: Add failing rollback and ownership-safety tests**
+
+Insert immediately after the successful-migration test:
+
+```sh
+echo -n "Codex --user restores the legacy marketplace after plugin failure... "
+mkdir -p "$(dirname "$LEGACY_MARKETPLACE")"
+cp "$ROOT_DIR/dist/codex/plugins/marketplace.json" "$LEGACY_MARKETPLACE"
+LEGACY_COPY=$(mktemp)
+cp "$LEGACY_MARKETPLACE" "$LEGACY_COPY"
+ROLLBACK_ROOT="$TMP_HOME/.codex/plugins/cache/gopher-ai/go-dev/1.7.1"
+mkdir -p "$ROLLBACK_ROOT"
+echo "active session" > "$ROLLBACK_ROOT/ACTIVE_SESSION"
+set +e
+HOME="$TMP_HOME" PATH="$STUB_PATH" CODEX_STUB_LOG="$STUB_LOG" \
+  CODEX_STUB_SOURCE_ROOT="$ROOT_DIR" CODEX_STUB_MARKETPLACE_REGISTERED=true \
+  CODEX_STUB_FAIL_ADD_PLUGIN=go-web bash "$ROOT_DIR/scripts/install-codex.sh" --user \
+  >/tmp/gopher-ai-legacy-rollback.log 2>&1
+LEGACY_EXIT=$?
+set -e
+if [ "$LEGACY_EXIT" -eq 0 ]; then
+  echo "FAIL (forced plugin failure unexpectedly succeeded)"
+  ERRORS=$((ERRORS + 1))
+elif ! cmp -s "$LEGACY_COPY" "$LEGACY_MARKETPLACE"; then
+  echo "FAIL (legacy marketplace was not restored byte-for-byte)"
+  ERRORS=$((ERRORS + 1))
+elif [ ! -f "$ROLLBACK_ROOT/ACTIVE_SESSION" ]; then
+  echo "FAIL (prior cache root was not restored after plugin failure)"
+  ERRORS=$((ERRORS + 1))
+else
+  echo "OK"
+fi
+rm -f "$LEGACY_COPY"
+
+echo -n "Codex --user restores the legacy marketplace after marketplace upgrade failure... "
+LEGACY_UPGRADE_COPY=$(mktemp)
+cp "$LEGACY_MARKETPLACE" "$LEGACY_UPGRADE_COPY"
+set +e
+HOME="$TMP_HOME" PATH="$STUB_PATH" CODEX_STUB_LOG="$STUB_LOG" \
+  CODEX_STUB_SOURCE_ROOT="$ROOT_DIR" CODEX_STUB_MARKETPLACE_REGISTERED=true \
+  CODEX_STUB_FAIL_MARKETPLACE_UPGRADE=true bash "$ROOT_DIR/scripts/install-codex.sh" --user \
+  >/tmp/gopher-ai-legacy-upgrade-rollback.log 2>&1
+UPGRADE_EXIT=$?
+set -e
+if [ "$UPGRADE_EXIT" -eq 0 ]; then
+  echo "FAIL (forced marketplace upgrade failure unexpectedly succeeded)"
+  ERRORS=$((ERRORS + 1))
+elif ! cmp -s "$LEGACY_UPGRADE_COPY" "$LEGACY_MARKETPLACE"; then
+  echo "FAIL (legacy marketplace was not restored after upgrade failure)"
+  ERRORS=$((ERRORS + 1))
+else
+  echo "OK"
+fi
+rm -f "$LEGACY_UPGRADE_COPY"
+
+echo -n "Codex --user restores the legacy marketplace after marketplace registration failure... "
+LEGACY_ADD_COPY=$(mktemp)
+cp "$LEGACY_MARKETPLACE" "$LEGACY_ADD_COPY"
+set +e
+HOME="$TMP_HOME" PATH="$STUB_PATH" CODEX_STUB_LOG="$STUB_LOG" \
+  CODEX_STUB_SOURCE_ROOT="$ROOT_DIR" CODEX_STUB_FAIL_MARKETPLACE_ADD=true \
+  bash "$ROOT_DIR/scripts/install-codex.sh" --user \
+  >/tmp/gopher-ai-legacy-add-rollback.log 2>&1
+ADD_EXIT=$?
+set -e
+if [ "$ADD_EXIT" -eq 0 ]; then
+  echo "FAIL (forced marketplace registration failure unexpectedly succeeded)"
+  ERRORS=$((ERRORS + 1))
+elif ! cmp -s "$LEGACY_ADD_COPY" "$LEGACY_MARKETPLACE"; then
+  echo "FAIL (legacy marketplace was not restored after registration failure)"
+  ERRORS=$((ERRORS + 1))
+else
+  echo "OK"
+fi
+rm -f "$LEGACY_ADD_COPY"
+
+echo -n "Codex --user preserves and rejects an uncertain gopher-ai marketplace... "
+UNKNOWN_COPY=$(mktemp)
+jq '.plugins[0].source.path = "./custom/go-dev"' \
+  "$ROOT_DIR/dist/codex/plugins/marketplace.json" > "$LEGACY_MARKETPLACE"
+cp "$LEGACY_MARKETPLACE" "$UNKNOWN_COPY"
+: > "$STUB_LOG"
+set +e
+HOME="$TMP_HOME" PATH="$STUB_PATH" CODEX_STUB_LOG="$STUB_LOG" \
+  CODEX_STUB_SOURCE_ROOT="$ROOT_DIR" CODEX_STUB_MARKETPLACE_REGISTERED=true \
+  bash "$ROOT_DIR/scripts/install-codex.sh" --user >/tmp/gopher-ai-legacy-uncertain.log 2>&1
+UNCERTAIN_EXIT=$?
+set -e
+if [ "$UNCERTAIN_EXIT" -eq 0 ]; then
+  echo "FAIL (uncertain marketplace unexpectedly migrated)"
+  ERRORS=$((ERRORS + 1))
+elif ! cmp -s "$UNKNOWN_COPY" "$LEGACY_MARKETPLACE"; then
+  echo "FAIL (uncertain marketplace was modified)"
+  ERRORS=$((ERRORS + 1))
+elif grep -q '^plugin marketplace ' "$STUB_LOG"; then
+  echo "FAIL (Codex marketplace state changed before ownership was proven)"
+  ERRORS=$((ERRORS + 1))
+elif ! grep -q 'preserved' /tmp/gopher-ai-legacy-uncertain.log; then
+  echo "FAIL (error did not explain that uncertain state was preserved)"
+  ERRORS=$((ERRORS + 1))
+else
+  echo "OK"
+fi
+rm -f "$UNKNOWN_COPY"
+
+echo -n "Codex --user preserves and rejects an unknown gopher-ai plugin... "
+jq '.plugins += [{"name":"unknown-plugin","source":{"source":"local","path":"./.codex/plugins/unknown-plugin"}}]' \
+  "$ROOT_DIR/dist/codex/plugins/marketplace.json" > "$LEGACY_MARKETPLACE"
+UNKNOWN_PLUGIN_COPY=$(mktemp)
+cp "$LEGACY_MARKETPLACE" "$UNKNOWN_PLUGIN_COPY"
+set +e
+HOME="$TMP_HOME" PATH="$STUB_PATH" CODEX_STUB_LOG="$STUB_LOG" \
+  CODEX_STUB_SOURCE_ROOT="$ROOT_DIR" CODEX_STUB_MARKETPLACE_REGISTERED=true \
+  bash "$ROOT_DIR/scripts/install-codex.sh" --user >/tmp/gopher-ai-legacy-unknown.log 2>&1
+UNKNOWN_PLUGIN_EXIT=$?
+set -e
+if [ "$UNKNOWN_PLUGIN_EXIT" -eq 0 ]; then
+  echo "FAIL (unknown plugin marketplace unexpectedly migrated)"
+  ERRORS=$((ERRORS + 1))
+elif ! cmp -s "$UNKNOWN_PLUGIN_COPY" "$LEGACY_MARKETPLACE"; then
+  echo "FAIL (unknown plugin marketplace was modified)"
+  ERRORS=$((ERRORS + 1))
+else
+  echo "OK"
+fi
+rm -f "$UNKNOWN_PLUGIN_COPY"
+
+echo -n "Codex --user preserves and rejects a malformed marketplace... "
+printf '{invalid json\n' > "$LEGACY_MARKETPLACE"
+MALFORMED_COPY=$(mktemp)
+cp "$LEGACY_MARKETPLACE" "$MALFORMED_COPY"
+set +e
+HOME="$TMP_HOME" PATH="$STUB_PATH" CODEX_STUB_LOG="$STUB_LOG" \
+  CODEX_STUB_SOURCE_ROOT="$ROOT_DIR" CODEX_STUB_MARKETPLACE_REGISTERED=true \
+  bash "$ROOT_DIR/scripts/install-codex.sh" --user >/tmp/gopher-ai-legacy-malformed.log 2>&1
+MALFORMED_EXIT=$?
+set -e
+if [ "$MALFORMED_EXIT" -eq 0 ]; then
+  echo "FAIL (malformed marketplace unexpectedly migrated)"
+  ERRORS=$((ERRORS + 1))
+elif ! cmp -s "$MALFORMED_COPY" "$LEGACY_MARKETPLACE"; then
+  echo "FAIL (malformed marketplace was modified)"
+  ERRORS=$((ERRORS + 1))
+else
+  echo "OK"
+fi
+rm -f "$MALFORMED_COPY"
+
+echo -n "Codex --user leaves an unrelated user marketplace untouched... "
+jq '.name = "other-marketplace"' "$ROOT_DIR/dist/codex/plugins/marketplace.json" > "$LEGACY_MARKETPLACE"
+UNRELATED_COPY=$(mktemp)
+cp "$LEGACY_MARKETPLACE" "$UNRELATED_COPY"
+if ! HOME="$TMP_HOME" PATH="$STUB_PATH" CODEX_STUB_LOG="$STUB_LOG" \
+  CODEX_STUB_SOURCE_ROOT="$ROOT_DIR" CODEX_STUB_MARKETPLACE_REGISTERED=true \
+  bash "$ROOT_DIR/scripts/install-codex.sh" --user >/dev/null 2>&1; then
+  echo "FAIL (unrelated marketplace blocked installation)"
+  ERRORS=$((ERRORS + 1))
+elif ! cmp -s "$UNRELATED_COPY" "$LEGACY_MARKETPLACE"; then
+  echo "FAIL (unrelated marketplace was modified)"
+  ERRORS=$((ERRORS + 1))
+else
+  echo "OK"
+fi
+rm -f "$UNRELATED_COPY" "$LEGACY_MARKETPLACE"
+```
+
+- [ ] **Step 4: Run the installation tests and verify the migration tests fail for the expected reason**
+
+Run:
+
+```bash
+./scripts/test-installation.sh
+```
+
+Expected: the new successful-migration test fails with `plugin source path is not a directory`, while the existing tests continue running and no syntax error occurs.
+
+- [ ] **Step 5: Add transaction state and make the exit trap restore an uncommitted marketplace**
+
+Add near `CACHE_BACKUP_DIRS=()` in `scripts/install-codex.sh`:
+
+```bash
+LEGACY_MARKETPLACE_PATH=""
+LEGACY_MARKETPLACE_BACKUP_DIR=""
+```
+
+Add before `cleanup()`:
+
+```bash
+restore_legacy_user_marketplace() {
+    [[ -n "$LEGACY_MARKETPLACE_PATH" ]] || return 0
+    local backup_file="$LEGACY_MARKETPLACE_BACKUP_DIR/marketplace.json"
+    if [[ -e "$backup_file" || -L "$backup_file" ]]; then
+        mkdir -p "$(dirname "$LEGACY_MARKETPLACE_PATH")"
+        mv "$backup_file" "$LEGACY_MARKETPLACE_PATH"
+    fi
+    [[ -z "$LEGACY_MARKETPLACE_BACKUP_DIR" ]] || rm -rf "$LEGACY_MARKETPLACE_BACKUP_DIR"
+    LEGACY_MARKETPLACE_PATH=""
+    LEGACY_MARKETPLACE_BACKUP_DIR=""
+}
+```
+
+Make `cleanup()` call `restore_legacy_user_marketplace` before removing bootstrap and cache backup directories:
+
+```bash
+cleanup() {
+    restore_legacy_user_marketplace
+    if [[ -n "$BOOTSTRAP_DIR" && -d "$BOOTSTRAP_DIR" ]]; then
+        rm -rf "$BOOTSTRAP_DIR"
+    fi
+    local cache_backup_dir
+    for cache_backup_dir in "${CACHE_BACKUP_DIRS[@]-}"; do
+        [[ -n "$cache_backup_dir" ]] || continue
+        if [[ -d "$cache_backup_dir" ]]; then
+            rm -rf "$cache_backup_dir"
+        fi
+    done
+}
+```
+
+- [ ] **Step 6: Implement strict ownership detection, preparation, and commit**
+
+Add before `install_user_plugins()`:
+
+```bash
+codex_plugin_names_json() {
+    local plugin_dir
+    for plugin_dir in "$ROOT_DIR"/plugins/*; do
+        [[ -d "$plugin_dir" ]] || continue
+        [[ -f "$plugin_dir/.codex-plugin/plugin.json" ]] || continue
+        basename "$plugin_dir"
+    done | jq -R . | jq -s .
+}
+
+prepare_legacy_user_marketplace_migration() {
+    local candidate="$HOME/.agents/plugins/marketplace.json"
+    [[ -e "$candidate" || -L "$candidate" ]] || return 0
+
+    if ! jq -e . "$candidate" >/dev/null 2>&1; then
+        echo "error: preserved invalid marketplace file: $candidate" >&2
+        echo "       move or repair it before installing gopher-ai." >&2
+        return 1
+    fi
+
+    local marketplace_name
+    marketplace_name="$(jq -r '.name // empty' "$candidate")"
+    [[ "$marketplace_name" == "gopher-ai" ]] || return 0
+
+    local allowed_plugins
+    allowed_plugins="$(codex_plugin_names_json)"
+    if ! jq -e --argjson allowed "$allowed_plugins" '
+        (.plugins | type == "array" and length > 0) and
+        all(.plugins[];
+            (.name | type == "string") and
+            ($allowed | index(.name) != null) and
+            .source.source == "local" and
+            .source.path == ("./.codex/plugins/" + .name)
+        )
+    ' "$candidate" >/dev/null; then
+        echo "error: preserved marketplace because ownership could not be proven: $candidate" >&2
+        echo "       remove or rename the conflicting gopher-ai marketplace, then retry." >&2
+        return 1
+    fi
+
+    local temp_base="${TMPDIR:-${TMP:-${TEMP:-/tmp}}}"
+    LEGACY_MARKETPLACE_BACKUP_DIR="$(mktemp -d "${temp_base%/}/gopher-ai-codex-marketplace.XXXXXX")"
+    LEGACY_MARKETPLACE_PATH="$candidate"
+    mv "$candidate" "$LEGACY_MARKETPLACE_BACKUP_DIR/marketplace.json"
+    echo "migrating legacy Codex marketplace: $candidate"
+}
+
+commit_legacy_user_marketplace_migration() {
+    [[ -z "$LEGACY_MARKETPLACE_BACKUP_DIR" ]] || rm -rf "$LEGACY_MARKETPLACE_BACKUP_DIR"
+    LEGACY_MARKETPLACE_PATH=""
+    LEGACY_MARKETPLACE_BACKUP_DIR=""
+}
+```
+
+- [ ] **Step 7: Integrate the transaction into `install_user_plugins()`**
+
+After the `codex plugin add --help` capability check and before `codex plugin marketplace list --json`, add:
+
+```bash
+    prepare_legacy_user_marketplace_migration
+```
+
+After all plugin additions and `restore_removed_plugin_roots "$cache_backup_dir"` succeed, add:
+
+```bash
+    commit_legacy_user_marketplace_migration
+```
+
+Do not add marketplace restore calls to individual error branches; returning non-zero must flow through the existing `EXIT` trap, which restores the uncommitted marketplace exactly once.
+
+- [ ] **Step 8: Run focused verification**
+
+Run:
+
+```bash
+bash -n scripts/install-codex.sh
+shellcheck scripts/install-codex.sh scripts/test-installation.sh
+./scripts/test-installation.sh
+```
+
+Expected: all commands exit zero and the new tests print `OK` for migration, rollback, uncertain ownership, and unrelated marketplace preservation.
+
+- [ ] **Step 9: Commit the migration fix**
+
+Run:
+
+```bash
+git add scripts/install-codex.sh scripts/test-installation.sh
+git commit -m "fix(codex): migrate legacy marketplace"
+```
+
+Expected: one focused fix commit on `fix/codex-legacy-marketplace-migration`.
+
+---
+
+### Task 2: Bump v1.7.3 and Run the Release Gate
+
+**Files:**
+- Modify: `.claude-plugin/marketplace.json`
+- Modify: `plugins/go-dev/.claude-plugin/plugin.json`
+- Modify: `plugins/go-dev/.codex-plugin/plugin.json`
+- Modify: `plugins/go-web/.claude-plugin/plugin.json`
+- Modify: `plugins/go-web/.codex-plugin/plugin.json`
+- Modify: `plugins/go-workflow/.claude-plugin/plugin.json`
+- Modify: `plugins/go-workflow/.codex-plugin/plugin.json`
+- Modify: `plugins/gopher-guides/.claude-plugin/plugin.json`
+- Modify: `plugins/gopher-guides/.codex-plugin/plugin.json`
+- Modify: `plugins/llm-tools/.claude-plugin/plugin.json`
+- Modify: `plugins/llm-tools/.codex-plugin/plugin.json`
+- Modify: `plugins/productivity/.claude-plugin/plugin.json`
+- Modify: `plugins/tailwind/.claude-plugin/plugin.json`
+- Modify: `plugins/tailwind/.codex-plugin/plugin.json`
+
+**Interfaces:**
+- Consumes: the migration fix from Task 1 and the release workflow's manifest synchronization requirement.
+- Produces: all version sources set to `1.7.3` and verified release archives in `dist/`.
+
+- [ ] **Step 1: Update every version source to 1.7.3**
+
+Run:
+
+```bash
+VERSION=1.7.3
+jq --arg v "$VERSION" '.metadata.version = $v | .plugins[].version = $v' \
+  .claude-plugin/marketplace.json > /tmp/marketplace.json.tmp
+mv /tmp/marketplace.json.tmp .claude-plugin/marketplace.json
+for pjson in plugins/*/.claude-plugin/plugin.json plugins/*/.codex-plugin/plugin.json; do
+  [ -f "$pjson" ] || continue
+  jq --arg v "$VERSION" '.version = $v' "$pjson" > /tmp/plugin.json.tmp
+  mv /tmp/plugin.json.tmp "$pjson"
+done
+```
+
+- [ ] **Step 2: Verify every manifest reports 1.7.3**
+
+Run:
+
+```bash
+VERSION=1.7.3
+jq -e --arg v "$VERSION" '.metadata.version == $v and all(.plugins[]; .version == $v)' \
+  .claude-plugin/marketplace.json >/dev/null
+for pjson in plugins/*/.claude-plugin/plugin.json plugins/*/.codex-plugin/plugin.json; do
+  [ -f "$pjson" ] || continue
+  jq -e --arg v "$VERSION" '.version == $v' "$pjson" >/dev/null
+done
+! rg -n '"version": "1\.7\.2"' .claude-plugin/marketplace.json \
+  plugins/*/.claude-plugin/plugin.json plugins/*/.codex-plugin/plugin.json
+```
+
+Expected: all commands exit zero and the final search prints nothing.
+
+- [ ] **Step 3: Run the full repository gate**
+
+Run:
+
+```bash
+bash -lc './scripts/test-installation.sh && ./scripts/test-commands.sh && ./scripts/test-hooks.sh && ./scripts/test-ship-e2e-gate.sh && ./scripts/check-shared-sync.sh && shellcheck agent-skills/scripts/*.sh && for skill_dir in agent-skills/skills/*/; do skill_name=$(basename "$skill_dir"); skill_file="$skill_dir/SKILL.md"; test -f "$skill_file"; lines=$(wc -l < "$skill_file"); test "$lines" -lt 500; name=$(sed -n "/^---$/,/^---$/p" "$skill_file" | awk "/^name:/ {print \$2; exit}"); test "$name" = "$skill_name"; rg -q "^description:" "$skill_file"; done && ruby -ryaml -e "YAML.load_file(ARGV[0])" agent-skills/config/severity.yaml && (cd agent-skills/examples/demo-repo && go build -o /tmp/gopher-ai-demo . && go test ./...)'
+```
+
+Expected: every test suite passes, shared files are synchronized, shellcheck succeeds, and the demo Go build/tests pass.
+
+- [ ] **Step 4: Build and verify v1.7.3 archives**
+
+Run:
+
+```bash
+./scripts/build-universal.sh
+VERSION=1.7.3
+CODEX_ASSET="dist/gopher-ai-codex-plugins-v${VERSION}.tar.gz"
+GEMINI_ASSET="dist/gopher-ai-gemini-extensions-v${VERSION}.tar.gz"
+test -f "$CODEX_ASSET"
+test -f "$GEMINI_ASSET"
+CODEX_MANIFESTS=$(tar -tzf "$CODEX_ASSET" | rg '/\.codex-plugin/plugin\.json$')
+test -n "$CODEX_MANIFESTS"
+while IFS= read -r manifest; do
+  tar -xOzf "$CODEX_ASSET" "$manifest" | jq -e --arg v "$VERSION" '.version == $v' >/dev/null
+done <<< "$CODEX_MANIFESTS"
+GEMINI_MANIFESTS=$(tar -tzf "$GEMINI_ASSET" | rg '/gemini-extension\.json$')
+test -n "$GEMINI_MANIFESTS"
+while IFS= read -r manifest; do
+  tar -xOzf "$GEMINI_ASSET" "$manifest" | jq -e --arg v "$VERSION" '.version == $v' >/dev/null
+done <<< "$GEMINI_MANIFESTS"
+```
+
+Expected: both archives exist and every packaged manifest reports 1.7.3.
+
+- [ ] **Step 5: Commit the release version**
+
+Run:
+
+```bash
+git add .claude-plugin/marketplace.json plugins/*/.claude-plugin/plugin.json plugins/*/.codex-plugin/plugin.json
+git commit -m "chore(release): release v1.7.3"
+```
+
+Expected: the release bump is separate from the migration fix.
+
+---
+
+### Task 3: Merge the Fix and Publish v1.7.3
+
+**Files:**
+- No additional repository files.
+
+**Interfaces:**
+- Consumes: the tested branch commits and verified archives from Tasks 1-2.
+- Produces: merged `main`, tag `v1.7.3`, published GitHub release, and two release assets tied to the exact CI-verified main commit.
+
+- [ ] **Step 1: Verify branch state and push**
+
+Run:
+
+```bash
+git status --short --branch
+test -z "$(git status --porcelain)"
+git push -u origin fix/codex-legacy-marketplace-migration
+```
+
+Expected: clean branch and successful push.
+
+- [ ] **Step 2: Create the pull request**
+
+No PR template exists, so run:
+
+```bash
+gh pr create --base main --head fix/codex-legacy-marketplace-migration \
+  --title "fix(codex): migrate legacy marketplace" \
+  --body "$(cat <<'EOF'
+## Summary
+- migrate the installer-owned legacy Codex marketplace before Git marketplace resolution
+- restore legacy marketplace and cache state after failed installs
+- release the correction as v1.7.3
+
+## Test Plan
+- `bash -n scripts/install-codex.sh`
+- `shellcheck scripts/install-codex.sh scripts/test-installation.sh`
+- `./scripts/test-installation.sh`
+- full repository release gate
+- verified Codex and Gemini v1.7.3 archives
+EOF
+)"
+```
+
+Expected: GitHub returns the new PR URL.
+
+- [ ] **Step 3: Wait for CI and reviews, address every finding, and merge**
+
+Run:
+
+```bash
+gh pr checks --watch
+PR_NUMBER=$(gh pr view --json number --jq '.number')
+gh pr reviews "$PR_NUMBER" --json author,state,body
+gh pr view "$PR_NUMBER" --json reviewRequests
+```
+
+Expected: all checks pass, no `CHANGES_REQUESTED`, `COMMENTED`, or pending bot review remains. If any review finding exists, fix it immediately, rerun the affected tests and full gate, commit, push, and repeat the checks/review gate before merging.
+
+Merge with:
+
+```bash
+gh pr merge "$PR_NUMBER" --squash --delete-branch
+```
+
+Expected: PR is merged and the remote feature branch is deleted.
+
+- [ ] **Step 4: Update local main and identify the exact release commit**
+
+Run:
+
+```bash
+git switch main
+git pull --ff-only origin main
+RELEASE_SHA=$(git rev-parse HEAD)
+test "$RELEASE_SHA" = "$(git rev-parse origin/main)"
+test "$(jq -r '.metadata.version' .claude-plugin/marketplace.json)" = "1.7.3"
+printf 'RELEASE_SHA=%s\n' "$RELEASE_SHA"
+```
+
+Expected: local and remote main match and the manifest is 1.7.3.
+
+- [ ] **Step 5: Require exact release-commit CI success**
+
+Run the release workflow's REST check loop against `$RELEASE_SHA`:
+
+```bash
+CHECKS=""
+for attempt in $(seq 1 24); do
+  CHECKS=$(gh api "repos/gopherguides/gopher-ai/commits/${RELEASE_SHA}/check-runs")
+  [ "$(jq '.total_count' <<< "$CHECKS")" -gt 0 ] && break
+  sleep 5
+done
+test "$(jq '.total_count' <<< "$CHECKS")" -gt 0
+for attempt in $(seq 1 60); do
+  CHECKS=$(gh api "repos/gopherguides/gopher-ai/commits/${RELEASE_SHA}/check-runs")
+  FAILED=$(jq '[.check_runs[] | select(.status == "completed" and (.conclusion | IN("success", "neutral", "skipped") | not))] | length' <<< "$CHECKS")
+  PENDING=$(jq '[.check_runs[] | select(.status != "completed")] | length' <<< "$CHECKS")
+  test "$FAILED" -eq 0
+  [ "$PENDING" -eq 0 ] && break
+  sleep 10
+done
+GREEN_COUNT=$(jq '.total_count' <<< "$CHECKS")
+sleep 10
+CHECKS=$(gh api "repos/gopherguides/gopher-ai/commits/${RELEASE_SHA}/check-runs")
+test "$(jq '[.check_runs[] | select(.status != "completed")] | length' <<< "$CHECKS")" -eq 0
+test "$(jq '[.check_runs[] | select(.conclusion | IN("success", "neutral", "skipped") | not)] | length' <<< "$CHECKS")" -eq 0
+test "$(jq '.total_count' <<< "$CHECKS")" -eq "$GREEN_COUNT"
+test "$(git rev-parse HEAD)" = "$RELEASE_SHA"
+test "$(git ls-remote origin refs/heads/main | awk '{print $1}')" = "$RELEASE_SHA"
+```
+
+Expected: a non-empty stable check set, all completed successfully, and main unchanged.
+
+- [ ] **Step 6: Rebuild assets from merged main and create a verified draft**
+
+Run:
+
+```bash
+./scripts/build-universal.sh
+VERSION=1.7.3
+TAG="v${VERSION}"
+CODEX_ASSET="dist/gopher-ai-codex-plugins-v${VERSION}.tar.gz"
+GEMINI_ASSET="dist/gopher-ai-gemini-extensions-v${VERSION}.tar.gz"
+gh release create "$TAG" --draft --target "$RELEASE_SHA" --title "$TAG" --generate-notes \
+  "$CODEX_ASSET" "$GEMINI_ASSET"
+RELEASE=$(gh api --paginate --slurp repos/gopherguides/gopher-ai/releases \
+  | jq --arg tag "$TAG" 'add | map(select(.tag_name == $tag)) | first')
+test "$(jq -r '.draft' <<< "$RELEASE")" = "true"
+test "$(jq -r '.target_commitish' <<< "$RELEASE")" = "$RELEASE_SHA"
+jq -e --arg codex "${CODEX_ASSET##*/}" --arg gemini "${GEMINI_ASSET##*/}" '
+  (.assets | length) == 2 and
+  ([.assets[].name] | sort) == ([$codex, $gemini] | sort)
+' <<< "$RELEASE" >/dev/null
+RELEASE_ID=$(jq -r '.id' <<< "$RELEASE")
+```
+
+Expected: draft v1.7.3 targets the exact verified commit and contains exactly the Codex and Gemini archives.
+
+- [ ] **Step 7: Publish and verify v1.7.3**
+
+Run:
+
+```bash
+gh api --method PATCH "repos/gopherguides/gopher-ai/releases/${RELEASE_ID}" -F draft=false >/dev/null
+PUBLISHED=$(gh api "repos/gopherguides/gopher-ai/releases/${RELEASE_ID}")
+jq -e --arg tag "$TAG" --arg codex "${CODEX_ASSET##*/}" --arg gemini "${GEMINI_ASSET##*/}" '
+  (.draft | not) and .tag_name == $tag and
+  ([.assets[].name] | sort) == ([$codex, $gemini] | sort)
+' <<< "$PUBLISHED" >/dev/null
+test "$(gh api "repos/gopherguides/gopher-ai/git/ref/tags/${TAG}" --jq '.object.sha')" = "$RELEASE_SHA"
+jq '{draft,tag_name,html_url,assets:[.assets[].name]}' <<< "$PUBLISHED"
+```
+
+Expected: published release URL, tag v1.7.3 at `$RELEASE_SHA`, and exactly two assets.
+
+---
+
+### Task 4: Install and Verify v1.7.3 on Both Hosts
+
+**Files:**
+- Host state only; no repository file changes.
+
+**Interfaces:**
+- Consumes: published v1.7.3 on `main` and the public raw GitHub installer URL.
+- Produces: successful Claude Code, Codex, and Gemini installation on this machine and Prometheus.
+
+- [ ] **Step 1: Run the exact installer locally**
+
+Run:
+
+```bash
+bash -c "$(curl -fsSL https://raw.githubusercontent.com/gopherguides/gopher-ai/main/scripts/install-all.sh)"
+```
+
+Expected: exit zero, Claude Code refresh reports 1.7.3, Codex installs six plugins through the CLI, Gemini installs seven extensions, and the final `Done!` summary appears.
+
+- [ ] **Step 2: Verify local Codex migration and versions**
+
+Run:
+
+```bash
+test ! -e "$HOME/.agents/plugins/marketplace.json"
+CURRENT_VERSION=1.7.3
+CODEX_JSON=$(codex plugin list --json)
+jq -e --arg v "$CURRENT_VERSION" '
+  [.installed[] | select(.marketplaceName == "gopher-ai")] as $plugins |
+  ($plugins | length) == 6 and
+  all($plugins[]; .installed and .enabled and .version == $v)
+' <<< "$CODEX_JSON" >/dev/null
+for plugin in go-dev go-web go-workflow gopher-guides llm-tools tailwind; do
+  test -f "$HOME/.codex/plugins/cache/gopher-ai/$plugin/$CURRENT_VERSION/.codex-plugin/plugin.json"
+done
+for plugin in go-dev go-web go-workflow gopher-guides llm-tools productivity tailwind; do
+  test -d "$HOME/.claude/plugins/cache/gopher-ai/$plugin/$CURRENT_VERSION"
+done
+```
+
+Expected: no legacy marketplace, six enabled Codex plugins at 1.7.3, complete Codex cache roots, and seven Claude Code cache roots.
+
+- [ ] **Step 3: Confirm Prometheus connectivity and platform tools**
+
+Run:
+
+```bash
+ssh prometheus 'hostname; command -v bash; command -v curl; command -v jq; command -v codex || true; command -v gemini || true; test -d "$HOME/.claude" && echo claude-home-present || true'
+```
+
+Expected: SSH succeeds and the host reports the installed platform tools before mutation.
+
+- [ ] **Step 4: Run the exact installer on Prometheus**
+
+Run:
+
+```bash
+ssh prometheus 'bash -c "$(curl -fsSL https://raw.githubusercontent.com/gopherguides/gopher-ai/main/scripts/install-all.sh)"'
+```
+
+Expected: exit zero and the final installer summary lists every platform detected on Prometheus.
+
+- [ ] **Step 5: Verify Prometheus Codex and Claude versions when those platforms are present**
+
+Run:
+
+```bash
+ssh prometheus '
+set -eu
+CURRENT_VERSION=1.7.3
+if command -v codex >/dev/null 2>&1; then
+  test ! -e "$HOME/.agents/plugins/marketplace.json"
+  CODEX_JSON=$(codex plugin list --json)
+  jq -e --arg v "$CURRENT_VERSION" '\''
+    [.installed[] | select(.marketplaceName == "gopher-ai")] as $plugins |
+    ($plugins | length) == 6 and
+    all($plugins[]; .installed and .enabled and .version == $v)
+  '\'' <<EOF >/dev/null
+$CODEX_JSON
+EOF
+fi
+if [ -d "$HOME/.claude/plugins/cache/gopher-ai" ]; then
+  for plugin in go-dev go-web go-workflow gopher-guides llm-tools productivity tailwind; do
+    test -d "$HOME/.claude/plugins/cache/gopher-ai/$plugin/$CURRENT_VERSION"
+  done
+fi
+'
+```
+
+Expected: every detected platform verifies at 1.7.3 and no legacy Codex marketplace remains.
+
+- [ ] **Step 6: Final repository and release verification**
+
+Run locally:
+
+```bash
+git status --short --branch
+gh release view v1.7.3 --json isDraft,tagName,url,targetCommitish,assets \
+  --jq '{draft:.isDraft,tag:.tagName,url,target:.targetCommitish,assets:[.assets[].name]}'
+```
+
+Expected: clean `main`, published v1.7.3, exact target commit, and both expected assets.

--- a/docs/superpowers/specs/2026-07-22-codex-legacy-marketplace-migration-design.md
+++ b/docs/superpowers/specs/2026-07-22-codex-legacy-marketplace-migration-design.md
@@ -1,0 +1,97 @@
+# Codex Legacy Marketplace Migration Design
+
+## Problem
+
+The v1.7.2 installer registers and upgrades the Git-backed `gopher-ai` Codex marketplace, but prior user installations can leave `~/.agents/plugins/marketplace.json` behind. Codex discovers both marketplaces under the same `gopher-ai` name and may resolve plugins from the legacy local marketplace first. Its sources point to removed `~/.codex/plugins/<name>` directories, causing `codex plugin add <name>@gopher-ai` to fail even though the Git marketplace and versioned cache are valid.
+
+## Goal
+
+Make `scripts/install-codex.sh --user` safely migrate an installer-owned legacy user marketplace to the Git-backed marketplace, preserve user-authored state, roll back on failure, and allow `scripts/install-all.sh` upgrades to complete without manual cleanup.
+
+## Scope
+
+- Detect the legacy marketplace at `~/.agents/plugins/marketplace.json`.
+- Establish ownership from the marketplace's JSON structure rather than its path alone.
+- Temporarily remove an owned legacy marketplace before Codex resolves marketplace names.
+- Restore the legacy marketplace and existing cache roots if any Git marketplace or plugin installation step fails.
+- Permanently retire the legacy marketplace only after every Codex plugin installs successfully.
+- Add regression coverage for migration, rollback, duplicate resolution, and ownership safeguards.
+- Release the correction as v1.7.3 and verify the exact public installer locally and on Prometheus.
+
+## Non-Goals
+
+- Migrating arbitrary user-authored Codex marketplaces.
+- Rewriting Codex CLI marketplace resolution behavior.
+- Removing unrelated files under `~/.agents/plugins` or `~/.codex/plugins`.
+- Changing repository-scoped `--repo` installation behavior.
+
+## Ownership Rules
+
+The installer may migrate `~/.agents/plugins/marketplace.json` only when all of these conditions hold:
+
+- The file is valid JSON.
+- Its top-level `name` is `gopher-ai`.
+- It contains at least one plugin.
+- Every plugin name is one of the Codex-capable Gopher AI plugins shipped by the current repository.
+- Every plugin source is local and points to `./.codex/plugins/<plugin-name>` with the path name matching the plugin name.
+
+A malformed file, unknown plugin, mixed marketplace, non-local source, or mismatched path is not installer-owned. The installer leaves such a file unchanged and exits with an actionable error if it would conflict with the `gopher-ai` Git marketplace.
+
+## Migration Flow
+
+1. Bootstrap the repository and identify the current Codex-capable plugin names.
+2. Inspect `~/.agents/plugins/marketplace.json` before calling `codex plugin marketplace list`.
+3. If the file is absent or is not named `gopher-ai`, continue unchanged.
+4. If it is named `gopher-ai` and passes every ownership rule, move it to a temporary backup and record the original path.
+5. If it is named `gopher-ai` but fails an ownership rule, stop without altering it.
+6. Back up existing published Gopher AI cache roots using the current cache transaction.
+7. List configured marketplaces, then register or upgrade the Git-backed `gopher-ai` marketplace.
+8. Install all Codex-capable plugins through `codex plugin add <name>@gopher-ai`.
+9. If any marketplace or plugin CLI operation fails, restore the cache roots and move the legacy marketplace backup back to its original path byte-for-byte.
+10. After all plugins install successfully, discard the temporary legacy marketplace backup, retain the new versioned cache, and run the existing cleanup for owned direct-install plugin directories and legacy skills.
+
+## Components
+
+### Legacy Marketplace Detection
+
+A focused function validates the candidate file with `jq` and the current repository's Codex-capable plugin set. It returns distinct outcomes for absent, owned, and conflicting files so callers can preserve uncertain state and report useful errors.
+
+### Transactional Backup
+
+A backup function moves the owned marketplace file into a private temporary directory and records both paths. A restore function is idempotent and moves the exact file back when installation fails. Successful installation removes the temporary backup through the existing exit cleanup mechanism without restoring it.
+
+### Installation Integration
+
+`install_user_plugins` begins the marketplace transaction before querying Codex. Existing cache backup and restoration remain in place. Every early return after the transaction starts restores both resources in a consistent order.
+
+## Error Handling
+
+- Invalid or uncertain marketplace ownership stops the install before any marketplace or cache mutation.
+- Git marketplace registration or upgrade failure restores the legacy marketplace and cache roots.
+- Any individual plugin installation failure restores the legacy marketplace and cache roots.
+- Restore operations are idempotent so the normal exit trap cannot corrupt a completed rollback.
+- Errors identify the conflicting path and explain that it was preserved because ownership could not be proven.
+
+## Testing
+
+Extend `scripts/test-installation.sh` with isolated homes and the existing mocked Codex CLI to verify:
+
+- An owned legacy marketplace creates the duplicate-name reproduction before migration and installation succeeds after migration.
+- The owned legacy marketplace is absent after a fully successful install.
+- A marketplace upgrade failure restores the original file byte-for-byte.
+- A plugin installation failure restores the original file byte-for-byte and preserves prior cache roots.
+- A malformed marketplace is preserved and rejected.
+- A `gopher-ai` marketplace containing an unknown plugin is preserved and rejected.
+- A marketplace with a mismatched plugin path is preserved and rejected.
+- An unrelated marketplace file is untouched.
+- A clean host without the legacy file continues through the existing installation path.
+
+The full repository release gate and universal archive verification must pass before publishing v1.7.3.
+
+## Release and Host Verification
+
+- Synchronize every marketplace, Claude plugin, and Codex plugin manifest to 1.7.3.
+- Run the repository release gate and build verified Codex and Gemini archives.
+- Commit and push the fix and version bump, require exact-commit CI success, create a verified draft with both assets, and publish v1.7.3.
+- Run `bash -c "$(curl -fsSL https://raw.githubusercontent.com/gopherguides/gopher-ai/main/scripts/install-all.sh)"` locally and verify Claude Code, Codex, and Gemini complete successfully at 1.7.3.
+- Run the same command over SSH on Prometheus and verify the installed versions there.

--- a/plugins/go-dev/.claude-plugin/plugin.json
+++ b/plugins/go-dev/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "go-dev",
   "description": "Go-specific development tools with idiomatic best practices",
-  "version": "1.7.2",
+  "version": "1.7.3",
   "author": {
     "name": "Gopher Guides",
     "email": "support@gopherguides.com"

--- a/plugins/go-dev/.codex-plugin/plugin.json
+++ b/plugins/go-dev/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "go-dev",
-  "version": "1.7.2",
+  "version": "1.7.3",
   "description": "Go-specific development tools with idiomatic best practices",
   "author": {
     "name": "Gopher Guides",
@@ -9,7 +9,13 @@
   "homepage": "https://gopherguides.com",
   "repository": "https://github.com/gopherguides/gopher-ai",
   "license": "MIT",
-  "keywords": ["go", "testing", "lint", "explain", "best-practices"],
+  "keywords": [
+    "go",
+    "testing",
+    "lint",
+    "explain",
+    "best-practices"
+  ],
   "skills": "./skills/",
   "interface": {
     "displayName": "Go Dev",

--- a/plugins/go-web/.claude-plugin/plugin.json
+++ b/plugins/go-web/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "go-web",
   "description": "Opinionated Go web app scaffolding with Templ + HTMX + Alpine.js + Tailwind",
-  "version": "1.7.2",
+  "version": "1.7.3",
   "author": {
     "name": "Gopher Guides",
     "email": "support@gopherguides.com"

--- a/plugins/go-web/.codex-plugin/plugin.json
+++ b/plugins/go-web/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "go-web",
-  "version": "1.7.2",
+  "version": "1.7.3",
   "description": "Opinionated Go web app scaffolding with Templ + HTMX + Alpine.js + Tailwind",
   "author": {
     "name": "Gopher Guides",
@@ -9,7 +9,15 @@
   "homepage": "https://gopherguides.com",
   "repository": "https://github.com/gopherguides/gopher-ai",
   "license": "MIT",
-  "keywords": ["go", "web", "templ", "htmx", "alpine", "templui", "tailwind"],
+  "keywords": [
+    "go",
+    "web",
+    "templ",
+    "htmx",
+    "alpine",
+    "templui",
+    "tailwind"
+  ],
   "skills": "./skills/",
   "interface": {
     "displayName": "Go Web",

--- a/plugins/go-workflow/.claude-plugin/plugin.json
+++ b/plugins/go-workflow/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "go-workflow",
   "description": "Issue-to-PR workflow automation with git worktree management",
-  "version": "1.7.2",
+  "version": "1.7.3",
   "author": {
     "name": "Gopher Guides",
     "email": "support@gopherguides.com"

--- a/plugins/go-workflow/.codex-plugin/plugin.json
+++ b/plugins/go-workflow/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "go-workflow",
-  "version": "1.7.2",
+  "version": "1.7.3",
   "description": "Issue-to-PR workflow automation with git worktree management",
   "author": {
     "name": "Gopher Guides",
@@ -9,7 +9,13 @@
   "homepage": "https://gopherguides.com",
   "repository": "https://github.com/gopherguides/gopher-ai",
   "license": "MIT",
-  "keywords": ["workflow", "github", "issues", "pr", "worktree"],
+  "keywords": [
+    "workflow",
+    "github",
+    "issues",
+    "pr",
+    "worktree"
+  ],
   "skills": "./skills/",
   "interface": {
     "displayName": "Go Workflow",

--- a/plugins/gopher-guides/.claude-plugin/plugin.json
+++ b/plugins/gopher-guides/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "gopher-guides",
   "description": "Gopher Guides training materials integrated into Claude",
-  "version": "1.7.2",
+  "version": "1.7.3",
   "author": {
     "name": "Gopher Guides",
     "email": "support@gopherguides.com"

--- a/plugins/gopher-guides/.codex-plugin/plugin.json
+++ b/plugins/gopher-guides/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "gopher-guides",
-  "version": "1.7.2",
+  "version": "1.7.3",
   "description": "Gopher Guides training materials integration",
   "author": {
     "name": "Gopher Guides",
@@ -9,7 +9,12 @@
   "homepage": "https://gopherguides.com",
   "repository": "https://github.com/gopherguides/gopher-ai",
   "license": "MIT",
-  "keywords": ["go", "training", "best-practices", "gopher-guides"],
+  "keywords": [
+    "go",
+    "training",
+    "best-practices",
+    "gopher-guides"
+  ],
   "skills": "./skills/",
   "interface": {
     "displayName": "Gopher Guides",

--- a/plugins/llm-tools/.claude-plugin/plugin.json
+++ b/plugins/llm-tools/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "llm-tools",
   "description": "Multi-LLM integration for second opinions and task delegation",
-  "version": "1.7.2",
+  "version": "1.7.3",
   "author": {
     "name": "Gopher Guides",
     "email": "support@gopherguides.com"

--- a/plugins/llm-tools/.codex-plugin/plugin.json
+++ b/plugins/llm-tools/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "llm-tools",
-  "version": "1.7.2",
+  "version": "1.7.3",
   "description": "Multi-LLM integration for second opinions and task delegation",
   "author": {
     "name": "Gopher Guides",
@@ -9,7 +9,15 @@
   "homepage": "https://gopherguides.com",
   "repository": "https://github.com/gopherguides/gopher-ai",
   "license": "MIT",
-  "keywords": ["llm", "openai", "codex", "gemini", "ollama", "multi-model", "second-opinion"],
+  "keywords": [
+    "llm",
+    "openai",
+    "codex",
+    "gemini",
+    "ollama",
+    "multi-model",
+    "second-opinion"
+  ],
   "skills": "./skills/",
   "interface": {
     "displayName": "LLM Tools",

--- a/plugins/productivity/.claude-plugin/plugin.json
+++ b/plugins/productivity/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "productivity",
   "description": "Standup reports, changelogs, and git productivity helpers",
-  "version": "1.7.2",
+  "version": "1.7.3",
   "author": {
     "name": "Gopher Guides",
     "email": "support@gopherguides.com"

--- a/plugins/tailwind/.claude-plugin/plugin.json
+++ b/plugins/tailwind/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "tailwind",
   "description": "Tailwind CSS v4 tools for initialization, auditing, migration, and optimization",
-  "version": "1.7.2",
+  "version": "1.7.3",
   "author": {
     "name": "Gopher Guides",
     "email": "support@gopherguides.com"

--- a/plugins/tailwind/.codex-plugin/plugin.json
+++ b/plugins/tailwind/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "tailwind",
-  "version": "1.7.2",
+  "version": "1.7.3",
   "description": "Tailwind CSS v4 tools for initialization, auditing, migration, and optimization",
   "author": {
     "name": "Gopher Guides",
@@ -9,7 +9,15 @@
   "homepage": "https://gopherguides.com",
   "repository": "https://github.com/gopherguides/gopher-ai",
   "license": "MIT",
-  "keywords": ["tailwind", "css", "styling", "frontend", "v4", "migration", "audit"],
+  "keywords": [
+    "tailwind",
+    "css",
+    "styling",
+    "frontend",
+    "v4",
+    "migration",
+    "audit"
+  ],
   "skills": "./skills/",
   "mcpServers": "./.mcp.json",
   "interface": {

--- a/scripts/install-codex.sh
+++ b/scripts/install-codex.sh
@@ -520,7 +520,7 @@ prepare_legacy_user_marketplace_migration() {
     local candidate="$HOME/.agents/plugins/marketplace.json"
     [[ -e "$candidate" || -L "$candidate" ]] || return 0
 
-    if ! jq -e . "$candidate" >/dev/null 2>&1; then
+    if ! jq -e -s 'length == 1' "$candidate" >/dev/null 2>&1; then
         echo "error: preserved invalid marketplace file: $candidate" >&2
         echo "       move or repair it before installing gopher-ai." >&2
         return 1

--- a/scripts/install-codex.sh
+++ b/scripts/install-codex.sh
@@ -9,6 +9,8 @@ REPO_REF="${GOPHER_AI_REF:-main}"
 ARCHIVE_URL="${GOPHER_AI_ARCHIVE_URL:-https://codeload.github.com/${REPO_SLUG}/tar.gz/refs/heads/${REPO_REF}}"
 BOOTSTRAP_DIR=""
 CACHE_BACKUP_DIRS=()
+LEGACY_MARKETPLACE_PATH=""
+LEGACY_MARKETPLACE_BACKUP_DIR=""
 
 usage() {
     cat <<'EOF'
@@ -53,7 +55,20 @@ gopher-ai for Codex can be installed in two ways:
 EOF
 }
 
+restore_legacy_user_marketplace() {
+    [[ -n "$LEGACY_MARKETPLACE_PATH" ]] || return 0
+    local backup_file="$LEGACY_MARKETPLACE_BACKUP_DIR/marketplace.json"
+    if [[ -e "$backup_file" || -L "$backup_file" ]]; then
+        mkdir -p "$(dirname "$LEGACY_MARKETPLACE_PATH")"
+        mv "$backup_file" "$LEGACY_MARKETPLACE_PATH"
+    fi
+    [[ -z "$LEGACY_MARKETPLACE_BACKUP_DIR" ]] || rm -rf "$LEGACY_MARKETPLACE_BACKUP_DIR"
+    LEGACY_MARKETPLACE_PATH=""
+    LEGACY_MARKETPLACE_BACKUP_DIR=""
+}
+
 cleanup() {
+    restore_legacy_user_marketplace
     if [[ -n "$BOOTSTRAP_DIR" && -d "$BOOTSTRAP_DIR" ]]; then
         rm -rf "$BOOTSTRAP_DIR"
     fi
@@ -492,6 +507,59 @@ restore_removed_plugin_roots() {
     rm -rf "$backup_dir"
 }
 
+codex_plugin_names_json() {
+    local plugin_dir
+    for plugin_dir in "$ROOT_DIR"/plugins/*; do
+        [[ -d "$plugin_dir" ]] || continue
+        [[ -f "$plugin_dir/.codex-plugin/plugin.json" ]] || continue
+        basename "$plugin_dir"
+    done | jq -R . | jq -s .
+}
+
+prepare_legacy_user_marketplace_migration() {
+    local candidate="$HOME/.agents/plugins/marketplace.json"
+    [[ -e "$candidate" || -L "$candidate" ]] || return 0
+
+    if ! jq -e . "$candidate" >/dev/null 2>&1; then
+        echo "error: preserved invalid marketplace file: $candidate" >&2
+        echo "       move or repair it before installing gopher-ai." >&2
+        return 1
+    fi
+
+    local marketplace_name
+    marketplace_name="$(jq -r '.name // empty' "$candidate")"
+    [[ "$marketplace_name" == "gopher-ai" ]] || return 0
+
+    local allowed_plugins
+    allowed_plugins="$(codex_plugin_names_json)"
+    if ! jq -e --argjson allowed "$allowed_plugins" '
+        (.plugins | type == "array" and length > 0) and
+        all(.plugins[];
+            .name as $plugin_name |
+            ($plugin_name | type == "string") and
+            ($allowed | index($plugin_name) != null) and
+            .source.source == "local" and
+            .source.path == ("./.codex/plugins/" + $plugin_name)
+        )
+    ' "$candidate" >/dev/null; then
+        echo "error: preserved marketplace because ownership could not be proven: $candidate" >&2
+        echo "       remove or rename the conflicting gopher-ai marketplace, then retry." >&2
+        return 1
+    fi
+
+    local temp_base="${TMPDIR:-${TMP:-${TEMP:-/tmp}}}"
+    LEGACY_MARKETPLACE_BACKUP_DIR="$(mktemp -d "${temp_base%/}/gopher-ai-codex-marketplace.XXXXXX")"
+    LEGACY_MARKETPLACE_PATH="$candidate"
+    mv "$candidate" "$LEGACY_MARKETPLACE_BACKUP_DIR/marketplace.json"
+    echo "migrating legacy Codex marketplace: $candidate"
+}
+
+commit_legacy_user_marketplace_migration() {
+    [[ -z "$LEGACY_MARKETPLACE_BACKUP_DIR" ]] || rm -rf "$LEGACY_MARKETPLACE_BACKUP_DIR"
+    LEGACY_MARKETPLACE_PATH=""
+    LEGACY_MARKETPLACE_BACKUP_DIR=""
+}
+
 install_user_plugins() {
     require_cmd codex
     if ! codex plugin add --help >/dev/null 2>&1; then
@@ -499,6 +567,8 @@ install_user_plugins() {
         echo "       upgrade Codex, then retry --user." >&2
         return 1
     fi
+
+    prepare_legacy_user_marketplace_migration
 
     local marketplaces
     if ! marketplaces="$(codex plugin marketplace list --json 2>/dev/null)"; then
@@ -546,6 +616,7 @@ install_user_plugins() {
         installed=$((installed + 1))
     done
     restore_removed_plugin_roots "$cache_backup_dir"
+    commit_legacy_user_marketplace_migration
 
     if [[ "$installed" -eq 0 ]]; then
         echo "error: no Codex-capable plugins found in $ROOT_DIR/plugins." >&2

--- a/scripts/test-installation.sh
+++ b/scripts/test-installation.sh
@@ -1184,6 +1184,35 @@ else
 fi
 rm -f "$MALFORMED_COPY"
 
+echo -n "Codex --user preserves and rejects a mixed JSON marketplace stream... "
+printf '{}\n' > "$LEGACY_MARKETPLACE"
+cat "$ROOT_DIR/dist/codex/plugins/marketplace.json" >> "$LEGACY_MARKETPLACE"
+MIXED_JSON_COPY=$(mktemp)
+cp "$LEGACY_MARKETPLACE" "$MIXED_JSON_COPY"
+: > "$STUB_LOG"
+set +e
+HOME="$TMP_HOME" PATH="$STUB_PATH" CODEX_STUB_LOG="$STUB_LOG" \
+  CODEX_STUB_SOURCE_ROOT="$ROOT_DIR" CODEX_STUB_MARKETPLACE_REGISTERED=true \
+  bash "$ROOT_DIR/scripts/install-codex.sh" --user >/tmp/gopher-ai-legacy-mixed-json.log 2>&1
+MIXED_JSON_EXIT=$?
+set -e
+if [ "$MIXED_JSON_EXIT" -eq 0 ]; then
+  echo "FAIL (mixed JSON marketplace unexpectedly migrated)"
+  ERRORS=$((ERRORS + 1))
+elif ! cmp -s "$MIXED_JSON_COPY" "$LEGACY_MARKETPLACE"; then
+  echo "FAIL (mixed JSON marketplace was modified)"
+  ERRORS=$((ERRORS + 1))
+elif grep -q '^plugin marketplace ' "$STUB_LOG"; then
+  echo "FAIL (Codex marketplace state changed before mixed JSON was rejected)"
+  ERRORS=$((ERRORS + 1))
+elif ! grep -q 'move or repair it before installing gopher-ai' /tmp/gopher-ai-legacy-mixed-json.log; then
+  echo "FAIL (mixed JSON error was not actionable)"
+  ERRORS=$((ERRORS + 1))
+else
+  echo "OK"
+fi
+rm -f "$MIXED_JSON_COPY"
+
 echo -n "Codex --user leaves an unrelated user marketplace untouched... "
 jq '.name = "other-marketplace"' "$ROOT_DIR/dist/codex/plugins/marketplace.json" > "$LEGACY_MARKETPLACE"
 UNRELATED_COPY=$(mktemp)

--- a/scripts/test-installation.sh
+++ b/scripts/test-installation.sh
@@ -909,8 +909,37 @@ if [ "${1:-}" = "plugin" ] && [ "${2:-}" = "marketplace" ] && [ "${3:-}" = "list
   fi
   exit
 fi
+if [ "${1:-}" = "plugin" ] && [ "${2:-}" = "marketplace" ] && [ "${3:-}" = "upgrade" ]; then
+  if [ "${CODEX_STUB_FAIL_MARKETPLACE_UPGRADE:-false}" = "true" ]; then
+    printf 'forced marketplace upgrade failure\n' >&2
+    exit 1
+  fi
+  exit
+fi
+if [ "${1:-}" = "plugin" ] && [ "${2:-}" = "marketplace" ] && [ "${3:-}" = "add" ]; then
+  if [ "${CODEX_STUB_FAIL_MARKETPLACE_ADD:-false}" = "true" ]; then
+    printf 'forced marketplace add failure\n' >&2
+    exit 1
+  fi
+  exit
+fi
 if [ "${1:-}" = "plugin" ] && [ "${2:-}" = "add" ]; then
   plugin="${3%@*}"
+  legacy_marketplace="$HOME/.agents/plugins/marketplace.json"
+  if [ -f "$legacy_marketplace" ] && [ "$(jq -r '.name // empty' "$legacy_marketplace")" = "gopher-ai" ]; then
+    legacy_path="$(jq -r --arg plugin "$plugin" '.plugins[]? | select(.name == $plugin) | .source.path // empty' "$legacy_marketplace")"
+    if [ -n "$legacy_path" ]; then
+      resolved_path="$HOME/${legacy_path#./}"
+      if [ ! -d "$resolved_path" ]; then
+        printf 'plugin source path is not a directory: %s\n' "$resolved_path" >&2
+        exit 1
+      fi
+    fi
+  fi
+  if [ "${CODEX_STUB_FAIL_ADD_PLUGIN:-}" = "$plugin" ]; then
+    printf 'forced plugin add failure: %s\n' "$plugin" >&2
+    exit 1
+  fi
   source_root="${CODEX_STUB_SOURCE_ROOT:?}/plugins/$plugin"
   version="$(jq -r '.version' "$source_root/.codex-plugin/plugin.json")"
   plugin_cache="$HOME/.codex/plugins/cache/gopher-ai/$plugin"
@@ -990,6 +1019,187 @@ elif grep -q '^plugin marketplace add ' "$STUB_LOG"; then
 else
   echo "OK"
 fi
+
+echo -n "Codex --user migrates the owned legacy user marketplace... "
+LEGACY_MARKETPLACE="$TMP_HOME/.agents/plugins/marketplace.json"
+mkdir -p "$(dirname "$LEGACY_MARKETPLACE")"
+cp "$ROOT_DIR/dist/codex/plugins/marketplace.json" "$LEGACY_MARKETPLACE"
+: > "$STUB_LOG"
+if ! HOME="$TMP_HOME" PATH="$STUB_PATH" CODEX_STUB_LOG="$STUB_LOG" \
+  CODEX_STUB_SOURCE_ROOT="$ROOT_DIR" CODEX_STUB_MARKETPLACE_REGISTERED=true \
+  bash "$ROOT_DIR/scripts/install-codex.sh" --user >/tmp/gopher-ai-legacy-marketplace.log 2>&1; then
+  echo "FAIL (--user did not migrate the owned legacy marketplace)"
+  sed -n '1,40p' /tmp/gopher-ai-legacy-marketplace.log
+  ERRORS=$((ERRORS + 1))
+elif [ -e "$LEGACY_MARKETPLACE" ]; then
+  echo "FAIL (owned legacy marketplace remained after successful install)"
+  ERRORS=$((ERRORS + 1))
+elif ! grep -qx 'plugin marketplace upgrade gopher-ai' "$STUB_LOG"; then
+  echo "FAIL (Git marketplace was not upgraded after migration)"
+  ERRORS=$((ERRORS + 1))
+else
+  echo "OK"
+fi
+
+echo -n "Codex --user restores the legacy marketplace after plugin failure... "
+mkdir -p "$(dirname "$LEGACY_MARKETPLACE")"
+cp "$ROOT_DIR/dist/codex/plugins/marketplace.json" "$LEGACY_MARKETPLACE"
+LEGACY_COPY=$(mktemp)
+cp "$LEGACY_MARKETPLACE" "$LEGACY_COPY"
+ROLLBACK_ROOT="$TMP_HOME/.codex/plugins/cache/gopher-ai/go-dev/1.7.1"
+mkdir -p "$ROLLBACK_ROOT"
+echo "active session" > "$ROLLBACK_ROOT/ACTIVE_SESSION"
+set +e
+HOME="$TMP_HOME" PATH="$STUB_PATH" CODEX_STUB_LOG="$STUB_LOG" \
+  CODEX_STUB_SOURCE_ROOT="$ROOT_DIR" CODEX_STUB_MARKETPLACE_REGISTERED=true \
+  CODEX_STUB_FAIL_ADD_PLUGIN=go-web bash "$ROOT_DIR/scripts/install-codex.sh" --user \
+  >/tmp/gopher-ai-legacy-rollback.log 2>&1
+LEGACY_EXIT=$?
+set -e
+if [ "$LEGACY_EXIT" -eq 0 ]; then
+  echo "FAIL (forced plugin failure unexpectedly succeeded)"
+  ERRORS=$((ERRORS + 1))
+elif ! cmp -s "$LEGACY_COPY" "$LEGACY_MARKETPLACE"; then
+  echo "FAIL (legacy marketplace was not restored byte-for-byte)"
+  ERRORS=$((ERRORS + 1))
+elif [ ! -f "$ROLLBACK_ROOT/ACTIVE_SESSION" ]; then
+  echo "FAIL (prior cache root was not restored after plugin failure)"
+  ERRORS=$((ERRORS + 1))
+else
+  echo "OK"
+fi
+rm -f "$LEGACY_COPY"
+
+echo -n "Codex --user restores the legacy marketplace after marketplace upgrade failure... "
+LEGACY_UPGRADE_COPY=$(mktemp)
+cp "$LEGACY_MARKETPLACE" "$LEGACY_UPGRADE_COPY"
+set +e
+HOME="$TMP_HOME" PATH="$STUB_PATH" CODEX_STUB_LOG="$STUB_LOG" \
+  CODEX_STUB_SOURCE_ROOT="$ROOT_DIR" CODEX_STUB_MARKETPLACE_REGISTERED=true \
+  CODEX_STUB_FAIL_MARKETPLACE_UPGRADE=true bash "$ROOT_DIR/scripts/install-codex.sh" --user \
+  >/tmp/gopher-ai-legacy-upgrade-rollback.log 2>&1
+UPGRADE_EXIT=$?
+set -e
+if [ "$UPGRADE_EXIT" -eq 0 ]; then
+  echo "FAIL (forced marketplace upgrade failure unexpectedly succeeded)"
+  ERRORS=$((ERRORS + 1))
+elif ! cmp -s "$LEGACY_UPGRADE_COPY" "$LEGACY_MARKETPLACE"; then
+  echo "FAIL (legacy marketplace was not restored after upgrade failure)"
+  ERRORS=$((ERRORS + 1))
+else
+  echo "OK"
+fi
+rm -f "$LEGACY_UPGRADE_COPY"
+
+echo -n "Codex --user restores the legacy marketplace after marketplace registration failure... "
+LEGACY_ADD_COPY=$(mktemp)
+cp "$LEGACY_MARKETPLACE" "$LEGACY_ADD_COPY"
+set +e
+HOME="$TMP_HOME" PATH="$STUB_PATH" CODEX_STUB_LOG="$STUB_LOG" \
+  CODEX_STUB_SOURCE_ROOT="$ROOT_DIR" CODEX_STUB_FAIL_MARKETPLACE_ADD=true \
+  bash "$ROOT_DIR/scripts/install-codex.sh" --user \
+  >/tmp/gopher-ai-legacy-add-rollback.log 2>&1
+ADD_EXIT=$?
+set -e
+if [ "$ADD_EXIT" -eq 0 ]; then
+  echo "FAIL (forced marketplace registration failure unexpectedly succeeded)"
+  ERRORS=$((ERRORS + 1))
+elif ! cmp -s "$LEGACY_ADD_COPY" "$LEGACY_MARKETPLACE"; then
+  echo "FAIL (legacy marketplace was not restored after registration failure)"
+  ERRORS=$((ERRORS + 1))
+else
+  echo "OK"
+fi
+rm -f "$LEGACY_ADD_COPY"
+
+echo -n "Codex --user preserves and rejects an uncertain gopher-ai marketplace... "
+UNKNOWN_COPY=$(mktemp)
+jq '.plugins[0].source.path = "./custom/go-dev"' \
+  "$ROOT_DIR/dist/codex/plugins/marketplace.json" > "$LEGACY_MARKETPLACE"
+cp "$LEGACY_MARKETPLACE" "$UNKNOWN_COPY"
+: > "$STUB_LOG"
+set +e
+HOME="$TMP_HOME" PATH="$STUB_PATH" CODEX_STUB_LOG="$STUB_LOG" \
+  CODEX_STUB_SOURCE_ROOT="$ROOT_DIR" CODEX_STUB_MARKETPLACE_REGISTERED=true \
+  bash "$ROOT_DIR/scripts/install-codex.sh" --user >/tmp/gopher-ai-legacy-uncertain.log 2>&1
+UNCERTAIN_EXIT=$?
+set -e
+if [ "$UNCERTAIN_EXIT" -eq 0 ]; then
+  echo "FAIL (uncertain marketplace unexpectedly migrated)"
+  ERRORS=$((ERRORS + 1))
+elif ! cmp -s "$UNKNOWN_COPY" "$LEGACY_MARKETPLACE"; then
+  echo "FAIL (uncertain marketplace was modified)"
+  ERRORS=$((ERRORS + 1))
+elif grep -q '^plugin marketplace ' "$STUB_LOG"; then
+  echo "FAIL (Codex marketplace state changed before ownership was proven)"
+  ERRORS=$((ERRORS + 1))
+elif ! grep -q 'preserved' /tmp/gopher-ai-legacy-uncertain.log; then
+  echo "FAIL (error did not explain that uncertain state was preserved)"
+  ERRORS=$((ERRORS + 1))
+else
+  echo "OK"
+fi
+rm -f "$UNKNOWN_COPY"
+
+echo -n "Codex --user preserves and rejects an unknown gopher-ai plugin... "
+jq '.plugins += [{"name":"unknown-plugin","source":{"source":"local","path":"./.codex/plugins/unknown-plugin"}}]' \
+  "$ROOT_DIR/dist/codex/plugins/marketplace.json" > "$LEGACY_MARKETPLACE"
+UNKNOWN_PLUGIN_COPY=$(mktemp)
+cp "$LEGACY_MARKETPLACE" "$UNKNOWN_PLUGIN_COPY"
+set +e
+HOME="$TMP_HOME" PATH="$STUB_PATH" CODEX_STUB_LOG="$STUB_LOG" \
+  CODEX_STUB_SOURCE_ROOT="$ROOT_DIR" CODEX_STUB_MARKETPLACE_REGISTERED=true \
+  bash "$ROOT_DIR/scripts/install-codex.sh" --user >/tmp/gopher-ai-legacy-unknown.log 2>&1
+UNKNOWN_PLUGIN_EXIT=$?
+set -e
+if [ "$UNKNOWN_PLUGIN_EXIT" -eq 0 ]; then
+  echo "FAIL (unknown plugin marketplace unexpectedly migrated)"
+  ERRORS=$((ERRORS + 1))
+elif ! cmp -s "$UNKNOWN_PLUGIN_COPY" "$LEGACY_MARKETPLACE"; then
+  echo "FAIL (unknown plugin marketplace was modified)"
+  ERRORS=$((ERRORS + 1))
+else
+  echo "OK"
+fi
+rm -f "$UNKNOWN_PLUGIN_COPY"
+
+echo -n "Codex --user preserves and rejects a malformed marketplace... "
+printf '{invalid json\n' > "$LEGACY_MARKETPLACE"
+MALFORMED_COPY=$(mktemp)
+cp "$LEGACY_MARKETPLACE" "$MALFORMED_COPY"
+set +e
+HOME="$TMP_HOME" PATH="$STUB_PATH" CODEX_STUB_LOG="$STUB_LOG" \
+  CODEX_STUB_SOURCE_ROOT="$ROOT_DIR" CODEX_STUB_MARKETPLACE_REGISTERED=true \
+  bash "$ROOT_DIR/scripts/install-codex.sh" --user >/tmp/gopher-ai-legacy-malformed.log 2>&1
+MALFORMED_EXIT=$?
+set -e
+if [ "$MALFORMED_EXIT" -eq 0 ]; then
+  echo "FAIL (malformed marketplace unexpectedly migrated)"
+  ERRORS=$((ERRORS + 1))
+elif ! cmp -s "$MALFORMED_COPY" "$LEGACY_MARKETPLACE"; then
+  echo "FAIL (malformed marketplace was modified)"
+  ERRORS=$((ERRORS + 1))
+else
+  echo "OK"
+fi
+rm -f "$MALFORMED_COPY"
+
+echo -n "Codex --user leaves an unrelated user marketplace untouched... "
+jq '.name = "other-marketplace"' "$ROOT_DIR/dist/codex/plugins/marketplace.json" > "$LEGACY_MARKETPLACE"
+UNRELATED_COPY=$(mktemp)
+cp "$LEGACY_MARKETPLACE" "$UNRELATED_COPY"
+if ! HOME="$TMP_HOME" PATH="$STUB_PATH" CODEX_STUB_LOG="$STUB_LOG" \
+  CODEX_STUB_SOURCE_ROOT="$ROOT_DIR" CODEX_STUB_MARKETPLACE_REGISTERED=true \
+  bash "$ROOT_DIR/scripts/install-codex.sh" --user >/dev/null 2>&1; then
+  echo "FAIL (unrelated marketplace blocked installation)"
+  ERRORS=$((ERRORS + 1))
+elif ! cmp -s "$UNRELATED_COPY" "$LEGACY_MARKETPLACE"; then
+  echo "FAIL (unrelated marketplace was modified)"
+  ERRORS=$((ERRORS + 1))
+else
+  echo "OK"
+fi
+rm -f "$UNRELATED_COPY" "$LEGACY_MARKETPLACE"
 
 echo -n "Codex --user preserves a published root on the same version... "
 PUBLISHED_ROOT="$TMP_HOME/.codex/plugins/cache/gopher-ai/go-dev/$CURRENT_VERSION"


### PR DESCRIPTION
## Summary
- migrate the installer-owned legacy Codex marketplace before Git marketplace resolution
- restore legacy marketplace and cache state after failed installs
- release the correction as v1.7.3

## Test Plan
- \`bash -n scripts/install-codex.sh\`
- \`shellcheck scripts/install-codex.sh scripts/test-installation.sh\`
- \`./scripts/test-installation.sh\`
- full repository release gate
- verified Codex and Gemini v1.7.3 archives