### PR TITLE
fix(install): restore Codex detection contract

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,14 +6,14 @@
   },
   "metadata": {
     "description": "Go-specific and general-purpose AI coding assistant plugins - by Gopher Guides",
-    "version": "1.7.4"
+    "version": "1.7.5"
   },
   "plugins": [
     {
       "name": "go-workflow",
       "source": "./plugins/go-workflow",
       "description": "Issue-to-PR workflow automation with worktree management",
-      "version": "1.7.4",
+      "version": "1.7.5",
       "keywords": [
         "workflow",
         "github",
@@ -26,7 +26,7 @@
       "name": "go-dev",
       "source": "./plugins/go-dev",
       "description": "Go-specific development tools with best practices",
-      "version": "1.7.4",
+      "version": "1.7.5",
       "keywords": [
         "go",
         "testing",
@@ -39,7 +39,7 @@
       "name": "productivity",
       "source": "./plugins/productivity",
       "description": "Standup reports and git productivity helpers",
-      "version": "1.7.4",
+      "version": "1.7.5",
       "keywords": [
         "standup",
         "changelog",
@@ -52,7 +52,7 @@
       "name": "gopher-guides",
       "source": "./plugins/gopher-guides",
       "description": "Go best practices guidance powered by Gopher Guides training materials",
-      "version": "1.7.4",
+      "version": "1.7.5",
       "keywords": [
         "go",
         "training",
@@ -64,7 +64,7 @@
       "name": "llm-tools",
       "source": "./plugins/llm-tools",
       "description": "Multi-LLM integration for second opinions and task delegation",
-      "version": "1.7.4",
+      "version": "1.7.5",
       "keywords": [
         "llm",
         "openai",
@@ -81,7 +81,7 @@
       "name": "go-web",
       "source": "./plugins/go-web",
       "description": "Opinionated Go web app scaffolding with Templ + HTMX + Alpine.js + Tailwind",
-      "version": "1.7.4",
+      "version": "1.7.5",
       "keywords": [
         "go",
         "web",
@@ -97,7 +97,7 @@
       "name": "tailwind",
       "source": "./plugins/tailwind",
       "description": "Tailwind CSS v4 tools for initialization, auditing, migration, and optimization",
-      "version": "1.7.4",
+      "version": "1.7.5",
       "keywords": [
         "tailwind",
         "css",

--- a/plugins/go-dev/.claude-plugin/plugin.json
+++ b/plugins/go-dev/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "go-dev",
   "description": "Go-specific development tools with idiomatic best practices",
-  "version": "1.7.4",
+  "version": "1.7.5",
   "author": {
     "name": "Gopher Guides",
     "email": "support@gopherguides.com"

--- a/plugins/go-dev/.codex-plugin/plugin.json
+++ b/plugins/go-dev/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "go-dev",
-  "version": "1.7.4",
+  "version": "1.7.5",
   "description": "Go-specific development tools with idiomatic best practices",
   "author": {
     "name": "Gopher Guides",

--- a/plugins/go-web/.claude-plugin/plugin.json
+++ b/plugins/go-web/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "go-web",
   "description": "Opinionated Go web app scaffolding with Templ + HTMX + Alpine.js + Tailwind",
-  "version": "1.7.4",
+  "version": "1.7.5",
   "author": {
     "name": "Gopher Guides",
     "email": "support@gopherguides.com"

--- a/plugins/go-web/.codex-plugin/plugin.json
+++ b/plugins/go-web/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "go-web",
-  "version": "1.7.4",
+  "version": "1.7.5",
   "description": "Opinionated Go web app scaffolding with Templ + HTMX + Alpine.js + Tailwind",
   "author": {
     "name": "Gopher Guides",

--- a/plugins/go-workflow/.claude-plugin/plugin.json
+++ b/plugins/go-workflow/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "go-workflow",
   "description": "Issue-to-PR workflow automation with git worktree management",
-  "version": "1.7.4",
+  "version": "1.7.5",
   "author": {
     "name": "Gopher Guides",
     "email": "support@gopherguides.com"

--- a/plugins/go-workflow/.codex-plugin/plugin.json
+++ b/plugins/go-workflow/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "go-workflow",
-  "version": "1.7.4",
+  "version": "1.7.5",
   "description": "Issue-to-PR workflow automation with git worktree management",
   "author": {
     "name": "Gopher Guides",

--- a/plugins/gopher-guides/.claude-plugin/plugin.json
+++ b/plugins/gopher-guides/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "gopher-guides",
   "description": "Gopher Guides training materials integrated into Claude",
-  "version": "1.7.4",
+  "version": "1.7.5",
   "author": {
     "name": "Gopher Guides",
     "email": "support@gopherguides.com"

--- a/plugins/gopher-guides/.codex-plugin/plugin.json
+++ b/plugins/gopher-guides/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "gopher-guides",
-  "version": "1.7.4",
+  "version": "1.7.5",
   "description": "Gopher Guides training materials integration",
   "author": {
     "name": "Gopher Guides",

--- a/plugins/llm-tools/.claude-plugin/plugin.json
+++ b/plugins/llm-tools/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "llm-tools",
   "description": "Multi-LLM integration for second opinions and task delegation",
-  "version": "1.7.4",
+  "version": "1.7.5",
   "author": {
     "name": "Gopher Guides",
     "email": "support@gopherguides.com"

--- a/plugins/llm-tools/.codex-plugin/plugin.json
+++ b/plugins/llm-tools/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "llm-tools",
-  "version": "1.7.4",
+  "version": "1.7.5",
   "description": "Multi-LLM integration for second opinions and task delegation",
   "author": {
     "name": "Gopher Guides",

--- a/plugins/productivity/.claude-plugin/plugin.json
+++ b/plugins/productivity/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "productivity",
   "description": "Standup reports, changelogs, and git productivity helpers",
-  "version": "1.7.4",
+  "version": "1.7.5",
   "author": {
     "name": "Gopher Guides",
     "email": "support@gopherguides.com"

--- a/plugins/tailwind/.claude-plugin/plugin.json
+++ b/plugins/tailwind/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "tailwind",
   "description": "Tailwind CSS v4 tools for initialization, auditing, migration, and optimization",
-  "version": "1.7.4",
+  "version": "1.7.5",
   "author": {
     "name": "Gopher Guides",
     "email": "support@gopherguides.com"

--- a/plugins/tailwind/.codex-plugin/plugin.json
+++ b/plugins/tailwind/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "tailwind",
-  "version": "1.7.4",
+  "version": "1.7.5",
   "description": "Tailwind CSS v4 tools for initialization, auditing, migration, and optimization",
   "author": {
     "name": "Gopher Guides",

--- a/scripts/install-all.sh
+++ b/scripts/install-all.sh
@@ -125,7 +125,6 @@ check_prerequisites() {
 detect_platforms() {
     HAVE_CLAUDE=false
     HAVE_CODEX=false
-    HAVE_CODEX_UNRUNNABLE=false
     HAVE_CODEX_STATE=false
     HAVE_GEMINI=false
 
@@ -134,11 +133,7 @@ detect_platforms() {
     fi
 
     if command -v codex >/dev/null 2>&1; then
-        if codex --version >/dev/null 2>&1; then
-            HAVE_CODEX=true
-        else
-            HAVE_CODEX_UNRUNNABLE=true
-        fi
+        HAVE_CODEX=true
     fi
     if [[ -d "$HOME/.codex" ]]; then
         HAVE_CODEX_STATE=true
@@ -159,8 +154,6 @@ print_detection() {
 
     if $HAVE_CODEX; then
         echo "  Codex CLI ...... found — will install global plugins to ~/.codex/plugins/"
-    elif $HAVE_CODEX_UNRUNNABLE; then
-        echo "  Codex CLI ...... skipped (codex executable on PATH is not runnable)"
     elif $HAVE_CODEX_STATE; then
         echo "  Codex CLI ...... skipped (found ~/.codex/ but no codex executable on PATH)"
     else

--- a/scripts/test-installation.sh
+++ b/scripts/test-installation.sh
@@ -228,8 +228,14 @@ fi
 
 echo -n "Release archives exclude AppleDouble and Finder metadata... "
 APPLEDOUBLE_FIXTURE="$ROOT_DIR/plugins/go-dev/scripts/._archive-metadata-test"
+COMMAND_APPLEDOUBLE_FIXTURE="$ROOT_DIR/plugins/go-dev/commands/._archive-metadata-test.md"
 DSSTORE_FIXTURE="$ROOT_DIR/plugins/go-dev/scripts/.DS_Store"
+cleanup_metadata_fixtures() {
+  rm -f "$APPLEDOUBLE_FIXTURE" "$COMMAND_APPLEDOUBLE_FIXTURE" "$DSSTORE_FIXTURE"
+}
+trap cleanup_metadata_fixtures EXIT
 printf '%s\n' 'metadata fixture' > "$APPLEDOUBLE_FIXTURE"
+printf '%s\n' 'metadata fixture' > "$COMMAND_APPLEDOUBLE_FIXTURE"
 printf '%s\n' 'metadata fixture' > "$DSSTORE_FIXTURE"
 ARCHIVE_METADATA_ERRORS=""
 if ! "$ROOT_DIR/scripts/build-universal.sh" >/tmp/gopher-ai-metadata-build.log 2>&1; then
@@ -291,9 +297,13 @@ EXPECTED_GEMINI_COMMAND_MEMBERS=$(
     command_dir=${command%/*}
     plugin_dir=${command_dir%/commands}
     command_name=${command##*/}
+    if [[ "$command_name" == ._* ]]; then
+      continue
+    fi
     printf 'gemini/gopher-ai-%s/commands/%s.toml\n' "${plugin_dir##*/}" "${command_name%.md}"
   done | LC_ALL=C sort
 )
+rm -f "$COMMAND_APPLEDOUBLE_FIXTURE"
 EXPECTED_CODEX_MANIFEST_COUNT=$(printf '%s\n' "$EXPECTED_CODEX_MANIFESTS" | awk 'NF {count++} END {print count+0}')
 EXPECTED_GEMINI_MANIFEST_COUNT=$(printf '%s\n' "$EXPECTED_GEMINI_MANIFESTS" | awk 'NF {count++} END {print count+0}')
 if [ ! -f "$CODEX_RELEASE_ASSET" ]; then

--- a/scripts/test-installation.sh
+++ b/scripts/test-installation.sh
@@ -292,7 +292,7 @@ EXPECTED_CODEX_MANIFESTS=$(
 )
 EXPECTED_GEMINI_MANIFESTS=$(jq -r '.plugins[].name | "gemini/gopher-ai-\(.)/gemini-extension.json"' "$MARKETPLACE" | LC_ALL=C sort)
 EXPECTED_GEMINI_COMMAND_MEMBERS=$(
-  for command in "$ROOT_DIR"/plugins/*/commands/*.md; do
+  for command in "$ROOT_DIR"/plugins/*/commands/*.md "$ROOT_DIR"/plugins/*/commands/._*.md; do
     [ -f "$command" ] || continue
     command_dir=${command%/*}
     plugin_dir=${command_dir%/commands}

--- a/scripts/test-installation.sh
+++ b/scripts/test-installation.sh
@@ -277,11 +277,25 @@ fi
 
 echo -n "Release archives contain canonical manifests and commands... "
 RELEASE_ASSET_ERRORS=""
-EXPECTED_CODEX_MANIFESTS=$(jq -r '.plugins[].name | select(. != "productivity") | "codex/plugins/\(.)/.codex-plugin/plugin.json"' "$MARKETPLACE" | LC_ALL=C sort)
+EXPECTED_CODEX_MANIFESTS=$(
+  for manifest in "$ROOT_DIR"/plugins/*/.codex-plugin/plugin.json; do
+    [ -f "$manifest" ] || continue
+    plugin_dir=${manifest%/.codex-plugin/plugin.json}
+    printf 'codex/plugins/%s/.codex-plugin/plugin.json\n' "${plugin_dir##*/}"
+  done | LC_ALL=C sort
+)
 EXPECTED_GEMINI_MANIFESTS=$(jq -r '.plugins[].name | "gemini/gopher-ai-\(.)/gemini-extension.json"' "$MARKETPLACE" | LC_ALL=C sort)
+EXPECTED_GEMINI_COMMAND_MEMBERS=$(
+  for command in "$ROOT_DIR"/plugins/*/commands/*.md; do
+    [ -f "$command" ] || continue
+    command_dir=${command%/*}
+    plugin_dir=${command_dir%/commands}
+    command_name=${command##*/}
+    printf 'gemini/gopher-ai-%s/commands/%s.toml\n' "${plugin_dir##*/}" "${command_name%.md}"
+  done | LC_ALL=C sort
+)
 EXPECTED_CODEX_MANIFEST_COUNT=$(printf '%s\n' "$EXPECTED_CODEX_MANIFESTS" | awk 'NF {count++} END {print count+0}')
 EXPECTED_GEMINI_MANIFEST_COUNT=$(printf '%s\n' "$EXPECTED_GEMINI_MANIFESTS" | awk 'NF {count++} END {print count+0}')
-EXPECTED_GEMINI_COMMAND_COUNT=36
 if [ ! -f "$CODEX_RELEASE_ASSET" ]; then
   RELEASE_ASSET_ERRORS="$RELEASE_ASSET_ERRORS\n  missing ${CODEX_RELEASE_ASSET#"$ROOT_DIR"/}"
 else
@@ -327,9 +341,9 @@ else
     fi
   done <<< "$GEMINI_MANIFESTS"
   GEMINI_COMMAND_MEMBERS=$(archive_members "$GEMINI_RELEASE_ASSET" | awk -F/ '$NF ~ /[.]toml$/ && $0 ~ /\/commands\// {print}' || true)
-  GEMINI_COMMAND_MEMBER_COUNT=$(printf '%s\n' "$GEMINI_COMMAND_MEMBERS" | awk 'NF {count++} END {print count+0}')
-  if [ "$GEMINI_COMMAND_MEMBER_COUNT" -ne "$EXPECTED_GEMINI_COMMAND_COUNT" ]; then
-    RELEASE_ASSET_ERRORS="$RELEASE_ASSET_ERRORS\n  Gemini archive has $GEMINI_COMMAND_MEMBER_COUNT command-shaped member(s), expected $EXPECTED_GEMINI_COMMAND_COUNT"
+  SORTED_GEMINI_COMMAND_MEMBERS=$(printf '%s\n' "$GEMINI_COMMAND_MEMBERS" | LC_ALL=C sort)
+  if [ "$SORTED_GEMINI_COMMAND_MEMBERS" != "$EXPECTED_GEMINI_COMMAND_MEMBERS" ]; then
+    RELEASE_ASSET_ERRORS="$RELEASE_ASSET_ERRORS\n  Gemini archive command set does not match plugins/*/commands/*.md"
   fi
   while IFS= read -r command; do
     [ -n "$command" ] || continue
@@ -718,7 +732,7 @@ else
 fi
 rm -rf "$TMP_HOME" "$TMP_BIN"
 
-echo -n "install-all.sh skips an unlaunchable Codex executable and continues... "
+echo -n "install-all.sh enters Codex install for a PATH executable and propagates failure... "
 TMP_HOME=$(mktemp -d)
 TMP_BIN=$(mktemp -d)
 mkdir -p "$TMP_HOME/.codex"
@@ -730,18 +744,21 @@ HOME="$TMP_HOME" PATH="$TMP_BIN:$PATH" bash "$ROOT_DIR/scripts/install-all.sh" -
   </dev/null >/tmp/gopher-ai-installall-unlaunchable-codex.log 2>&1
 UNLAUNCHABLE_CODEX_EXIT=$?
 set -e
-if [ "$UNLAUNCHABLE_CODEX_EXIT" -ne 0 ]; then
-  echo "FAIL (Gemini install exited non-zero)"
+if [ "$UNLAUNCHABLE_CODEX_EXIT" -eq 0 ]; then
+  echo "FAIL (Codex installer failure was hidden)"
+  ERRORS=$((ERRORS + 1))
+elif ! grep -Fq 'Codex CLI ...... found — will install global plugins to ~/.codex/plugins/' /tmp/gopher-ai-installall-unlaunchable-codex.log; then
+  echo "FAIL (PATH Codex executable was not detected)"
+  ERRORS=$((ERRORS + 1))
+elif ! grep -Fq '=== Codex CLI ===' /tmp/gopher-ai-installall-unlaunchable-codex.log; then
+  echo "FAIL (Codex installer path was not entered)"
+  ERRORS=$((ERRORS + 1))
+elif ! grep -Fq "error: installed Codex CLI does not support 'codex plugin add'." /tmp/gopher-ai-installall-unlaunchable-codex.log; then
+  echo "FAIL (Codex installer failure was not actionable)"
   sed -n '1,80p' /tmp/gopher-ai-installall-unlaunchable-codex.log
   ERRORS=$((ERRORS + 1))
-elif ! grep -Fq 'Codex CLI ...... skipped (codex executable on PATH is not runnable)' /tmp/gopher-ai-installall-unlaunchable-codex.log; then
-  echo "FAIL (unlaunchable Codex warning was missing)"
-  ERRORS=$((ERRORS + 1))
-elif grep -Fq '=== Codex CLI ===' /tmp/gopher-ai-installall-unlaunchable-codex.log; then
-  echo "FAIL (Codex installer ran with an unlaunchable executable)"
-  ERRORS=$((ERRORS + 1))
-elif ! grep -Fq 'Done! Installed for: Gemini CLI' /tmp/gopher-ai-installall-unlaunchable-codex.log; then
-  echo "FAIL (Gemini completion summary was missing)"
+elif grep -Fq 'Done! Installed for: Gemini CLI' /tmp/gopher-ai-installall-unlaunchable-codex.log; then
+  echo "FAIL (false Gemini-only success summary was printed)"
   ERRORS=$((ERRORS + 1))
 else
   echo "OK"


### PR DESCRIPTION
## Summary
- remove the pre-confirmation `codex --version` probe and let `install-codex` validate capabilities
- compare packaged Gemini commands against the exact source-derived command set
- derive expected Codex manifests from the installed Codex plugin manifests
- release the correction as v1.7.5

## Test Plan
- `bash -n` and `shellcheck` for changed scripts
- `./scripts/test-installation.sh`
- full repository release gate
- deterministic, metadata-free Codex and Gemini v1.7.5 archives
