### PR TITLE
fix(ship): guard head-shift reset

### DIFF
--- a/plugins/go-workflow/lib/ship/ci-watch.md
+++ b/plugins/go-workflow/lib/ship/ci-watch.md
@@ -60,6 +60,11 @@ if [ -n "$FINAL_SHA" ] && [ "$FINAL_SHA" != "$HEAD_SHA" ]; then
   echo "STOP: PR head shifted to SHA $FINAL_SHA during watch (expected $HEAD_SHA)."
   echo "A new commit landed on this PR that was NOT reviewed locally."
   echo "Restarting from review phase against the new HEAD."
+  if [ -n "$(git status --porcelain)" ]; then
+    echo "BLOCKED: PR head shifted, but the working tree has uncommitted changes."
+    echo "Commit them before shipping, or abort?"
+    exit 1
+  fi
   HEAD_SHA="$FINAL_SHA"
   BRANCH_REMOTE=$(git config "branch.$(git branch --show-current).remote" 2>/dev/null || echo "origin")
   PR_HEAD_BRANCH=$(gh pr view "$PR_NUM" --json headRefName --jq '.headRefName')
@@ -73,6 +78,10 @@ if [ -n "$FINAL_SHA" ] && [ "$FINAL_SHA" != "$HEAD_SHA" ]; then
   # Go back to Step 5, which marks the review in-flight before dispatch.
 fi
 ```
+
+The dirty-tree check reapplies Step 3's policy during recovery. Treat its
+non-zero exit as blocking: stop, surface the commit-or-abort choice to the user,
+and do not fetch, check out, or reset until the working tree is clean.
 
 The reset on SHA shift is critical: if a concurrent push lands content that
 wasn't reviewed locally, we MUST re-review it. The pass counter is reset to

--- a/scripts/test-ship-e2e-gate.sh
+++ b/scripts/test-ship-e2e-gate.sh
@@ -197,6 +197,72 @@ require_text "$RESUME_MESSAGES" "Do not start another review.*Commit the validat
 require_text "$COMPLETE_ISSUE" '`reviewing` → Phase 3' \
   "complete-issue must not resume an expired agent review"
 
+CI_SHIFT_BLOCK=$(mktemp "${TMPDIR:-/tmp}/gopher-ai-ci-shift-XXXXXX")
+DIRTY_HEAD_SHIFT_TMP=$(mktemp -d "${TMPDIR:-/tmp}/gopher-ai-dirty-head-shift-XXXXXX")
+awk '
+  /^## 10d\./ { section=1 }
+  section && /^```bash$/ { block=1; next }
+  block && /^```$/ { exit }
+  block { print }
+' "$CI_WATCH" > "$CI_SHIFT_BLOCK"
+
+git -C "$DIRTY_HEAD_SHIFT_TMP" init -q -b fixture
+git -C "$DIRTY_HEAD_SHIFT_TMP" config user.name "Test User"
+git -C "$DIRTY_HEAD_SHIFT_TMP" config user.email "test@example.com"
+printf '%s\n' "clean" > "$DIRTY_HEAD_SHIFT_TMP/tracked.txt"
+git -C "$DIRTY_HEAD_SHIFT_TMP" add tracked.txt
+git -C "$DIRTY_HEAD_SHIFT_TMP" commit -q -m "test: initialize fixture"
+printf '%s\n' "dirty" >> "$DIRTY_HEAD_SHIFT_TMP/tracked.txt"
+mkdir -p "$DIRTY_HEAD_SHIFT_TMP/.local/state"
+printf '%s\n' '{"phase":"ci-watch"}' > "$DIRTY_HEAD_SHIFT_TMP/.local/state/ship.loop.local.json"
+
+set +e
+DIRTY_HEAD_SHIFT_OUTPUT=$(cd "$DIRTY_HEAD_SHIFT_TMP" && \
+  RESET_MARKER="$DIRTY_HEAD_SHIFT_TMP/reset-attempted" bash -c '
+    gh() {
+      if [[ "$*" == *"headRefOid"* ]]; then
+        printf "%s\n" "new-sha"
+      elif [[ "$*" == *"headRefName"* ]]; then
+        printf "%s\n" "fixture"
+      fi
+    }
+    git() {
+      if [ "$1" = "fetch" ] || [ "$1" = "checkout" ]; then
+        return 0
+      fi
+      if [ "$1" = "reset" ]; then
+        printf "%s\n" "reset" > "$RESET_MARKER"
+        return 0
+      fi
+      command git "$@"
+    }
+    HEAD_SHA="old-sha"
+    PR_NUM=1
+    source "$1"
+  ' _ "$CI_SHIFT_BLOCK" 2>&1)
+DIRTY_HEAD_SHIFT_STATUS=$?
+set -e
+
+if [ "$DIRTY_HEAD_SHIFT_STATUS" -ne 1 ]; then
+  fail "dirty-tree head-shift recovery must return a blocking status"
+fi
+if [[ "$DIRTY_HEAD_SHIFT_OUTPUT" != *"working tree has uncommitted changes"* ]] || \
+   [[ "$DIRTY_HEAD_SHIFT_OUTPUT" != *"Commit them before shipping, or abort?"* ]]; then
+  fail "dirty-tree head-shift recovery must surface ship's dirty-tree policy"
+fi
+if [ -f "$DIRTY_HEAD_SHIFT_TMP/reset-attempted" ]; then
+  fail "dirty-tree head-shift recovery must stop before reset"
+fi
+if git -C "$DIRTY_HEAD_SHIFT_TMP" diff --quiet; then
+  fail "dirty-tree head-shift recovery must preserve local changes"
+fi
+if ! jq -e '.phase == "ci-watch"' "$DIRTY_HEAD_SHIFT_TMP/.local/state/ship.loop.local.json" >/dev/null; then
+  fail "dirty-tree head-shift recovery must not advance the ship phase"
+fi
+
+rm -f "$CI_SHIFT_BLOCK"
+rm -rf "$DIRTY_HEAD_SHIFT_TMP"
+
 HEADLESS_TMP=$(mktemp -d /tmp/ship-headless-e2e-XXXXXX)
 mkdir -p "$HEADLESS_TMP/.local/state" "$HEADLESS_TMP/hooks" "$HEADLESS_TMP/lib"
 cp "$STOP_HOOK" "$HEADLESS_TMP/hooks/stop-hook.sh"


### PR DESCRIPTION
## Summary
- Stop concurrent-head recovery when the working tree contains uncommitted changes, before fetch, checkout, or reset.
- Preserve local changes and retain the CI-watch phase while surfacing the existing commit-or-abort policy.
- Exercise the recovery block in a dirty Git fixture that detects reset attempts and verifies preservation.

## Test Plan
- `./scripts/test-ship-e2e-gate.sh`
- Configured validation gate: command tests, hook tests, ship gate, shared-sync check, ShellCheck, skill metadata/YAML checks, demo build, and Go tests.

Fixes #267