### PR TITLE
fix(install): require Codex executable

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,14 +6,14 @@
   },
   "metadata": {
     "description": "Go-specific and general-purpose AI coding assistant plugins - by Gopher Guides",
-    "version": "1.7.3"
+    "version": "1.7.4"
   },
   "plugins": [
     {
       "name": "go-workflow",
       "source": "./plugins/go-workflow",
       "description": "Issue-to-PR workflow automation with worktree management",
-      "version": "1.7.3",
+      "version": "1.7.4",
       "keywords": [
         "workflow",
         "github",
@@ -26,7 +26,7 @@
       "name": "go-dev",
       "source": "./plugins/go-dev",
       "description": "Go-specific development tools with best practices",
-      "version": "1.7.3",
+      "version": "1.7.4",
       "keywords": [
         "go",
         "testing",
@@ -39,7 +39,7 @@
       "name": "productivity",
       "source": "./plugins/productivity",
       "description": "Standup reports and git productivity helpers",
-      "version": "1.7.3",
+      "version": "1.7.4",
       "keywords": [
         "standup",
         "changelog",
@@ -52,7 +52,7 @@
       "name": "gopher-guides",
       "source": "./plugins/gopher-guides",
       "description": "Go best practices guidance powered by Gopher Guides training materials",
-      "version": "1.7.3",
+      "version": "1.7.4",
       "keywords": [
         "go",
         "training",
@@ -64,7 +64,7 @@
       "name": "llm-tools",
       "source": "./plugins/llm-tools",
       "description": "Multi-LLM integration for second opinions and task delegation",
-      "version": "1.7.3",
+      "version": "1.7.4",
       "keywords": [
         "llm",
         "openai",
@@ -81,7 +81,7 @@
       "name": "go-web",
       "source": "./plugins/go-web",
       "description": "Opinionated Go web app scaffolding with Templ + HTMX + Alpine.js + Tailwind",
-      "version": "1.7.3",
+      "version": "1.7.4",
       "keywords": [
         "go",
         "web",
@@ -97,7 +97,7 @@
       "name": "tailwind",
       "source": "./plugins/tailwind",
       "description": "Tailwind CSS v4 tools for initialization, auditing, migration, and optimization",
-      "version": "1.7.3",
+      "version": "1.7.4",
       "keywords": [
         "tailwind",
         "css",

--- a/docs/superpowers/plans/2026-07-23-codex-cli-detection.md
+++ b/docs/superpowers/plans/2026-07-23-codex-cli-detection.md
@@ -15,7 +15,9 @@
 - Print `Codex CLI ...... skipped (found ~/.codex/ but no codex executable on PATH)` for stale state without a CLI.
 - Continue installing other detected platforms and print a successful summary for those platforms.
 - Keep `scripts/install-codex.sh --user` behavior unchanged.
-- Synchronize every marketplace, Claude plugin, and Codex plugin manifest to 1.7.4.
+- Synchronize `.claude-plugin/marketplace.json`, every Claude plugin manifest, every Codex plugin manifest, and every generated Gemini extension manifest to 1.7.4.
+- Keep the existing unversioned Codex marketplace schema; do not add a top-level version to the generated Codex `marketplace.json`.
+- Treat only `.claude-plugin/marketplace.json`, Claude plugin manifests, Codex plugin manifests, and Gemini extension manifests as version-bearing.
 - Publish only after PR CI/review gates and exact merged-main CI pass.
 - Run the user's exact public installer command locally and on Prometheus after publication.
 
@@ -146,10 +148,12 @@ git commit -m "fix(install): require Codex executable"
 - Modify: `.claude-plugin/marketplace.json`
 - Modify: `plugins/*/.claude-plugin/plugin.json`
 - Modify: `plugins/*/.codex-plugin/plugin.json`
+- Generate: `dist/gemini/gopher-ai-*/gemini-extension.json`
 
 **Interfaces:**
 - Consumes: Task 1's approved detection fix.
-- Produces: all version sources and both release archives at 1.7.4.
+- Produces: all version-bearing manifests and both release archives at 1.7.4.
+- Preserves: the existing unversioned generated Codex marketplace schema with no top-level version.
 
 - [ ] **Step 1: Synchronize all manifest versions**
 

--- a/docs/superpowers/plans/2026-07-23-codex-cli-detection.md
+++ b/docs/superpowers/plans/2026-07-23-codex-cli-detection.md
@@ -1,0 +1,349 @@
+# Codex CLI Detection Correction Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make the universal installer skip stale Codex state when no executable is available, publish v1.7.4, and complete exact installer runs locally and on Prometheus.
+
+**Architecture:** `scripts/install-all.sh` will separate executable capability from persisted Codex state. Only a resolvable executable makes Codex an installation target; stale state changes the detection message but is never modified.
+
+**Tech Stack:** Bash, `jq`, shellcheck, isolated-home integration tests, Git/GitHub CLI, existing release scripts.
+
+## Global Constraints
+
+- Set `HAVE_CODEX=true` only when `command -v codex` succeeds.
+- Preserve `~/.codex/` unchanged when the Codex executable is absent.
+- Print `Codex CLI ...... skipped (found ~/.codex/ but no codex executable on PATH)` for stale state without a CLI.
+- Continue installing other detected platforms and print a successful summary for those platforms.
+- Keep `scripts/install-codex.sh --user` behavior unchanged.
+- Synchronize every marketplace, Claude plugin, and Codex plugin manifest to 1.7.4.
+- Publish only after PR CI/review gates and exact merged-main CI pass.
+- Run the user's exact public installer command locally and on Prometheus after publication.
+
+---
+
+### Task 1: Correct Codex Detection with an Integration Regression
+
+**Files:**
+- Modify: `scripts/install-all.sh:124-167`
+- Modify: `scripts/test-installation.sh:495-527`
+
+**Interfaces:**
+- Consumes: `HOME`, `PATH`, existing `HAVE_CLAUDE`, `HAVE_CODEX`, and `HAVE_GEMINI` platform flags.
+- Produces: `HAVE_CODEX_STATE` boolean used only for user-facing detection output.
+
+- [ ] **Step 1: Add the failing stale-state integration regression**
+
+Insert after the existing `install-all.sh fails cleanly when jq is missing` test:
+
+```bash
+echo -n "install-all.sh skips stale Codex state when the CLI is unavailable... "
+TMP_HOME=$(mktemp -d)
+TMP_BIN=$(mktemp -d)
+mkdir -p "$TMP_HOME/.claude" "$TMP_HOME/.codex"
+printf '%s\n' 'preserve me' > "$TMP_HOME/.codex/SENTINEL"
+for cmd in bash sh awk sed grep find mkdir rm cp mv cmp mktemp printf cat dirname basename tr head tail xargs sleep date wc sha256sum shasum git sort uniq stat ln readlink jq comm touch chmod cut id env true false echo test tar tree; do
+  cmd_path="$(command -v "$cmd" 2>/dev/null || true)"
+  [ -n "$cmd_path" ] && ln -s "$cmd_path" "$TMP_BIN/$cmd"
+done
+set +e
+HOME="$TMP_HOME" PATH="$TMP_BIN" bash "$ROOT_DIR/scripts/install-all.sh" --force \
+  </dev/null >/tmp/gopher-ai-installall-stale-codex.log 2>&1
+STALE_CODEX_EXIT=$?
+set -e
+if [ "$STALE_CODEX_EXIT" -ne 0 ]; then
+  echo "FAIL (Claude-only install exited non-zero)"
+  sed -n '1,80p' /tmp/gopher-ai-installall-stale-codex.log
+  ERRORS=$((ERRORS + 1))
+elif ! grep -Fq 'Codex CLI ...... skipped (found ~/.codex/ but no codex executable on PATH)' /tmp/gopher-ai-installall-stale-codex.log; then
+  echo "FAIL (stale Codex state warning was missing)"
+  ERRORS=$((ERRORS + 1))
+elif grep -Fq '=== Codex CLI ===' /tmp/gopher-ai-installall-stale-codex.log; then
+  echo "FAIL (Codex installer ran without a Codex executable)"
+  ERRORS=$((ERRORS + 1))
+elif ! grep -Fq 'Done! Installed for: Claude Code' /tmp/gopher-ai-installall-stale-codex.log; then
+  echo "FAIL (Claude-only completion summary was missing)"
+  ERRORS=$((ERRORS + 1))
+elif [ "$(cat "$TMP_HOME/.codex/SENTINEL")" != 'preserve me' ]; then
+  echo "FAIL (stale Codex state was modified)"
+  ERRORS=$((ERRORS + 1))
+else
+  echo "OK"
+fi
+rm -rf "$TMP_HOME" "$TMP_BIN"
+```
+
+- [ ] **Step 2: Run the installation suite and verify RED**
+
+Run:
+
+```bash
+./scripts/test-installation.sh
+```
+
+Expected: the new regression fails because the current installer enters `=== Codex CLI ===` and exits with `error: required command not found: codex`; existing tests continue running.
+
+- [ ] **Step 3: Separate executable detection from stale state**
+
+Replace the Codex portion of `detect_platforms()` with:
+
+```bash
+    HAVE_CODEX=false
+    HAVE_CODEX_STATE=false
+
+    if command -v codex >/dev/null 2>&1; then
+        HAVE_CODEX=true
+    fi
+    if [[ -d "$HOME/.codex" ]]; then
+        HAVE_CODEX_STATE=true
+    fi
+```
+
+Keep the existing Claude and Gemini detection unchanged.
+
+- [ ] **Step 4: Print distinct Codex skip states**
+
+Replace the Codex branch in `print_detection()` with:
+
+```bash
+    if $HAVE_CODEX; then
+        echo "  Codex CLI ...... found — will install global plugins to ~/.codex/plugins/"
+    elif $HAVE_CODEX_STATE; then
+        echo "  Codex CLI ...... skipped (found ~/.codex/ but no codex executable on PATH)"
+    else
+        echo "  Codex CLI ...... skipped (no codex executable on PATH)"
+    fi
+```
+
+Do not change platform-list construction or `install_codex()` invocation; both already depend on `HAVE_CODEX`.
+
+- [ ] **Step 5: Run focused verification**
+
+Run:
+
+```bash
+bash -n scripts/install-all.sh
+shellcheck scripts/install-all.sh scripts/test-installation.sh
+./scripts/test-installation.sh
+git diff --check
+```
+
+Expected: all commands exit zero, the stale-state regression prints `OK`, and the installation suite ends with `All installation tests passed.`
+
+- [ ] **Step 6: Commit the detection fix**
+
+Run:
+
+```bash
+git add scripts/install-all.sh scripts/test-installation.sh
+git commit -m "fix(install): require Codex executable"
+```
+
+---
+
+### Task 2: Bump and Validate v1.7.4
+
+**Files:**
+- Modify: `.claude-plugin/marketplace.json`
+- Modify: `plugins/*/.claude-plugin/plugin.json`
+- Modify: `plugins/*/.codex-plugin/plugin.json`
+
+**Interfaces:**
+- Consumes: Task 1's approved detection fix.
+- Produces: all version sources and both release archives at 1.7.4.
+
+- [ ] **Step 1: Synchronize all manifest versions**
+
+Run:
+
+```bash
+VERSION=1.7.4
+jq --arg v "$VERSION" '.metadata.version = $v | .plugins[].version = $v' \
+  .claude-plugin/marketplace.json > /tmp/marketplace.json.tmp
+mv /tmp/marketplace.json.tmp .claude-plugin/marketplace.json
+for pjson in plugins/*/.claude-plugin/plugin.json plugins/*/.codex-plugin/plugin.json; do
+  [ -f "$pjson" ] || continue
+  jq --arg v "$VERSION" '.version = $v' "$pjson" > /tmp/plugin.json.tmp
+  mv /tmp/plugin.json.tmp "$pjson"
+done
+jq -e --arg v "$VERSION" '.metadata.version == $v and all(.plugins[]; .version == $v)' \
+  .claude-plugin/marketplace.json >/dev/null
+for pjson in plugins/*/.claude-plugin/plugin.json plugins/*/.codex-plugin/plugin.json; do
+  [ -f "$pjson" ] || continue
+  jq -e --arg v "$VERSION" '.version == $v' "$pjson" >/dev/null
+done
+```
+
+- [ ] **Step 2: Run the full repository release gate**
+
+Run:
+
+```bash
+bash -lc './scripts/test-installation.sh && ./scripts/test-commands.sh && ./scripts/test-hooks.sh && ./scripts/test-ship-e2e-gate.sh && ./scripts/check-shared-sync.sh && shellcheck agent-skills/scripts/*.sh && for skill_dir in agent-skills/skills/*/; do skill_name=$(basename "$skill_dir"); skill_file="$skill_dir/SKILL.md"; test -f "$skill_file"; lines=$(wc -l < "$skill_file"); test "$lines" -lt 500; name=$(sed -n "/^---$/,/^---$/p" "$skill_file" | awk "/^name:/ {print \$2; exit}"); test "$name" = "$skill_name"; rg -q "^description:" "$skill_file"; done && ruby -ryaml -e "YAML.load_file(ARGV[0])" agent-skills/config/severity.yaml && (cd agent-skills/examples/demo-repo && go build -o /tmp/gopher-ai-demo . && go test ./...)'
+```
+
+- [ ] **Step 3: Build and verify release archives**
+
+Run:
+
+```bash
+./scripts/build-universal.sh
+VERSION=1.7.4
+CODEX_ASSET="dist/gopher-ai-codex-plugins-v${VERSION}.tar.gz"
+GEMINI_ASSET="dist/gopher-ai-gemini-extensions-v${VERSION}.tar.gz"
+test -f "$CODEX_ASSET"
+test -f "$GEMINI_ASSET"
+CODEX_MANIFESTS=$(tar -tzf "$CODEX_ASSET" | rg '/\.codex-plugin/plugin\.json$')
+GEMINI_MANIFESTS=$(tar -tzf "$GEMINI_ASSET" | rg '/gemini-extension\.json$')
+test -n "$CODEX_MANIFESTS"
+test -n "$GEMINI_MANIFESTS"
+while IFS= read -r manifest; do
+  tar -xOzf "$CODEX_ASSET" "$manifest" | jq -e --arg v "$VERSION" '.version == $v' >/dev/null
+done <<< "$CODEX_MANIFESTS"
+while IFS= read -r manifest; do
+  tar -xOzf "$GEMINI_ASSET" "$manifest" | jq -e --arg v "$VERSION" '.version == $v' >/dev/null
+done <<< "$GEMINI_MANIFESTS"
+```
+
+- [ ] **Step 4: Commit the release bump**
+
+Run:
+
+```bash
+git add .claude-plugin/marketplace.json plugins/*/.claude-plugin/plugin.json plugins/*/.codex-plugin/plugin.json
+git commit -m "chore(release): release v1.7.4"
+```
+
+---
+
+### Task 3: Merge and Publish v1.7.4
+
+**Files:**
+- No additional repository changes unless review findings require fixes.
+
+**Interfaces:**
+- Consumes: approved Task 1 and Task 2 commits.
+- Produces: merged PR, exact-main release SHA, v1.7.4 tag, and published release with two verified assets.
+
+- [ ] **Step 1: Push and create the PR**
+
+Run:
+
+```bash
+git push -u origin HEAD:refs/heads/fix/codex-cli-detection
+gh pr create --base main --head fix/codex-cli-detection \
+  --title "fix(install): require Codex executable" \
+  --body "$(cat <<'EOF'
+## Summary
+- require a runnable Codex executable before invoking the Codex installer
+- preserve stale ~/.codex state and continue other platform installations
+- release the correction as v1.7.4
+
+## Test Plan
+- `bash -n scripts/install-all.sh`
+- `shellcheck scripts/install-all.sh scripts/test-installation.sh`
+- `./scripts/test-installation.sh`
+- full repository release gate
+- verified Codex and Gemini v1.7.4 archives
+EOF
+)"
+```
+
+- [ ] **Step 2: Require clean CI and review gates, then squash merge**
+
+Run `gh pr checks --watch`, inspect reviews, review requests, comments, and unresolved threads. Address every finding with focused tests and the full gate before merging. Merge only when both gates are clean:
+
+```bash
+gh pr merge --squash --delete-branch
+```
+
+- [ ] **Step 3: Detach this worktree at merged main and require exact-commit CI**
+
+Run:
+
+```bash
+git fetch origin --prune
+git switch --detach origin/main
+RELEASE_SHA=$(git rev-parse HEAD)
+test "$RELEASE_SHA" = "$(git rev-parse origin/main)"
+test "$(jq -r '.metadata.version' .claude-plugin/marketplace.json)" = "1.7.4"
+```
+
+Use the same non-empty, stable GitHub check-runs REST loop used for v1.7.3. Require every exact-commit check to be completed with `success`, `neutral`, or `skipped`, and verify remote main remains at `RELEASE_SHA`.
+
+- [ ] **Step 4: Create, verify, and publish the release**
+
+Rebuild from detached merged main, then run:
+
+```bash
+VERSION=1.7.4
+TAG="v${VERSION}"
+CODEX_ASSET="dist/gopher-ai-codex-plugins-v${VERSION}.tar.gz"
+GEMINI_ASSET="dist/gopher-ai-gemini-extensions-v${VERSION}.tar.gz"
+gh release create "$TAG" --draft --target "$RELEASE_SHA" --title "$TAG" --generate-notes \
+  "$CODEX_ASSET" "$GEMINI_ASSET"
+```
+
+Verify the draft targets `RELEASE_SHA` and contains exactly both assets, publish through the releases API, and verify the lightweight tag resolves exactly to `RELEASE_SHA`.
+
+---
+
+### Task 4: Install and Verify v1.7.4 on Both Hosts
+
+**Files:**
+- Host state only.
+
+**Interfaces:**
+- Consumes: published v1.7.4 at merged main.
+- Produces: successful exact installer runs and verified platform state locally and on Prometheus.
+
+- [ ] **Step 1: Run and verify the exact installer locally**
+
+Run:
+
+```bash
+bash -c "$(curl -fsSL https://raw.githubusercontent.com/gopherguides/gopher-ai/main/scripts/install-all.sh)"
+```
+
+Require exit zero, a final summary for Claude Code, Codex CLI, and Gemini CLI, all seven Claude cache roots at 1.7.4, six enabled Codex plugins and cache roots at 1.7.4, and seven Gemini extension manifests at 1.7.4.
+
+- [ ] **Step 2: Snapshot Prometheus stale Codex state before installation**
+
+Run:
+
+```bash
+ssh prometheus 'set -eu; test -d "$HOME/.codex"; find "$HOME/.codex" -type f -print0 | sort -z | xargs -0 shasum -a 256 > /tmp/gopher-ai-codex-before.sha256; hostname; command -v codex || true; command -v gemini || true'
+```
+
+Expected: host `prometheus`, no Codex or Gemini executable, and a checksum snapshot of existing Codex files.
+
+- [ ] **Step 3: Run the exact installer on Prometheus**
+
+Run:
+
+```bash
+ssh prometheus 'bash -c "$(curl -fsSL https://raw.githubusercontent.com/gopherguides/gopher-ai/main/scripts/install-all.sh)"'
+```
+
+Require exit zero, the exact stale-state skip warning, no `=== Codex CLI ===` section, no Gemini installation, and `Done! Installed for: Claude Code`.
+
+- [ ] **Step 4: Verify Prometheus state and stale Codex preservation**
+
+Run:
+
+```bash
+ssh prometheus 'set -eu; CURRENT_VERSION=1.7.4; for plugin in go-dev go-web go-workflow gopher-guides llm-tools productivity tailwind; do test -d "$HOME/.claude/plugins/cache/gopher-ai/$plugin/$CURRENT_VERSION"; done; test "$(git -C "$HOME/.claude/plugins/marketplaces/gopher-ai" rev-parse HEAD)" = "$(git ls-remote https://github.com/gopherguides/gopher-ai.git refs/tags/v1.7.4 | awk "{print \$1}")"; find "$HOME/.codex" -type f -print0 | sort -z | xargs -0 shasum -a 256 > /tmp/gopher-ai-codex-after.sha256; cmp -s /tmp/gopher-ai-codex-before.sha256 /tmp/gopher-ai-codex-after.sha256'
+```
+
+Expected: all Claude plugins at 1.7.4, marketplace checkout at the release SHA, and existing Codex files unchanged.
+
+- [ ] **Step 5: Verify final release and repository state**
+
+Run locally:
+
+```bash
+git status --short --branch
+gh release view v1.7.4 --json isDraft,tagName,url,targetCommitish,assets \
+  --jq '{draft:.isDraft,tag:.tagName,url:.url,target:.targetCommitish,assets:[.assets[].name]}'
+```
+
+Expected: clean detached worktree at merged main and published v1.7.4 with exactly both release assets.

--- a/docs/superpowers/specs/2026-07-23-codex-cli-detection-design.md
+++ b/docs/superpowers/specs/2026-07-23-codex-cli-detection-design.md
@@ -80,7 +80,8 @@ The full repository release gate and universal archive verification must pass be
 
 ## Release and Host Verification
 
-- Synchronize all marketplace, Claude plugin, and Codex plugin versions to 1.7.4.
+- Synchronize `.claude-plugin/marketplace.json`, all Claude plugin manifests, all Codex plugin manifests, and all generated Gemini extension manifests to 1.7.4.
+- Keep the existing generated Codex marketplace schema unversioned; do not add a top-level version. Only `.claude-plugin/marketplace.json`, Claude plugin manifests, Codex plugin manifests, and Gemini extension manifests are version-bearing.
 - Push a focused PR, require CI and review gates, and squash merge.
 - Require a non-empty successful check set for the exact merged main commit.
 - Publish v1.7.4 with verified Codex and Gemini archives and PR-generated notes.

--- a/docs/superpowers/specs/2026-07-23-codex-cli-detection-design.md
+++ b/docs/superpowers/specs/2026-07-23-codex-cli-detection-design.md
@@ -1,0 +1,88 @@
+# Codex CLI Detection Correction Design
+
+## Problem
+
+`scripts/install-all.sh` currently marks Codex as available when either a `codex` executable is on `PATH` or `~/.codex/` exists. Prometheus has stale `~/.codex/` state but no Codex executable in non-login or login shells. The universal installer therefore announces Codex as detected, successfully refreshes Claude Code, then aborts when `scripts/install-codex.sh --user` requires the missing command. The exact public installer exits nonzero and never prints its final platform summary.
+
+## Goal
+
+Make the universal installer install only runnable platforms, preserve stale Codex state without modification, and allow other detected platforms to complete successfully when `~/.codex/` exists but the Codex CLI does not.
+
+## Scope
+
+- Detect Codex installation capability only from a resolvable `codex` executable.
+- Track the separate condition where `~/.codex/` exists without an executable.
+- Print a specific skip warning for that stale-state condition.
+- Preserve `~/.codex/` byte-for-byte and do not invoke `scripts/install-codex.sh` when the executable is absent.
+- Continue installing Claude Code and Gemini when either is independently detected.
+- Add integration regression coverage for a host with Claude Code state, stale Codex state, and no Codex executable.
+- Publish the correction as v1.7.4 and rerun the exact public installer locally and on Prometheus.
+
+## Non-Goals
+
+- Installing the Codex CLI itself.
+- Searching arbitrary filesystem locations for Codex executables that are not on `PATH`.
+- Modifying, deleting, or archiving `~/.codex/`.
+- Changing `scripts/install-codex.sh --user` requirements or behavior.
+- Installing Gemini on hosts where the Gemini CLI is absent.
+
+## Detection Model
+
+`detect_platforms()` will maintain two independent Codex signals:
+
+- `HAVE_CODEX=true` only when `command -v codex` succeeds.
+- `HAVE_CODEX_STATE=true` when `~/.codex/` exists, regardless of executable availability.
+
+The installer will add Codex to the installation platform list and call `install_codex()` only when `HAVE_CODEX=true`. `HAVE_CODEX_STATE` affects user-facing detection output only.
+
+## User-Facing Behavior
+
+`print_detection()` will report one of three Codex states:
+
+- Executable available: `Codex CLI ...... found — will install global plugins to ~/.codex/plugins/`
+- No executable but state exists: `Codex CLI ...... skipped (found ~/.codex/ but no codex executable on PATH)`
+- Neither executable nor state exists: `Codex CLI ...... skipped (no codex executable on PATH)`
+
+A host with Claude Code and stale Codex state will proceed as a Claude-only installation, exit zero, and print `Done! Installed for: Claude Code`.
+
+## Data Flow
+
+1. Bootstrap the repository if necessary.
+2. Detect Claude Code from `~/.claude/`.
+3. Detect Codex capability from `command -v codex` and Codex state from `~/.codex/` separately.
+4. Detect Gemini from `command -v gemini`.
+5. Print the appropriate Codex found or skipped message.
+6. Build distributions when Claude Code or Gemini requires them.
+7. Invoke only installers whose executable or state requirements are satisfied.
+8. Print the final success summary for the platforms actually installed.
+
+## Error Handling
+
+- Missing Codex executable is not an error when another supported platform is available.
+- A stale `~/.codex/` directory is never mutated and does not make Codex an installation target.
+- If no runnable or supported platform remains, the existing `No supported platforms detected` error remains unchanged.
+- A detected Codex executable that later fails remains a real installation error; this correction does not suppress failures from runnable tools.
+
+## Testing
+
+Extend `scripts/test-installation.sh` with an isolated home and controlled `PATH`:
+
+- Create `~/.claude/` and `~/.codex/` under the isolated home.
+- Exclude `codex` and `gemini` from the controlled `PATH` while retaining the installer prerequisites.
+- Run `scripts/install-all.sh --force` from the repository.
+- Require exit zero.
+- Require the stale-state skip warning.
+- Require no `=== Codex CLI ===` installation section.
+- Require the final summary `Done! Installed for: Claude Code`.
+- Require the isolated `~/.codex/` directory and a sentinel file inside it to remain unchanged.
+
+The full repository release gate and universal archive verification must pass before publication.
+
+## Release and Host Verification
+
+- Synchronize all marketplace, Claude plugin, and Codex plugin versions to 1.7.4.
+- Push a focused PR, require CI and review gates, and squash merge.
+- Require a non-empty successful check set for the exact merged main commit.
+- Publish v1.7.4 with verified Codex and Gemini archives and PR-generated notes.
+- Run `bash -c "$(curl -fsSL https://raw.githubusercontent.com/gopherguides/gopher-ai/main/scripts/install-all.sh)"` locally and verify Claude Code, Codex, and Gemini at 1.7.4.
+- Run the same exact command on Prometheus and verify a successful Claude-only summary, all seven Claude Code plugin cache roots at 1.7.4, marketplace checkout at the v1.7.4 release SHA, no Codex installation section, and unchanged `~/.codex/` state.

--- a/plugins/go-dev/.claude-plugin/plugin.json
+++ b/plugins/go-dev/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "go-dev",
   "description": "Go-specific development tools with idiomatic best practices",
-  "version": "1.7.3",
+  "version": "1.7.4",
   "author": {
     "name": "Gopher Guides",
     "email": "support@gopherguides.com"

--- a/plugins/go-dev/.codex-plugin/plugin.json
+++ b/plugins/go-dev/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "go-dev",
-  "version": "1.7.3",
+  "version": "1.7.4",
   "description": "Go-specific development tools with idiomatic best practices",
   "author": {
     "name": "Gopher Guides",

--- a/plugins/go-web/.claude-plugin/plugin.json
+++ b/plugins/go-web/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "go-web",
   "description": "Opinionated Go web app scaffolding with Templ + HTMX + Alpine.js + Tailwind",
-  "version": "1.7.3",
+  "version": "1.7.4",
   "author": {
     "name": "Gopher Guides",
     "email": "support@gopherguides.com"

--- a/plugins/go-web/.codex-plugin/plugin.json
+++ b/plugins/go-web/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "go-web",
-  "version": "1.7.3",
+  "version": "1.7.4",
   "description": "Opinionated Go web app scaffolding with Templ + HTMX + Alpine.js + Tailwind",
   "author": {
     "name": "Gopher Guides",

--- a/plugins/go-workflow/.claude-plugin/plugin.json
+++ b/plugins/go-workflow/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "go-workflow",
   "description": "Issue-to-PR workflow automation with git worktree management",
-  "version": "1.7.3",
+  "version": "1.7.4",
   "author": {
     "name": "Gopher Guides",
     "email": "support@gopherguides.com"

--- a/plugins/go-workflow/.codex-plugin/plugin.json
+++ b/plugins/go-workflow/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "go-workflow",
-  "version": "1.7.3",
+  "version": "1.7.4",
   "description": "Issue-to-PR workflow automation with git worktree management",
   "author": {
     "name": "Gopher Guides",

--- a/plugins/gopher-guides/.claude-plugin/plugin.json
+++ b/plugins/gopher-guides/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "gopher-guides",
   "description": "Gopher Guides training materials integrated into Claude",
-  "version": "1.7.3",
+  "version": "1.7.4",
   "author": {
     "name": "Gopher Guides",
     "email": "support@gopherguides.com"

--- a/plugins/gopher-guides/.codex-plugin/plugin.json
+++ b/plugins/gopher-guides/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "gopher-guides",
-  "version": "1.7.3",
+  "version": "1.7.4",
   "description": "Gopher Guides training materials integration",
   "author": {
     "name": "Gopher Guides",

--- a/plugins/llm-tools/.claude-plugin/plugin.json
+++ b/plugins/llm-tools/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "llm-tools",
   "description": "Multi-LLM integration for second opinions and task delegation",
-  "version": "1.7.3",
+  "version": "1.7.4",
   "author": {
     "name": "Gopher Guides",
     "email": "support@gopherguides.com"

--- a/plugins/llm-tools/.codex-plugin/plugin.json
+++ b/plugins/llm-tools/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "llm-tools",
-  "version": "1.7.3",
+  "version": "1.7.4",
   "description": "Multi-LLM integration for second opinions and task delegation",
   "author": {
     "name": "Gopher Guides",

--- a/plugins/productivity/.claude-plugin/plugin.json
+++ b/plugins/productivity/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "productivity",
   "description": "Standup reports, changelogs, and git productivity helpers",
-  "version": "1.7.3",
+  "version": "1.7.4",
   "author": {
     "name": "Gopher Guides",
     "email": "support@gopherguides.com"

--- a/plugins/tailwind/.claude-plugin/plugin.json
+++ b/plugins/tailwind/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "tailwind",
   "description": "Tailwind CSS v4 tools for initialization, auditing, migration, and optimization",
-  "version": "1.7.3",
+  "version": "1.7.4",
   "author": {
     "name": "Gopher Guides",
     "email": "support@gopherguides.com"

--- a/plugins/tailwind/.codex-plugin/plugin.json
+++ b/plugins/tailwind/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "tailwind",
-  "version": "1.7.3",
+  "version": "1.7.4",
   "description": "Tailwind CSS v4 tools for initialization, auditing, migration, and optimization",
   "author": {
     "name": "Gopher Guides",

--- a/scripts/build-universal.sh
+++ b/scripts/build-universal.sh
@@ -508,6 +508,9 @@ create_archive() {
 
     member_list=$(mktemp)
     find "$source_dir" -depth \( -name '._*' -o -name '.DS_Store' \) -delete
+    find "$source_dir" -type d -exec chmod 0755 {} +
+    find "$source_dir" -type f -perm -0100 -exec chmod 0755 {} +
+    find "$source_dir" -type f ! -perm -0100 -exec chmod 0644 {} +
     TZ=UTC find "$source_dir" -exec touch -t 200001010000 {} +
 
     if tar --version 2>&1 | grep -q 'GNU tar'; then

--- a/scripts/build-universal.sh
+++ b/scripts/build-universal.sh
@@ -1,6 +1,9 @@
 #!/bin/bash
 set -euo pipefail
 
+export COPYFILE_DISABLE=1
+export COPY_EXTENDED_ATTRIBUTES_DISABLE=1
+
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
 DIST_DIR="$ROOT_DIR/dist"
@@ -496,24 +499,46 @@ convert_gemini_prompt_body() {
     ' <<< "$value"
 }
 
+create_archive() {
+    local source_dir="$1"
+    local archive="$2"
+    local archive_tar="${archive%.gz}"
+    local member_list
+    local tar_owner_args
+
+    member_list=$(mktemp)
+    find "$source_dir" -depth \( -name '._*' -o -name '.DS_Store' \) -delete
+    TZ=UTC find "$source_dir" -exec touch -t 200001010000 {} +
+
+    if tar --version 2>&1 | grep -q 'GNU tar'; then
+        tar_owner_args=(--owner=0 --group=0 --numeric-owner)
+    else
+        tar_owner_args=(--uid 0 --gid 0 --uname '' --gname '')
+    fi
+
+    (
+        cd "$DIST_DIR"
+        LC_ALL=C find "$(basename "$source_dir")" -print | LC_ALL=C sort > "$member_list"
+        tar --format=ustar --no-recursion "${tar_owner_args[@]}" -cf "$archive_tar" -T "$member_list"
+    )
+    gzip -n -f "$archive_tar"
+    rm -f "$member_list"
+}
+
 create_archives() {
     echo ""
     echo "Creating distribution archives..."
     echo "----------------------------------"
 
-    cd "$DIST_DIR"
-
-    if [[ -d "codex" ]]; then
-        tar -czf "gopher-ai-codex-plugins-v${VERSION}.tar.gz" codex/
+    if [[ -d "$DIST_DIR/codex" ]]; then
+        create_archive "$DIST_DIR/codex" "$DIST_DIR/gopher-ai-codex-plugins-v${VERSION}.tar.gz"
         echo "  - Created: gopher-ai-codex-plugins-v${VERSION}.tar.gz"
     fi
 
-    if [[ -d "gemini" ]]; then
-        tar -czf "gopher-ai-gemini-extensions-v${VERSION}.tar.gz" gemini/
+    if [[ -d "$DIST_DIR/gemini" ]]; then
+        create_archive "$DIST_DIR/gemini" "$DIST_DIR/gopher-ai-gemini-extensions-v${VERSION}.tar.gz"
         echo "  - Created: gopher-ai-gemini-extensions-v${VERSION}.tar.gz"
     fi
-
-    cd "$ROOT_DIR"
 }
 
 print_summary() {

--- a/scripts/install-all.sh
+++ b/scripts/install-all.sh
@@ -125,18 +125,18 @@ check_prerequisites() {
 detect_platforms() {
     HAVE_CLAUDE=false
     HAVE_CODEX=false
+    HAVE_CODEX_STATE=false
     HAVE_GEMINI=false
 
     if [[ -d "$HOME/.claude" ]]; then
         HAVE_CLAUDE=true
     fi
 
-    # Detect Codex via either the CLI on PATH or an existing ~/.codex/. The
-    # CLI signal catches fresh installs that haven't run codex yet (no config
-    # dir created); the directory signal catches setups where the CLI is
-    # installed elsewhere (e.g. node global npm dir not on PATH for this shell).
-    if command -v codex >/dev/null 2>&1 || [[ -d "$HOME/.codex" ]]; then
+    if command -v codex >/dev/null 2>&1; then
         HAVE_CODEX=true
+    fi
+    if [[ -d "$HOME/.codex" ]]; then
+        HAVE_CODEX_STATE=true
     fi
 
     if command -v gemini >/dev/null 2>&1; then
@@ -154,8 +154,10 @@ print_detection() {
 
     if $HAVE_CODEX; then
         echo "  Codex CLI ...... found — will install global plugins to ~/.codex/plugins/"
+    elif $HAVE_CODEX_STATE; then
+        echo "  Codex CLI ...... skipped (found ~/.codex/ but no codex executable on PATH)"
     else
-        echo "  Codex CLI ...... skipped (no codex binary, no ~/.codex/ directory)"
+        echo "  Codex CLI ...... skipped (no codex executable on PATH)"
     fi
 
     if $HAVE_GEMINI; then

--- a/scripts/install-all.sh
+++ b/scripts/install-all.sh
@@ -287,6 +287,7 @@ main() {
     bootstrap_if_needed
     detect_platforms
     check_prerequisites
+    print_detection
 
     if ! $HAVE_CLAUDE && ! $HAVE_CODEX && ! $HAVE_GEMINI; then
         echo "No supported platforms detected."
@@ -297,8 +298,6 @@ main() {
         echo "  Gemini CLI:  npm install -g @google/gemini-cli"
         exit 1
     fi
-
-    print_detection
 
     # Count platforms to install
     local platforms=()

--- a/scripts/install-all.sh
+++ b/scripts/install-all.sh
@@ -125,6 +125,7 @@ check_prerequisites() {
 detect_platforms() {
     HAVE_CLAUDE=false
     HAVE_CODEX=false
+    HAVE_CODEX_UNRUNNABLE=false
     HAVE_CODEX_STATE=false
     HAVE_GEMINI=false
 
@@ -133,7 +134,11 @@ detect_platforms() {
     fi
 
     if command -v codex >/dev/null 2>&1; then
-        HAVE_CODEX=true
+        if codex --version >/dev/null 2>&1; then
+            HAVE_CODEX=true
+        else
+            HAVE_CODEX_UNRUNNABLE=true
+        fi
     fi
     if [[ -d "$HOME/.codex" ]]; then
         HAVE_CODEX_STATE=true
@@ -154,6 +159,8 @@ print_detection() {
 
     if $HAVE_CODEX; then
         echo "  Codex CLI ...... found — will install global plugins to ~/.codex/plugins/"
+    elif $HAVE_CODEX_UNRUNNABLE; then
+        echo "  Codex CLI ...... skipped (codex executable on PATH is not runnable)"
     elif $HAVE_CODEX_STATE; then
         echo "  Codex CLI ...... skipped (found ~/.codex/ but no codex executable on PATH)"
     else

--- a/scripts/test-installation.sh
+++ b/scripts/test-installation.sh
@@ -146,6 +146,93 @@ fi
 EXPECTED_VERSION=$(jq -r '.metadata.version' "$ROOT_DIR/.claude-plugin/marketplace.json")
 CODEX_RELEASE_ASSET="$ROOT_DIR/dist/gopher-ai-codex-plugins-v${EXPECTED_VERSION}.tar.gz"
 GEMINI_RELEASE_ASSET="$ROOT_DIR/dist/gopher-ai-gemini-extensions-v${EXPECTED_VERSION}.tar.gz"
+ARCHIVE_MTIME=946684800
+
+archive_members() {
+  ruby -rzlib -rrubygems/package -e '
+    Zlib::GzipReader.open(ARGV[0]) do |gzip|
+      Gem::Package::TarReader.new(gzip) do |tar|
+        tar.each { |entry| puts entry.full_name }
+      end
+    end
+  ' "$1"
+}
+
+archive_headers_are_normalized() {
+  ruby -rzlib -rrubygems/package -e '
+    expected_mtime = Integer(ARGV[1])
+    Zlib::GzipReader.open(ARGV[0]) do |gzip|
+      Gem::Package::TarReader.new(gzip) do |tar|
+        tar.each do |entry|
+          header = entry.header
+          next if header.uid == 0 && header.gid == 0 && header.uname.to_s.empty? && header.gname.to_s.empty? && header.mtime == expected_mtime
+          warn "#{entry.full_name}: uid=#{header.uid} gid=#{header.gid} uname=#{header.uname.inspect} gname=#{header.gname.inspect} mtime=#{header.mtime}"
+          exit 1
+        end
+      end
+    end
+  ' "$1" "$ARCHIVE_MTIME"
+}
+
+archive_sha256() {
+  if command -v sha256sum >/dev/null 2>&1; then
+    sha256sum "$1" | awk '{print $1}'
+  else
+    shasum -a 256 "$1" | awk '{print $1}'
+  fi
+}
+
+echo -n "Release archives are byte-for-byte reproducible... "
+FIRST_CODEX_SHA=$(archive_sha256 "$CODEX_RELEASE_ASSET")
+FIRST_GEMINI_SHA=$(archive_sha256 "$GEMINI_RELEASE_ASSET")
+sleep 1
+if ! "$ROOT_DIR/scripts/build-universal.sh" >/tmp/gopher-ai-rebuild.log 2>&1; then
+  echo "FAIL (second build failed)"
+  sed -n '1,120p' /tmp/gopher-ai-rebuild.log
+  ERRORS=$((ERRORS + 1))
+else
+  SECOND_CODEX_SHA=$(archive_sha256 "$CODEX_RELEASE_ASSET")
+  SECOND_GEMINI_SHA=$(archive_sha256 "$GEMINI_RELEASE_ASSET")
+  if [ "$FIRST_CODEX_SHA" != "$SECOND_CODEX_SHA" ] || [ "$FIRST_GEMINI_SHA" != "$SECOND_GEMINI_SHA" ]; then
+    echo "FAIL"
+    echo "  Codex: $FIRST_CODEX_SHA != $SECOND_CODEX_SHA"
+    echo "  Gemini: $FIRST_GEMINI_SHA != $SECOND_GEMINI_SHA"
+    ERRORS=$((ERRORS + 1))
+  else
+    echo "OK"
+  fi
+fi
+
+echo -n "Release archives exclude AppleDouble metadata... "
+ARCHIVE_METADATA_ERRORS=""
+for archive in "$CODEX_RELEASE_ASSET" "$GEMINI_RELEASE_ASSET"; do
+  APPLEDOUBLE_MEMBERS=$(archive_members "$archive" | awk -F/ '$NF ~ /^\._/' || true)
+  if [ -n "$APPLEDOUBLE_MEMBERS" ]; then
+    ARCHIVE_METADATA_ERRORS="$ARCHIVE_METADATA_ERRORS\n  ${archive#"$ROOT_DIR"/} contains $(printf '%s\n' "$APPLEDOUBLE_MEMBERS" | wc -l | tr -d ' ') AppleDouble member(s)"
+  fi
+done
+if [ -n "$ARCHIVE_METADATA_ERRORS" ]; then
+  echo "FAIL"
+  printf '%b\n' "$ARCHIVE_METADATA_ERRORS"
+  ERRORS=$((ERRORS + 1))
+else
+  echo "OK"
+fi
+
+echo -n "Release archive headers are normalized... "
+ARCHIVE_HEADER_ERRORS=""
+for archive in "$CODEX_RELEASE_ASSET" "$GEMINI_RELEASE_ASSET"; do
+  if ! archive_headers_are_normalized "$archive" >/tmp/gopher-ai-archive-header.log 2>&1; then
+    ARCHIVE_HEADER_ERRORS="$ARCHIVE_HEADER_ERRORS\n  ${archive#"$ROOT_DIR"/}: $(sed -n '1p' /tmp/gopher-ai-archive-header.log)"
+  fi
+done
+if [ -n "$ARCHIVE_HEADER_ERRORS" ]; then
+  echo "FAIL"
+  printf '%b\n' "$ARCHIVE_HEADER_ERRORS"
+  ERRORS=$((ERRORS + 1))
+else
+  echo "OK"
+fi
 
 echo -n "Release command uses builder-produced asset names... "
 if ! awk 'index($0, "dist/gopher-ai-codex-plugins-v${VERSION}.tar.gz") { found=1 } END { exit found ? 0 : 1 }' "$ROOT_DIR/plugins/productivity/commands/release.md" ||
@@ -157,38 +244,62 @@ else
   echo "OK"
 fi
 
-echo -n "Release archives exist with expected names and versions... "
+echo -n "Release archives contain canonical manifests and commands... "
 RELEASE_ASSET_ERRORS=""
+EXPECTED_CODEX_MANIFEST_COUNT=$(find "$ROOT_DIR/plugins" -path '*/.codex-plugin/plugin.json' -type f | wc -l | tr -d ' ')
+EXPECTED_GEMINI_MANIFEST_COUNT=$(find "$ROOT_DIR/plugins" -path '*/.claude-plugin/plugin.json' -type f | wc -l | tr -d ' ')
+EXPECTED_GEMINI_COMMAND_COUNT=$(find "$ROOT_DIR/plugins" -path '*/commands/*.md' -type f | wc -l | tr -d ' ')
 if [ ! -f "$CODEX_RELEASE_ASSET" ]; then
   RELEASE_ASSET_ERRORS="$RELEASE_ASSET_ERRORS\n  missing ${CODEX_RELEASE_ASSET#"$ROOT_DIR"/}"
 else
-  CODEX_MANIFESTS=$(tar -tzf "$CODEX_RELEASE_ASSET" | awk '/\/\.codex-plugin\/plugin\.json$/' || true)
-  if [ -z "$CODEX_MANIFESTS" ]; then
-    RELEASE_ASSET_ERRORS="$RELEASE_ASSET_ERRORS\n  Codex archive has no plugin manifests"
-  else
-    while IFS= read -r manifest; do
-      ACTUAL_VERSION=$(tar -xOzf "$CODEX_RELEASE_ASSET" "$manifest" | jq -r '.version // empty')
-      if [ "$ACTUAL_VERSION" != "$EXPECTED_VERSION" ]; then
-        RELEASE_ASSET_ERRORS="$RELEASE_ASSET_ERRORS\n  $manifest ($ACTUAL_VERSION != $EXPECTED_VERSION)"
-      fi
-    done <<< "$CODEX_MANIFESTS"
+  CODEX_MANIFESTS=$(archive_members "$CODEX_RELEASE_ASSET" | awk -F/ '$NF ~ /plugin[.]json$/ {print}' || true)
+  CODEX_MANIFEST_COUNT=$(printf '%s\n' "$CODEX_MANIFESTS" | awk 'NF {count++} END {print count+0}')
+  if [ "$CODEX_MANIFEST_COUNT" -ne "$EXPECTED_CODEX_MANIFEST_COUNT" ]; then
+    RELEASE_ASSET_ERRORS="$RELEASE_ASSET_ERRORS\n  Codex archive has $CODEX_MANIFEST_COUNT manifest-shaped member(s), expected $EXPECTED_CODEX_MANIFEST_COUNT"
   fi
+  while IFS= read -r manifest; do
+    [ -n "$manifest" ] || continue
+    if ! printf '%s\n' "$manifest" | awk -F/ 'NF == 5 && $1 == "codex" && $2 == "plugins" && $3 != "" && $4 == ".codex-plugin" && $5 == "plugin.json" {found=1} END {exit found ? 0 : 1}'; then
+      RELEASE_ASSET_ERRORS="$RELEASE_ASSET_ERRORS\n  unexpected Codex manifest-shaped member: $manifest"
+      continue
+    fi
+    ACTUAL_VERSION=$(tar -xOzf "$CODEX_RELEASE_ASSET" "$manifest" | jq -r '.version // empty')
+    if [ "$ACTUAL_VERSION" != "$EXPECTED_VERSION" ]; then
+      RELEASE_ASSET_ERRORS="$RELEASE_ASSET_ERRORS\n  $manifest ($ACTUAL_VERSION != $EXPECTED_VERSION)"
+    fi
+  done <<< "$CODEX_MANIFESTS"
 fi
 
 if [ ! -f "$GEMINI_RELEASE_ASSET" ]; then
   RELEASE_ASSET_ERRORS="$RELEASE_ASSET_ERRORS\n  missing ${GEMINI_RELEASE_ASSET#"$ROOT_DIR"/}"
 else
-  GEMINI_MANIFESTS=$(tar -tzf "$GEMINI_RELEASE_ASSET" | awk '/\/gemini-extension\.json$/' || true)
-  if [ -z "$GEMINI_MANIFESTS" ]; then
-    RELEASE_ASSET_ERRORS="$RELEASE_ASSET_ERRORS\n  Gemini archive has no extension manifests"
-  else
-    while IFS= read -r manifest; do
-      ACTUAL_VERSION=$(tar -xOzf "$GEMINI_RELEASE_ASSET" "$manifest" | jq -r '.version // empty')
-      if [ "$ACTUAL_VERSION" != "$EXPECTED_VERSION" ]; then
-        RELEASE_ASSET_ERRORS="$RELEASE_ASSET_ERRORS\n  $manifest ($ACTUAL_VERSION != $EXPECTED_VERSION)"
-      fi
-    done <<< "$GEMINI_MANIFESTS"
+  GEMINI_MANIFESTS=$(archive_members "$GEMINI_RELEASE_ASSET" | awk -F/ '$NF ~ /gemini-extension[.]json$/ {print}' || true)
+  GEMINI_MANIFEST_COUNT=$(printf '%s\n' "$GEMINI_MANIFESTS" | awk 'NF {count++} END {print count+0}')
+  if [ "$GEMINI_MANIFEST_COUNT" -ne "$EXPECTED_GEMINI_MANIFEST_COUNT" ]; then
+    RELEASE_ASSET_ERRORS="$RELEASE_ASSET_ERRORS\n  Gemini archive has $GEMINI_MANIFEST_COUNT manifest-shaped member(s), expected $EXPECTED_GEMINI_MANIFEST_COUNT"
   fi
+  while IFS= read -r manifest; do
+    [ -n "$manifest" ] || continue
+    if ! printf '%s\n' "$manifest" | awk -F/ 'NF == 3 && $1 == "gemini" && $2 ~ /^gopher-ai-/ && $3 == "gemini-extension.json" {found=1} END {exit found ? 0 : 1}'; then
+      RELEASE_ASSET_ERRORS="$RELEASE_ASSET_ERRORS\n  unexpected Gemini manifest-shaped member: $manifest"
+      continue
+    fi
+    ACTUAL_VERSION=$(tar -xOzf "$GEMINI_RELEASE_ASSET" "$manifest" | jq -r '.version // empty')
+    if [ "$ACTUAL_VERSION" != "$EXPECTED_VERSION" ]; then
+      RELEASE_ASSET_ERRORS="$RELEASE_ASSET_ERRORS\n  $manifest ($ACTUAL_VERSION != $EXPECTED_VERSION)"
+    fi
+  done <<< "$GEMINI_MANIFESTS"
+  GEMINI_COMMAND_MEMBERS=$(archive_members "$GEMINI_RELEASE_ASSET" | awk -F/ '$NF ~ /[.]toml$/ && $0 ~ /\/commands\// {print}' || true)
+  GEMINI_COMMAND_MEMBER_COUNT=$(printf '%s\n' "$GEMINI_COMMAND_MEMBERS" | awk 'NF {count++} END {print count+0}')
+  if [ "$GEMINI_COMMAND_MEMBER_COUNT" -ne "$EXPECTED_GEMINI_COMMAND_COUNT" ]; then
+    RELEASE_ASSET_ERRORS="$RELEASE_ASSET_ERRORS\n  Gemini archive has $GEMINI_COMMAND_MEMBER_COUNT command-shaped member(s), expected $EXPECTED_GEMINI_COMMAND_COUNT"
+  fi
+  while IFS= read -r command; do
+    [ -n "$command" ] || continue
+    if ! printf '%s\n' "$command" | awk -F/ 'NF == 4 && $1 == "gemini" && $2 ~ /^gopher-ai-/ && $3 == "commands" && $4 !~ /^\._/ && $4 ~ /[.]toml$/ {found=1} END {exit found ? 0 : 1}'; then
+      RELEASE_ASSET_ERRORS="$RELEASE_ASSET_ERRORS\n  unexpected Gemini command-shaped member: $command"
+    fi
+  done <<< "$GEMINI_COMMAND_MEMBERS"
 fi
 
 if [ -n "$RELEASE_ASSET_ERRORS" ]; then
@@ -532,7 +643,7 @@ TMP_HOME=$(mktemp -d)
 TMP_BIN=$(mktemp -d)
 mkdir -p "$TMP_HOME/.claude" "$TMP_HOME/.codex"
 printf '%s\n' 'preserve me' > "$TMP_HOME/.codex/SENTINEL"
-for cmd in bash sh awk sed grep find mkdir rm cp mv cmp mktemp printf cat dirname basename tr head tail xargs sleep date wc sha256sum shasum git sort uniq stat ln readlink jq comm touch chmod cut id env true false echo test tar tree; do
+for cmd in bash sh awk sed grep find mkdir rm cp mv cmp mktemp printf cat dirname basename tr head tail xargs sleep date wc sha256sum shasum git sort uniq stat ln readlink jq comm touch chmod cut id env true false echo test tar gzip tree; do
   cmd_path="$(command -v "$cmd" 2>/dev/null || true)"
   [ -n "$cmd_path" ] && ln -s "$cmd_path" "$TMP_BIN/$cmd"
 done
@@ -568,7 +679,7 @@ TMP_BIN=$(mktemp -d)
 mkdir -p "$TMP_HOME/.codex"
 printf '%s\n' 'preserve me' > "$TMP_HOME/.codex/SENTINEL"
 cp "$TMP_HOME/.codex/SENTINEL" "$TMP_HOME/SENTINEL.expected"
-for cmd in bash sh awk sed grep find mkdir rm cp mv cmp mktemp printf cat dirname basename tr head tail xargs sleep date wc sha256sum shasum git sort uniq stat ln readlink jq comm touch chmod cut id env true false echo test tar tree; do
+for cmd in bash sh awk sed grep find mkdir rm cp mv cmp mktemp printf cat dirname basename tr head tail xargs sleep date wc sha256sum shasum git sort uniq stat ln readlink jq comm touch chmod cut id env true false echo test tar gzip tree; do
   cmd_path="$(command -v "$cmd" 2>/dev/null || true)"
   [ -n "$cmd_path" ] && ln -s "$cmd_path" "$TMP_BIN/$cmd"
 done

--- a/scripts/test-installation.sh
+++ b/scripts/test-installation.sh
@@ -562,6 +562,41 @@ else
 fi
 rm -rf "$TMP_HOME" "$TMP_BIN"
 
+echo -n "install-all.sh reports stale Codex state before no-platform exit... "
+TMP_HOME=$(mktemp -d)
+TMP_BIN=$(mktemp -d)
+mkdir -p "$TMP_HOME/.codex"
+printf '%s\n' 'preserve me' > "$TMP_HOME/.codex/SENTINEL"
+cp "$TMP_HOME/.codex/SENTINEL" "$TMP_HOME/SENTINEL.expected"
+for cmd in bash sh awk sed grep find mkdir rm cp mv cmp mktemp printf cat dirname basename tr head tail xargs sleep date wc sha256sum shasum git sort uniq stat ln readlink jq comm touch chmod cut id env true false echo test tar tree; do
+  cmd_path="$(command -v "$cmd" 2>/dev/null || true)"
+  [ -n "$cmd_path" ] && ln -s "$cmd_path" "$TMP_BIN/$cmd"
+done
+set +e
+HOME="$TMP_HOME" PATH="$TMP_BIN" bash "$ROOT_DIR/scripts/install-all.sh" --force \
+  </dev/null >/tmp/gopher-ai-installall-stale-codex-only.log 2>&1
+STALE_CODEX_ONLY_EXIT=$?
+set -e
+if [ "$STALE_CODEX_ONLY_EXIT" -eq 0 ]; then
+  echo "FAIL (stale Codex-only install should exit non-zero)"
+  ERRORS=$((ERRORS + 1))
+elif ! grep -Fq 'Codex CLI ...... skipped (found ~/.codex/ but no codex executable on PATH)' /tmp/gopher-ai-installall-stale-codex-only.log; then
+  echo "FAIL (stale Codex state warning was missing before exit)"
+  ERRORS=$((ERRORS + 1))
+elif grep -Fq '=== Codex CLI ===' /tmp/gopher-ai-installall-stale-codex-only.log; then
+  echo "FAIL (Codex installer ran without a Codex executable)"
+  ERRORS=$((ERRORS + 1))
+elif ! grep -Fq 'No supported platforms detected.' /tmp/gopher-ai-installall-stale-codex-only.log; then
+  echo "FAIL (no-supported-platform message was missing)"
+  ERRORS=$((ERRORS + 1))
+elif ! cmp -s "$TMP_HOME/.codex/SENTINEL" "$TMP_HOME/SENTINEL.expected"; then
+  echo "FAIL (stale Codex state was modified)"
+  ERRORS=$((ERRORS + 1))
+else
+  echo "OK"
+fi
+rm -rf "$TMP_HOME" "$TMP_BIN"
+
 echo -n "Codex --cleanup works without jq installed... "
 TMP_HOME=$(mktemp -d)
 SKILLS_DIR="$TMP_HOME/.codex/skills"

--- a/scripts/test-installation.sh
+++ b/scripts/test-installation.sh
@@ -341,7 +341,7 @@ else
     COMMAND_PLUGIN=${COMMAND_PLUGIN%%/*}
     if ! jq -e --arg name "$COMMAND_PLUGIN" '.plugins[] | select(.name == $name)' "$MARKETPLACE" >/dev/null; then
       RELEASE_ASSET_ERRORS="$RELEASE_ASSET_ERRORS\n  $command references a plugin absent from the marketplace"
-    elif ! tar -xOzf "$GEMINI_RELEASE_ASSET" "$command" | rg -Fxq "# gopher-ai v$EXPECTED_VERSION"; then
+    elif ! tar -xOzf "$GEMINI_RELEASE_ASSET" "$command" | awk -v expected="# gopher-ai v$EXPECTED_VERSION" '$0 == expected {found=1} END {exit found ? 0 : 1}'; then
       RELEASE_ASSET_ERRORS="$RELEASE_ASSET_ERRORS\n  $command is missing the v$EXPECTED_VERSION generation header"
     fi
   done <<< "$GEMINI_COMMAND_MEMBERS"

--- a/scripts/test-installation.sh
+++ b/scripts/test-installation.sh
@@ -506,6 +506,7 @@ if [ -n "$JQ_PATH" ]; then
     cmd_path="$(command -v "$cmd" 2>/dev/null || true)"
     [ -n "$cmd_path" ] && ln -s "$cmd_path" "$TMP_BIN/$cmd"
   done
+  ln -s "$TMP_BIN/bash" "$TMP_BIN/codex"
   set +e
   HOME="$TMP_HOME" PATH="$TMP_BIN" bash "$ROOT_DIR/scripts/install-all.sh" --force </dev/null >/tmp/gopher-ai-installall-nojq.log 2>&1
   EXIT=$?
@@ -525,6 +526,41 @@ else
   echo "SKIP (jq not installed locally)"
 fi
 rm -rf "$TMP_HOME"
+
+echo -n "install-all.sh skips stale Codex state when the CLI is unavailable... "
+TMP_HOME=$(mktemp -d)
+TMP_BIN=$(mktemp -d)
+mkdir -p "$TMP_HOME/.claude" "$TMP_HOME/.codex"
+printf '%s\n' 'preserve me' > "$TMP_HOME/.codex/SENTINEL"
+for cmd in bash sh awk sed grep find mkdir rm cp mv cmp mktemp printf cat dirname basename tr head tail xargs sleep date wc sha256sum shasum git sort uniq stat ln readlink jq comm touch chmod cut id env true false echo test tar tree; do
+  cmd_path="$(command -v "$cmd" 2>/dev/null || true)"
+  [ -n "$cmd_path" ] && ln -s "$cmd_path" "$TMP_BIN/$cmd"
+done
+set +e
+HOME="$TMP_HOME" PATH="$TMP_BIN" bash "$ROOT_DIR/scripts/install-all.sh" --force \
+  </dev/null >/tmp/gopher-ai-installall-stale-codex.log 2>&1
+STALE_CODEX_EXIT=$?
+set -e
+if [ "$STALE_CODEX_EXIT" -ne 0 ]; then
+  echo "FAIL (Claude-only install exited non-zero)"
+  sed -n '1,80p' /tmp/gopher-ai-installall-stale-codex.log
+  ERRORS=$((ERRORS + 1))
+elif ! grep -Fq 'Codex CLI ...... skipped (found ~/.codex/ but no codex executable on PATH)' /tmp/gopher-ai-installall-stale-codex.log; then
+  echo "FAIL (stale Codex state warning was missing)"
+  ERRORS=$((ERRORS + 1))
+elif grep -Fq '=== Codex CLI ===' /tmp/gopher-ai-installall-stale-codex.log; then
+  echo "FAIL (Codex installer ran without a Codex executable)"
+  ERRORS=$((ERRORS + 1))
+elif ! grep -Fq 'Done! Installed for: Claude Code' /tmp/gopher-ai-installall-stale-codex.log; then
+  echo "FAIL (Claude-only completion summary was missing)"
+  ERRORS=$((ERRORS + 1))
+elif [ "$(cat "$TMP_HOME/.codex/SENTINEL")" != 'preserve me' ]; then
+  echo "FAIL (stale Codex state was modified)"
+  ERRORS=$((ERRORS + 1))
+else
+  echo "OK"
+fi
+rm -rf "$TMP_HOME" "$TMP_BIN"
 
 echo -n "Codex --cleanup works without jq installed... "
 TMP_HOME=$(mktemp -d)

--- a/scripts/test-installation.sh
+++ b/scripts/test-installation.sh
@@ -100,7 +100,9 @@ for i in $(seq 0 $((PLUGIN_COUNT - 1))); do
   PLUGIN_JSON="plugins/$NAME/.claude-plugin/plugin.json"
   if [ -f "$PLUGIN_JSON" ]; then
     ACTUAL_VER=$(jq -r '.version // empty' "$PLUGIN_JSON" 2>/dev/null)
-    if [ -n "$ACTUAL_VER" ] && [ "$ACTUAL_VER" != "$EXPECTED_VER" ]; then
+    if [ -z "$ACTUAL_VER" ]; then
+      PLUGIN_JSON_MISMATCHES="$PLUGIN_JSON_MISMATCHES $NAME(plugin.json:missing-version)"
+    elif [ "$ACTUAL_VER" != "$EXPECTED_VER" ]; then
       PLUGIN_JSON_MISMATCHES="$PLUGIN_JSON_MISMATCHES $NAME(plugin.json:$ACTUAL_VER!=marketplace:$EXPECTED_VER)"
     fi
   fi
@@ -165,8 +167,9 @@ archive_headers_are_normalized() {
       Gem::Package::TarReader.new(gzip) do |tar|
         tar.each do |entry|
           header = entry.header
-          next if header.uid == 0 && header.gid == 0 && header.uname.to_s.empty? && header.gname.to_s.empty? && header.mtime == expected_mtime
-          warn "#{entry.full_name}: uid=#{header.uid} gid=#{header.gid} uname=#{header.uname.inspect} gname=#{header.gname.inspect} mtime=#{header.mtime}"
+          mode_ok = (entry.directory? && header.mode == 0o755) || (entry.file? && [0o644, 0o755].include?(header.mode))
+          next if header.uid == 0 && header.gid == 0 && header.uname.to_s.empty? && header.gname.to_s.empty? && header.mtime == expected_mtime && mode_ok
+          warn "#{entry.full_name}: uid=#{header.uid} gid=#{header.gid} uname=#{header.uname.inspect} gname=#{header.gname.inspect} mtime=#{header.mtime} mode=#{format("%04o", header.mode)}"
           exit 1
         end
       end
@@ -203,12 +206,40 @@ else
   fi
 fi
 
-echo -n "Release archives exclude AppleDouble metadata... "
+echo -n "Release archives are byte-for-byte reproducible across umasks... "
+DEFAULT_UMASK_CODEX_SHA=$(archive_sha256 "$CODEX_RELEASE_ASSET")
+DEFAULT_UMASK_GEMINI_SHA=$(archive_sha256 "$GEMINI_RELEASE_ASSET")
+if ! (umask 077; "$ROOT_DIR/scripts/build-universal.sh" >/tmp/gopher-ai-restrictive-umask-build.log 2>&1); then
+  echo "FAIL (restrictive-umask build failed)"
+  sed -n '1,120p' /tmp/gopher-ai-restrictive-umask-build.log
+  ERRORS=$((ERRORS + 1))
+else
+  RESTRICTIVE_UMASK_CODEX_SHA=$(archive_sha256 "$CODEX_RELEASE_ASSET")
+  RESTRICTIVE_UMASK_GEMINI_SHA=$(archive_sha256 "$GEMINI_RELEASE_ASSET")
+  if [ "$DEFAULT_UMASK_CODEX_SHA" != "$RESTRICTIVE_UMASK_CODEX_SHA" ] || [ "$DEFAULT_UMASK_GEMINI_SHA" != "$RESTRICTIVE_UMASK_GEMINI_SHA" ]; then
+    echo "FAIL"
+    echo "  Codex: $DEFAULT_UMASK_CODEX_SHA != $RESTRICTIVE_UMASK_CODEX_SHA"
+    echo "  Gemini: $DEFAULT_UMASK_GEMINI_SHA != $RESTRICTIVE_UMASK_GEMINI_SHA"
+    ERRORS=$((ERRORS + 1))
+  else
+    echo "OK"
+  fi
+fi
+
+echo -n "Release archives exclude AppleDouble and Finder metadata... "
+APPLEDOUBLE_FIXTURE="$ROOT_DIR/plugins/go-dev/scripts/._archive-metadata-test"
+DSSTORE_FIXTURE="$ROOT_DIR/plugins/go-dev/scripts/.DS_Store"
+printf '%s\n' 'metadata fixture' > "$APPLEDOUBLE_FIXTURE"
+printf '%s\n' 'metadata fixture' > "$DSSTORE_FIXTURE"
 ARCHIVE_METADATA_ERRORS=""
+if ! "$ROOT_DIR/scripts/build-universal.sh" >/tmp/gopher-ai-metadata-build.log 2>&1; then
+  ARCHIVE_METADATA_ERRORS="$ARCHIVE_METADATA_ERRORS\n  metadata-fixture build failed: $(sed -n '1p' /tmp/gopher-ai-metadata-build.log)"
+fi
+rm -f "$APPLEDOUBLE_FIXTURE" "$DSSTORE_FIXTURE"
 for archive in "$CODEX_RELEASE_ASSET" "$GEMINI_RELEASE_ASSET"; do
-  APPLEDOUBLE_MEMBERS=$(archive_members "$archive" | awk -F/ '$NF ~ /^\._/' || true)
-  if [ -n "$APPLEDOUBLE_MEMBERS" ]; then
-    ARCHIVE_METADATA_ERRORS="$ARCHIVE_METADATA_ERRORS\n  ${archive#"$ROOT_DIR"/} contains $(printf '%s\n' "$APPLEDOUBLE_MEMBERS" | wc -l | tr -d ' ') AppleDouble member(s)"
+  METADATA_MEMBERS=$(archive_members "$archive" | awk -F/ '$NF ~ /^\._/ || $NF == ".DS_Store"' || true)
+  if [ -n "$METADATA_MEMBERS" ]; then
+    ARCHIVE_METADATA_ERRORS="$ARCHIVE_METADATA_ERRORS\n  ${archive#"$ROOT_DIR"/} contains $(printf '%s\n' "$METADATA_MEMBERS" | wc -l | tr -d ' ') metadata member(s)"
   fi
 done
 if [ -n "$ARCHIVE_METADATA_ERRORS" ]; then
@@ -246,9 +277,11 @@ fi
 
 echo -n "Release archives contain canonical manifests and commands... "
 RELEASE_ASSET_ERRORS=""
-EXPECTED_CODEX_MANIFEST_COUNT=$(find "$ROOT_DIR/plugins" -path '*/.codex-plugin/plugin.json' -type f | wc -l | tr -d ' ')
-EXPECTED_GEMINI_MANIFEST_COUNT=$(find "$ROOT_DIR/plugins" -path '*/.claude-plugin/plugin.json' -type f | wc -l | tr -d ' ')
-EXPECTED_GEMINI_COMMAND_COUNT=$(find "$ROOT_DIR/plugins" -path '*/commands/*.md' -type f | wc -l | tr -d ' ')
+EXPECTED_CODEX_MANIFESTS=$(jq -r '.plugins[].name | select(. != "productivity") | "codex/plugins/\(.)/.codex-plugin/plugin.json"' "$MARKETPLACE" | LC_ALL=C sort)
+EXPECTED_GEMINI_MANIFESTS=$(jq -r '.plugins[].name | "gemini/gopher-ai-\(.)/gemini-extension.json"' "$MARKETPLACE" | LC_ALL=C sort)
+EXPECTED_CODEX_MANIFEST_COUNT=$(printf '%s\n' "$EXPECTED_CODEX_MANIFESTS" | awk 'NF {count++} END {print count+0}')
+EXPECTED_GEMINI_MANIFEST_COUNT=$(printf '%s\n' "$EXPECTED_GEMINI_MANIFESTS" | awk 'NF {count++} END {print count+0}')
+EXPECTED_GEMINI_COMMAND_COUNT=36
 if [ ! -f "$CODEX_RELEASE_ASSET" ]; then
   RELEASE_ASSET_ERRORS="$RELEASE_ASSET_ERRORS\n  missing ${CODEX_RELEASE_ASSET#"$ROOT_DIR"/}"
 else
@@ -256,6 +289,8 @@ else
   CODEX_MANIFEST_COUNT=$(printf '%s\n' "$CODEX_MANIFESTS" | awk 'NF {count++} END {print count+0}')
   if [ "$CODEX_MANIFEST_COUNT" -ne "$EXPECTED_CODEX_MANIFEST_COUNT" ]; then
     RELEASE_ASSET_ERRORS="$RELEASE_ASSET_ERRORS\n  Codex archive has $CODEX_MANIFEST_COUNT manifest-shaped member(s), expected $EXPECTED_CODEX_MANIFEST_COUNT"
+  elif [ "$(printf '%s\n' "$CODEX_MANIFESTS" | LC_ALL=C sort)" != "$EXPECTED_CODEX_MANIFESTS" ]; then
+    RELEASE_ASSET_ERRORS="$RELEASE_ASSET_ERRORS\n  Codex archive manifest set does not match the marketplace"
   fi
   while IFS= read -r manifest; do
     [ -n "$manifest" ] || continue
@@ -277,6 +312,8 @@ else
   GEMINI_MANIFEST_COUNT=$(printf '%s\n' "$GEMINI_MANIFESTS" | awk 'NF {count++} END {print count+0}')
   if [ "$GEMINI_MANIFEST_COUNT" -ne "$EXPECTED_GEMINI_MANIFEST_COUNT" ]; then
     RELEASE_ASSET_ERRORS="$RELEASE_ASSET_ERRORS\n  Gemini archive has $GEMINI_MANIFEST_COUNT manifest-shaped member(s), expected $EXPECTED_GEMINI_MANIFEST_COUNT"
+  elif [ "$(printf '%s\n' "$GEMINI_MANIFESTS" | LC_ALL=C sort)" != "$EXPECTED_GEMINI_MANIFESTS" ]; then
+    RELEASE_ASSET_ERRORS="$RELEASE_ASSET_ERRORS\n  Gemini archive manifest set does not match the marketplace"
   fi
   while IFS= read -r manifest; do
     [ -n "$manifest" ] || continue
@@ -298,6 +335,14 @@ else
     [ -n "$command" ] || continue
     if ! printf '%s\n' "$command" | awk -F/ 'NF == 4 && $1 == "gemini" && $2 ~ /^gopher-ai-/ && $3 == "commands" && $4 !~ /^\._/ && $4 ~ /[.]toml$/ {found=1} END {exit found ? 0 : 1}'; then
       RELEASE_ASSET_ERRORS="$RELEASE_ASSET_ERRORS\n  unexpected Gemini command-shaped member: $command"
+      continue
+    fi
+    COMMAND_PLUGIN=${command#gemini/gopher-ai-}
+    COMMAND_PLUGIN=${COMMAND_PLUGIN%%/*}
+    if ! jq -e --arg name "$COMMAND_PLUGIN" '.plugins[] | select(.name == $name)' "$MARKETPLACE" >/dev/null; then
+      RELEASE_ASSET_ERRORS="$RELEASE_ASSET_ERRORS\n  $command references a plugin absent from the marketplace"
+    elif ! tar -xOzf "$GEMINI_RELEASE_ASSET" "$command" | rg -Fxq "# gopher-ai v$EXPECTED_VERSION"; then
+      RELEASE_ASSET_ERRORS="$RELEASE_ASSET_ERRORS\n  $command is missing the v$EXPECTED_VERSION generation header"
     fi
   done <<< "$GEMINI_COMMAND_MEMBERS"
 fi
@@ -667,6 +712,36 @@ elif ! grep -Fq 'Done! Installed for: Claude Code' /tmp/gopher-ai-installall-sta
   ERRORS=$((ERRORS + 1))
 elif [ "$(cat "$TMP_HOME/.codex/SENTINEL")" != 'preserve me' ]; then
   echo "FAIL (stale Codex state was modified)"
+  ERRORS=$((ERRORS + 1))
+else
+  echo "OK"
+fi
+rm -rf "$TMP_HOME" "$TMP_BIN"
+
+echo -n "install-all.sh skips an unlaunchable Codex executable and continues... "
+TMP_HOME=$(mktemp -d)
+TMP_BIN=$(mktemp -d)
+mkdir -p "$TMP_HOME/.codex"
+printf '%s\n' '#!/missing/codex-interpreter' > "$TMP_BIN/codex"
+printf '%s\n' '#!/bin/sh' 'exit 0' > "$TMP_BIN/gemini"
+chmod +x "$TMP_BIN/codex" "$TMP_BIN/gemini"
+set +e
+HOME="$TMP_HOME" PATH="$TMP_BIN:$PATH" bash "$ROOT_DIR/scripts/install-all.sh" --force \
+  </dev/null >/tmp/gopher-ai-installall-unlaunchable-codex.log 2>&1
+UNLAUNCHABLE_CODEX_EXIT=$?
+set -e
+if [ "$UNLAUNCHABLE_CODEX_EXIT" -ne 0 ]; then
+  echo "FAIL (Gemini install exited non-zero)"
+  sed -n '1,80p' /tmp/gopher-ai-installall-unlaunchable-codex.log
+  ERRORS=$((ERRORS + 1))
+elif ! grep -Fq 'Codex CLI ...... skipped (codex executable on PATH is not runnable)' /tmp/gopher-ai-installall-unlaunchable-codex.log; then
+  echo "FAIL (unlaunchable Codex warning was missing)"
+  ERRORS=$((ERRORS + 1))
+elif grep -Fq '=== Codex CLI ===' /tmp/gopher-ai-installall-unlaunchable-codex.log; then
+  echo "FAIL (Codex installer ran with an unlaunchable executable)"
+  ERRORS=$((ERRORS + 1))
+elif ! grep -Fq 'Done! Installed for: Gemini CLI' /tmp/gopher-ai-installall-unlaunchable-codex.log; then
+  echo "FAIL (Gemini completion summary was missing)"
   ERRORS=$((ERRORS + 1))
 else
   echo "OK"


### PR DESCRIPTION
## Summary
- require a runnable Codex executable before invoking the Codex installer
- preserve stale `~/.codex` state and continue other platform installations
- make release archives deterministic and exclude macOS metadata
- release the correction as v1.7.4

## Test Plan
- `bash -n` and `shellcheck` for changed scripts
- `./scripts/test-installation.sh`
- full repository release gate
- deterministic, metadata-free Codex and Gemini v1.7.4 archives