### PR TITLE
fix(tailwind): pin MCP server version

### DIFF
--- a/.detent/skills/verify-mcp-stdio-compatibility.md
+++ b/.detent/skills/verify-mcp-stdio-compatibility.md
@@ -1,0 +1,29 @@
+---
+name: verify-mcp-stdio-compatibility
+description: Verify a pinned STDIO MCP server across modern and legacy protocol eras.
+when_to_use: Use when auditing or pinning an MCP server after a protocol revision changes initialization or discovery.
+---
+
+# Verify MCP STDIO Compatibility
+
+1. Query the package registry for the latest version, publication time, source
+   repository, and MCP SDK dependency.
+2. Download the exact artifact into the configured temporary directory and
+   inspect the published code rather than relying on repository main.
+3. Start the pinned command with an isolated npm cache under `TMPDIR`.
+4. Send `server/discover` with the preferred modern protocol version and the
+   required per-request `_meta`.
+5. Classify the response using the specification:
+   - A discovery result identifies a modern server.
+   - A recognized modern version error requires retrying a supported version.
+   - Any other error or timeout identifies a legacy server.
+6. For a legacy server, send `initialize`, then
+   `notifications/initialized`, followed by `tools/list`.
+7. Assert every tool referenced by the consuming plugin is advertised. Do not
+   rely on a documented tool count when source references can be enumerated.
+8. Capture non-JSON stdout separately from stderr because STDIO MCP requires
+   stdout to contain protocol messages only.
+9. Verify at least one current client from each supported client family can
+   connect through an isolated configuration.
+10. Document the negotiated protocol, unsupported modern version, exact pin,
+    and non-MCP fallback behavior.

--- a/README.md
+++ b/README.md
@@ -236,11 +236,15 @@ Tailwind CSS v4 tools for initialization, auditing, migration, and optimization.
 | `/tailwind-audit` | Audit Tailwind usage for best practices |
 | `/tailwind-optimize` | Optimize Tailwind configuration and usage |
 
-**MCP Tools** (Claude Code only):
+**MCP Tools** (Claude Code, Codex, and generated Gemini extensions):
 - `search_tailwind_docs` - Search Tailwind CSS documentation
 - `get_tailwind_utilities` - Get utility classes for CSS properties
 - `get_tailwind_colors` - Get color palette information
+- `get_tailwind_config_guide` - Get framework-specific configuration guidance
+- `install_tailwind` - Generate framework installation instructions
 - `convert_css_to_tailwind` - Convert CSS to Tailwind utilities
+- `generate_color_palette` - Generate a custom color palette
+- `generate_component_template` - Generate styled component templates
 
 ## Skills Reference
 
@@ -351,7 +355,7 @@ The **tailwind** module includes an MCP (Model Context Protocol) server for Tail
   "mcpServers": {
     "tailwindcss": {
       "command": "npx",
-      "args": ["-y", "tailwindcss-mcp-server"]
+      "args": ["-y", "tailwindcss-mcp-server@0.1.1"]
     }
   }
 }
@@ -361,19 +365,33 @@ The **tailwind** module includes an MCP (Model Context Protocol) server for Tail
 - Node.js 16+ (`node` and `npx` must be on your PATH)
 - Internet access on first run (to download the package)
 
+Version `0.1.1` implements legacy MCP `2024-11-05`, not MCP `2026-07-28`.
+Current Claude Code and Codex clients use the standard STDIO compatibility
+probe and fall back to the legacy initialization handshake. Run
+`node scripts/test-tailwind-mcp-server.mjs` to verify the pinned version,
+protocol path, and advertised tools.
+
 **Available MCP tools:**
 - `search_tailwind_docs` — Search Tailwind CSS documentation
 - `get_tailwind_utilities` — Get utility classes for CSS properties
 - `get_tailwind_colors` — Get color palette information
+- `get_tailwind_config_guide` — Get framework-specific configuration guidance
+- `install_tailwind` — Generate framework installation instructions
 - `convert_css_to_tailwind` — Convert CSS to Tailwind utilities
+- `generate_color_palette` — Generate a custom color palette
+- `generate_component_template` — Generate styled component templates
 
 **Fallback behavior:**
