### PR TITLE
fix(test): anchor plugin manifest paths

### DIFF
--- a/scripts/test-installation.sh
+++ b/scripts/test-installation.sh
@@ -97,7 +97,7 @@ PLUGIN_JSON_MISMATCHES=""
 for i in $(seq 0 $((PLUGIN_COUNT - 1))); do
   NAME=$(jq -r ".plugins[$i].name" "$MARKETPLACE")
   EXPECTED_VER=$(jq -r ".plugins[$i].version" "$MARKETPLACE")
-  PLUGIN_JSON="plugins/$NAME/.claude-plugin/plugin.json"
+  PLUGIN_JSON="$ROOT_DIR/plugins/$NAME/.claude-plugin/plugin.json"
   if [ -f "$PLUGIN_JSON" ]; then
     ACTUAL_VER=$(jq -r '.version // empty' "$PLUGIN_JSON" 2>/dev/null)
     if [ -z "$ACTUAL_VER" ]; then


### PR DESCRIPTION
## Summary
- anchor Claude plugin manifest validation to the repository root
- preserve version checks when the installation gate runs from another working directory
- address the final release review finding before publishing v1.7.4

## Test Plan
- `bash -n scripts/test-installation.sh`
- `shellcheck scripts/test-installation.sh`
- run `scripts/test-installation.sh` by absolute path from `/tmp`
- full repository release gate