-If the MCP server is unavailable (Node.js not installed, network issues, or using a non-Claude platform), the Tailwind slash commands (`/tailwind-init`, `/tailwind-migrate`, `/tailwind-audit`, `/tailwind-optimize`) still work fully — they do not depend on the MCP server. The MCP tools provide supplementary documentation lookups only.
+If the MCP server is unavailable (Node.js not installed, network issues, or a
+client without legacy MCP support), the Tailwind commands still work fully.
+They use the official documentation URLs in
+`plugins/tailwind/skills/tailwind-best-practices/docs-urls.md`; the MCP tools
+provide supplementary lookups only.
 
 **Troubleshooting:**
 - **"npx: command not found"** — Install Node.js 16+ (`brew install node` or [nodejs.org](https://nodejs.org))
 - **MCP tools not appearing** — Ensure you installed the `tailwind` plugin module; run `/plugin install tailwind@gopher-ai`
-- **Timeout on first run** — The first `npx -y tailwindcss-mcp-server` invocation downloads the package; subsequent runs are cached
+- **Timeout on first run** — The first `npx -y tailwindcss-mcp-server@0.1.1` invocation downloads the package; subsequent runs are cached
 
 ## Best Practices Guide
 

--- a/plugins/tailwind/.claude-plugin/plugin.json
+++ b/plugins/tailwind/.claude-plugin/plugin.json
@@ -23,7 +23,7 @@
       "command": "npx",
       "args": [
         "-y",
-        "tailwindcss-mcp-server"
+        "tailwindcss-mcp-server@0.1.1"
       ]
     }
   }

--- a/plugins/tailwind/.mcp.json
+++ b/plugins/tailwind/.mcp.json
@@ -3,7 +3,7 @@
     "command": "npx",
     "args": [
       "-y",
-      "tailwindcss-mcp-server"
+      "tailwindcss-mcp-server@0.1.1"
     ]
   }
 }

--- a/plugins/tailwind/README.md
+++ b/plugins/tailwind/README.md
@@ -47,8 +47,20 @@ This plugin includes the `tailwindcss-mcp-server` which provides:
 | `search_tailwind_docs` | Search documentation for any topic |
 | `get_tailwind_utilities` | Get utilities by category |
 | `get_tailwind_colors` | Access color palette |
+| `get_tailwind_config_guide` | Get framework-specific configuration guidance |
+| `install_tailwind` | Generate framework installation instructions |
 | `convert_css_to_tailwind` | Convert CSS to utilities |
 | `generate_component_template` | Generate component templates |
+| `generate_color_palette` | Generate a custom color palette |
+
+The plugin pins `tailwindcss-mcp-server@0.1.1`. This release implements legacy
+MCP `2024-11-05`; current Claude Code and Codex clients connect through the
+standard STDIO fallback because it does not implement MCP `2026-07-28`
+`server/discover`. Run `node scripts/test-tailwind-mcp-server.mjs` from the
+repository root to verify the protocol path and advertised tools.
+
+When the server is unavailable, use the official documentation links in
+`skills/tailwind-best-practices/docs-urls.md`.
 
 ## Tailwind v4 Quick Reference
 

--- a/scripts/build-universal.sh
+++ b/scripts/build-universal.sh
@@ -289,10 +289,15 @@ rewrite_gemini_plugin_paths() {
 generate_gemini_extension_json() {
     local plugin_name="$1"
     local plugin_json="$ROOT_DIR/plugins/$plugin_name/.claude-plugin/plugin.json"
+    local mcp_json="$ROOT_DIR/plugins/$plugin_name/.mcp.json"
 
     local description=""
+    local mcp_servers="{}"
     if [[ -f "$plugin_json" ]]; then
         description=$(jq -r '.description // ""' "$plugin_json")
+    fi
+    if [[ -f "$mcp_json" ]]; then
+        mcp_servers=$(jq -c '.' "$mcp_json")
     fi
 
     cat << EOF
@@ -301,7 +306,7 @@ generate_gemini_extension_json() {
   "version": "$VERSION",
   "description": "$description",
   "contextFileName": "GEMINI.md",
-  "mcpServers": {},
+  "mcpServers": $mcp_servers,
   "excludeTools": [],
   "settings": []
 }

--- a/scripts/test-tailwind-mcp-server.mjs
+++ b/scripts/test-tailwind-mcp-server.mjs
@@ -1,0 +1,240 @@
+#!/usr/bin/env node
+
+import { spawn } from "node:child_process";
+import { readFile } from "node:fs/promises";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const root = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+const claudeManifestPath = resolve(root, "plugins/tailwind/.claude-plugin/plugin.json");
+const mcpManifestPath = resolve(root, "plugins/tailwind/.mcp.json");
+const protocolVersion = "2026-07-28";
+const legacyProtocolVersion = "2024-11-05";
+const requiredTools = [
+  "search_tailwind_docs",
+  "get_tailwind_utilities",
+  "get_tailwind_colors",
+  "convert_css_to_tailwind",
+  "generate_component_template",
+  "install_tailwind",
+  "get_tailwind_config_guide",
+];
+
+function assert(condition, message) {
+  if (!condition) {
+    throw new Error(message);
+  }
+}
+
+async function readJson(path) {
+  return JSON.parse(await readFile(path, "utf8"));
+}
+
+const [claudeManifest, mcpManifest] = await Promise.all([
+  readJson(claudeManifestPath),
+  readJson(mcpManifestPath),
+]);
+const claudeConfig = claudeManifest.mcpServers?.tailwindcss;
+const serverConfig = mcpManifest.tailwindcss;
+
+assert(claudeConfig, "Claude manifest is missing the tailwindcss MCP server");
+assert(serverConfig, "MCP manifest is missing the tailwindcss server");
+assert(
+  JSON.stringify(claudeConfig) === JSON.stringify(serverConfig),
+  "Claude and shared MCP server configurations differ",
+);
+assert(serverConfig.command === "npx", "tailwindcss MCP server must run with npx");
+assert(serverConfig.args?.[0] === "-y", "tailwindcss MCP server must pass npx -y");
+
+const packageSpec = serverConfig.args?.[1];
+assert(
+  /^tailwindcss-mcp-server@\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?$/.test(packageSpec ?? ""),
+  "tailwindcss-mcp-server must use an explicit semantic version",
+);
+
+const tempRoot =
+  process.env.TMPDIR ?? process.env.TMP ?? process.env.TEMP ?? "/tmp";
+const npmCache =
+  process.env.npm_config_cache ??
+  resolve(tempRoot, "gopher-ai-tailwind-mcp-npm-cache");
+const child = spawn(serverConfig.command, serverConfig.args, {
+  cwd: root,
+  env: {
+    ...process.env,
+    npm_config_cache: npmCache,
+  },
+  stdio: ["pipe", "pipe", "pipe"],
+});
+
+child.stdout.setEncoding("utf8");
+child.stderr.setEncoding("utf8");
+
+let stdoutBuffer = "";
+let stderr = "";
+const nonProtocolLines = [];
+const pending = new Map();
+
+function rejectPending(error) {
+  for (const { reject, timer } of pending.values()) {
+    clearTimeout(timer);
+    reject(error);
+  }
+  pending.clear();
+}
+
+function handleLine(line) {
+  if (!line.trim()) {
+    return;
+  }
+
+  let message;
+  try {
+    message = JSON.parse(line);
+  } catch {
+    nonProtocolLines.push(line);
+    return;
+  }
+
+  const request = pending.get(String(message.id));
+  if (!request) {
+    return;
+  }
+
+  clearTimeout(request.timer);
+  pending.delete(String(message.id));
+  request.resolve(message);
+}
+
+child.stdout.on("data", (chunk) => {
+  stdoutBuffer += chunk;
+  const lines = stdoutBuffer.split("\n");
+  stdoutBuffer = lines.pop() ?? "";
+  for (const line of lines) {
+    handleLine(line);
+  }
+});
+child.stderr.on("data", (chunk) => {
+  stderr += chunk;
+});
+child.on("error", rejectPending);
+child.on("exit", (code, signal) => {
+  if (pending.size > 0) {
+    rejectPending(
+      new Error(
+        `tailwindcss MCP server exited before responding (code=${code}, signal=${signal})`,
+      ),
+    );
+  }
+});
+
+function send(message) {
+  child.stdin.write(`${JSON.stringify(message)}\n`);
+}
+
+function request(id, method, params) {
+  return new Promise((resolveRequest, rejectRequest) => {
+    const timer = setTimeout(() => {
+      pending.delete(String(id));
+      rejectRequest(new Error(`timed out waiting for ${method}`));
+    }, 30000);
+
+    pending.set(String(id), {
+      resolve: resolveRequest,
+      reject: rejectRequest,
+      timer,
+    });
+    send({ jsonrpc: "2.0", id, method, params });
+  });
+}
+
+function modernMeta() {
+  return {
+    "io.modelcontextprotocol/protocolVersion": protocolVersion,
+    "io.modelcontextprotocol/clientInfo": {
+      name: "gopher-ai-tailwind-smoke",
+      version: "1.0.0",
+    },
+    "io.modelcontextprotocol/clientCapabilities": {},
+  };
+}
+
+try {
+  const discovery = await request("discover", "server/discover", {
+    _meta: modernMeta(),
+  });
+
+  let protocolMode;
+  if (discovery.result) {
+    assert(
+      discovery.result.supportedVersions?.includes(protocolVersion),
+      `server/discover did not advertise ${protocolVersion}`,
+    );
+    protocolMode = `modern MCP ${protocolVersion}`;
+  } else {
+    assert(discovery.error, "server/discover returned neither a result nor an error");
+    assert(
+      discovery.error.code !== -32022,
+      `server is modern but does not support ${protocolVersion}`,
+    );
+
+    const initialization = await request("initialize", "initialize", {
+      protocolVersion: legacyProtocolVersion,
+      capabilities: {},
+      clientInfo: {
+        name: "gopher-ai-tailwind-smoke",
+        version: "1.0.0",
+      },
+    });
+    assert(
+      initialization.result?.protocolVersion === legacyProtocolVersion,
+      `legacy initialize did not negotiate ${legacyProtocolVersion}`,
+    );
+    send({
+      jsonrpc: "2.0",
+      method: "notifications/initialized",
+      params: {},
+    });
+    protocolMode = `legacy MCP ${legacyProtocolVersion} fallback`;
+  }
+
+  const toolsResponse = await request(
+    "tools",
+    "tools/list",
+    protocolMode.startsWith("modern") ? { _meta: modernMeta() } : {},
+  );
+  assert(toolsResponse.result?.tools, "tools/list did not return tools");
+
+  const advertisedTools = new Set(
+    toolsResponse.result.tools.map((tool) => tool.name),
+  );
+  const missingTools = requiredTools.filter((tool) => !advertisedTools.has(tool));
+  assert(
+    missingTools.length === 0,
+    `tools/list is missing required tools: ${missingTools.join(", ")}`,
+  );
+
+  process.stdout.write(
+    `PASS: ${packageSpec} used ${protocolMode} and advertised ${advertisedTools.size} tools (${requiredTools.length} required by the plugin).\n`,
+  );
+  if (discovery.error) {
+    process.stdout.write(
+      `SPEC: server/discover returned ${discovery.error.code}; ${protocolVersion} is not supported.\n`,
+    );
+  }
+  if (nonProtocolLines.length > 0) {
+    process.stdout.write(
+      `NOTICE: server wrote ${nonProtocolLines.length} non-JSON line(s) to stdout before MCP responses.\n`,
+    );
+  }
+} catch (error) {
+  process.stderr.write(`FAIL: ${error.message}\n`);
+  if (stderr.trim()) {
+    process.stderr.write(stderr);
+  }
+  process.exitCode = 1;
+} finally {
+  child.stdin.end();
+  if (process.exitCode) {
+    child.kill();
+  }
+}


### PR DESCRIPTION
## Summary
- Pin the Tailwind MCP dependency to `0.1.1` and document that it uses the legacy `2024-11-05` protocol through the modern STDIO fallback path.
- Add a live protocol smoke check that probes `server/discover`, performs legacy initialization, and verifies every tool required by the plugin.
- Include the shared MCP configuration in generated Gemini extensions while retaining official Tailwind documentation as the non-MCP fallback.

## Test Plan
- `node scripts/test-tailwind-mcp-server.mjs`
- Isolated Claude Code 2.1.220 MCP tool call and Codex CLI 0.146.0 tool discovery
- Temporary universal build with generated Gemini MCP manifest verification
- Full Detent validation gate (command, hook, ship, sync, shell, skill, YAML, build, and Go tests)

Fixes #260