### PR TITLE
fix(address-review): harden review completion

### DIFF
--- a/plugins/go-workflow/hooks/legacy-skill-hashes.txt
+++ b/plugins/go-workflow/hooks/legacy-skill-hashes.txt
@@ -7,7 +7,7 @@
 # this prevents accepting a hash from skill A as proof of ownership for skill B.
 # DO NOT EDIT BY HAND — re-run the regen script after committing SKILL.md changes.
 #
-# Total entries: 238
+# Total entries: 239
 017e2d820506e7bef4a89a4d65839150db1ffdc124852a43dc916023e6d37e16 review-deep
 0322d4a7ddc204a9bf5addfec4e512edaea92ab8f4ebdd0541ca099330a09408 worktree
 03dac3a27d6da4b0a0c64ff6511df17004747e20b47a1691b4f9f030478877b9 commit
@@ -144,6 +144,7 @@
 93827094677dd44ce194ea2868e85eb54f1ded5c42fee3e0242155bd27505729 ship
 93b24a0632356acdab3440e60f304547d28bcf460bdb9d450317db273097bdd7 tmux-start
 93b9ddd56d963ce00681acc1b102a00fa51430b5bb7c2f0e112bc3beb7fa72f1 go-concurrency
+94d6b0b908d9b0823ce2908fcde0f3c821295a2140ce14c8e82112f5e4523aab address-review
 958cd292b8c8ce32bd161b6bdc6e21aaa95dc3b41683b1218d83b04c6b0de529 ship
 967e4973fe88ee1938651cb7c95e361361a0c9f32c4a3650193d5c3f48da2be6 second-opinion
 983506ba0af0089055cfccb8438ed22a166638d0f895dc1380caf09fdf7afb33 complete-issue

--- a/plugins/go-workflow/skills/address-review/SKILL.md
+++ b/plugins/go-workflow/skills/address-review/SKILL.md
@@ -137,6 +137,8 @@ All above, PLUS all detected review bots signaled approval per `bot-registry.md`
 
 **When ALL criteria are met, output exactly:** `<done>COMPLETE</done>`
 
+If the user exits or skips a bot before all detected bots approve, follow the **Incomplete Approval Outcome** procedure in `watch-loop.md`. Persist `approval_result` and `approval_reason`, then output `<done>INCOMPLETE</done>` instead. Never output the completion marker for this path.
+
 **Safety:** If 15+ iterations without success, document blockers and ask user.
 
 ## Supporting Files

--- a/plugins/go-workflow/skills/address-review/fix-cycle.md
+++ b/plugins/go-workflow/skills/address-review/fix-cycle.md
@@ -76,11 +76,11 @@ Make the **minimal change** that addresses the comment. Follow existing patterns
 4. Avoid mechanical edits that miss the underlying concern
 
 ### 4e. Track the Fix
-Note: thread ID, what was fixed, brief explanation, testability (`testable`/`not-testable`), source file/function/package if testable.
+Note: thread ID, what was fixed, brief explanation, testability (`testable`/`not-testable`), source file/function/package if testable, and every file modified by the fix. Maintain one explicit owned-files list for this fix cycle. Do not add files that were already modified before the cycle or changed for unrelated work.
 
 ## Step 4.5: Generate Tests for Testable Fixes
 
-Read `test-generation.md` for full test generation guidelines including testability rules, existing test detection, pattern matching, and test writing procedures.
+Read `test-generation.md` for full test generation guidelines including testability rules, existing test detection, pattern matching, and test writing procedures. Add every generated or modified test file to the owned-files list.
 
 ---
 
@@ -98,12 +98,28 @@ Fix any failures and re-run until all green.
 
 ## Step 6: Commit and Push
 
+Stage only files modified during this fix cycle. Build `OWNED_FILES` from the paths tracked in Steps 4 and 4.5, inspect `git status --short`, and exclude every pre-existing or unrelated change. Start from an empty index so an earlier staged change cannot enter the review-fix commit.
+
 ```bash
-git add -A
-git commit -m "address review comments
+if ! git diff --cached --quiet; then
+  echo "Error: Pre-existing staged changes must be committed or unstaged before address-review can commit."
+  exit 1
+fi
+
+OWNED_FILES=(
+  "path/to/fixed-file.go"
+  "path/to/generated_test.go"
+)
+git add -- "${OWNED_FILES[@]}"
+
+if ! git diff --cached --quiet; then
+  git commit -m "address review comments
 
 - [brief summary of each fix]
 - [tests added for testable fixes, if any]"
+else
+  echo "No owned review-fix changes to commit."
+fi
 git push
 ```
 

--- a/plugins/go-workflow/skills/address-review/fix-cycle.md
+++ b/plugins/go-workflow/skills/address-review/fix-cycle.md
@@ -43,6 +43,20 @@ if [ -f "$LOOP_STATE_FILE" ]; then
 fi
 ```
 
+### Protect Pre-existing Target Changes
+
+Before the first edit to each unique source or test path in this fix cycle, verify that the target path has no staged, unstaged, or untracked changes. Run this guard exactly once per path, before sequential work or agent dispatch:
+
+```bash
+TARGET_FILE="path/from-review-thread"
+if [ -n "$(git status --porcelain -- "$TARGET_FILE")" ]; then
+  echo "Error: $TARGET_FILE already has changes that are not owned by this review-fix cycle."
+  exit 1
+fi
+```
+
+If the guard fails, stop and ask the user to commit, stash, or otherwise separate those changes. Do not edit the path and do not attempt path-level staging, because Git cannot distinguish the pre-existing hunks from the review fix.
+
 ### Parallel Fix Dispatch (when 3+ comments target different files)
 
 When there are 3 or more unresolved comments targeting **different files**, dispatch parallel Implementer subagents:
@@ -52,7 +66,7 @@ When there are 3 or more unresolved comments targeting **different files**, disp
 3. **For each file group**, dispatch an Agent subagent (sonnet) with:
    - "You are addressing PR review comments in `{FILE_PATH}`. Working directory: `{PROJECT_ROOT}`."
    - All comments for that file (reviewer text, line number, suggested change)
-   - "For each comment: understand the request, locate the code, make the minimal fix, validate against feedback. Report: files changed, fixes applied, testability of each fix."
+   - "Before editing, run the pre-existing target changes guard. For each comment: understand the request, locate the code, make the minimal fix, validate against feedback. Report: files changed, fixes applied, testability of each fix."
 3. **Dispatch all file-group agents in parallel** using `run_in_background: true`
 4. **Collect results** — proceed to Step 4.5 (test generation) with combined fix list
 
@@ -80,7 +94,7 @@ Note: thread ID, what was fixed, brief explanation, testability (`testable`/`not
 
 ## Step 4.5: Generate Tests for Testable Fixes
 
-Read `test-generation.md` for full test generation guidelines including testability rules, existing test detection, pattern matching, and test writing procedures. Add every generated or modified test file to the owned-files list.
+Read `test-generation.md` for full test generation guidelines including testability rules, existing test detection, pattern matching, and test writing procedures. Run the pre-existing target changes guard before modifying an existing test path, then add every generated or modified test file to the owned-files list.
 
 ---
 

--- a/plugins/go-workflow/skills/address-review/watch-loop.md
+++ b/plugins/go-workflow/skills/address-review/watch-loop.md
@@ -30,6 +30,27 @@ if [ -f "$LOOP_STATE_FILE" ]; then
 fi
 ```
 
+## Incomplete Approval Outcome
+
+If the user chooses a terminal path before every detected bot approves, do not report the workflow as complete. Set `APPROVAL_REASON` to the reason code specified by the decision branch, then persist the incomplete outcome:
+
+```bash
+APPROVAL_REASON="${APPROVAL_REASON:?approval reason is required}"
+if [ ! -f "$LOOP_STATE_FILE" ]; then
+  echo "Error: Cannot persist incomplete approval outcome without loop state."
+  exit 1
+fi
+
+source "${CLAUDE_PLUGIN_ROOT}/lib/loop-state.sh"
+set_loop_field "$LOOP_STATE_FILE" "approval_result" "incomplete"
+set_loop_field "$LOOP_STATE_FILE" "approval_reason" "$APPROVAL_REASON"
+set_loop_phase "$LOOP_STATE_FILE" "approval-incomplete"
+set_loop_field "$LOOP_STATE_FILE" "completion_promise" "INCOMPLETE"
+echo "Address-review stopped without required bot approvals: $APPROVAL_REASON"
+```
+
+After the state update succeeds, output `<done>INCOMPLETE</done>` and stop. The changed completion promise lets the stop hook accept the distinct terminal marker, while `approval_result` and `approval_reason` give callers a machine-readable outcome before loop cleanup.
+
 ---
 
 ## Step 12: Watch for Bot Re-review (default, skipped with --no-watch)
@@ -73,7 +94,7 @@ If any bot hasn't approved yet:
    - Use `AskUserQuestion` to ask: "Bots haven't responded after 5 minutes. Would you like to keep waiting, re-trigger bot reviews, or exit?"
    - If "keep waiting" → reset timeout, continue polling
    - If "re-trigger" → go to 12d
-   - If "exit" → output `<done>COMPLETE</done>`
+   - If "exit" → set `APPROVAL_REASON="bot-approval-timeout"`, follow **Incomplete Approval Outcome**, and stop
 
 ### 12c. New comments found — loop back to Step 2
 
@@ -108,4 +129,8 @@ If a bot's quiet period ended with no new comments but it still hasn't approved:
    ```
 3. **Max 3 re-trigger attempts per bot.** Track the count.
 4. If 3 attempts exhausted → use `AskUserQuestion`: "Bot <login> hasn't approved after 3 re-trigger attempts. Keep trying, skip this bot, or exit?"
-5. After re-triggering → return to 12b to wait again.
+5. Handle the response:
+   - If "keep trying" → reset the bot's re-trigger count and return to 12b
+   - If "skip this bot" → set `APPROVAL_REASON="bot-approval-exhausted-skip"`, follow **Incomplete Approval Outcome**, and stop
+   - If "exit" → set `APPROVAL_REASON="bot-approval-exhausted-exit"`, follow **Incomplete Approval Outcome**, and stop
+6. After re-triggering → return to 12b to wait again.

--- a/plugins/go-workflow/skills/address-review/watch-loop.md
+++ b/plugins/go-workflow/skills/address-review/watch-loop.md
@@ -36,20 +36,21 @@ If the user chooses a terminal path before every detected bot approves, do not r
 
 ```bash
 APPROVAL_REASON="${APPROVAL_REASON:?approval reason is required}"
-if [ ! -f "$LOOP_STATE_FILE" ]; then
+APPROVAL_STATE_FILE="${STATE_FILE:-${LOOP_STATE_FILE:-}}"
+if [ -z "$APPROVAL_STATE_FILE" ] || [ ! -f "$APPROVAL_STATE_FILE" ]; then
   echo "Error: Cannot persist incomplete approval outcome without loop state."
   exit 1
 fi
 
 source "${CLAUDE_PLUGIN_ROOT}/lib/loop-state.sh"
-set_loop_field "$LOOP_STATE_FILE" "approval_result" "incomplete"
-set_loop_field "$LOOP_STATE_FILE" "approval_reason" "$APPROVAL_REASON"
-set_loop_phase "$LOOP_STATE_FILE" "approval-incomplete"
-set_loop_field "$LOOP_STATE_FILE" "completion_promise" "INCOMPLETE"
+set_loop_field "$APPROVAL_STATE_FILE" "approval_result" "incomplete"
+set_loop_field "$APPROVAL_STATE_FILE" "approval_reason" "$APPROVAL_REASON"
+set_loop_phase "$APPROVAL_STATE_FILE" "approval-incomplete"
+set_loop_field "$APPROVAL_STATE_FILE" "completion_promise" "INCOMPLETE"
 echo "Address-review stopped without required bot approvals: $APPROVAL_REASON"
 ```
 
-After the state update succeeds, output `<done>INCOMPLETE</done>` and stop. The changed completion promise lets the stop hook accept the distinct terminal marker, while `approval_result` and `approval_reason` give callers a machine-readable outcome before loop cleanup.
+`STATE_FILE` is the caller-owned state used when ship consumes Steps 12a-12d; standalone address-review falls back to `LOOP_STATE_FILE`. After the state update succeeds, output `<done>INCOMPLETE</done>` and stop. The changed completion promise lets the active caller's stop hook accept the distinct terminal marker, while `approval_result` and `approval_reason` give callers a machine-readable outcome before loop cleanup.
 
 ---
 

--- a/scripts/legacy-skill-hashes.txt
+++ b/scripts/legacy-skill-hashes.txt
@@ -7,7 +7,7 @@
 # this prevents accepting a hash from skill A as proof of ownership for skill B.
 # DO NOT EDIT BY HAND — re-run the regen script after committing SKILL.md changes.
 #
-# Total entries: 238
+# Total entries: 239
 017e2d820506e7bef4a89a4d65839150db1ffdc124852a43dc916023e6d37e16 review-deep
 0322d4a7ddc204a9bf5addfec4e512edaea92ab8f4ebdd0541ca099330a09408 worktree
 03dac3a27d6da4b0a0c64ff6511df17004747e20b47a1691b4f9f030478877b9 commit
@@ -144,6 +144,7 @@
 93827094677dd44ce194ea2868e85eb54f1ded5c42fee3e0242155bd27505729 ship
 93b24a0632356acdab3440e60f304547d28bcf460bdb9d450317db273097bdd7 tmux-start
 93b9ddd56d963ce00681acc1b102a00fa51430b5bb7c2f0e112bc3beb7fa72f1 go-concurrency
+94d6b0b908d9b0823ce2908fcde0f3c821295a2140ce14c8e82112f5e4523aab address-review
 958cd292b8c8ce32bd161b6bdc6e21aaa95dc3b41683b1218d83b04c6b0de529 ship
 967e4973fe88ee1938651cb7c95e361361a0c9f32c4a3650193d5c3f48da2be6 second-opinion
 983506ba0af0089055cfccb8438ed22a166638d0f895dc1380caf09fdf7afb33 complete-issue

--- a/scripts/test-commands.sh
+++ b/scripts/test-commands.sh
@@ -176,6 +176,9 @@ if file_contains 'git add -A' "$ADDRESS_REVIEW_FIX_CYCLE"; then
 elif ! file_contains 'Stage only files modified during this fix cycle' "$ADDRESS_REVIEW_FIX_CYCLE"; then
   echo "FAIL (owned-file staging policy missing)"
   ERRORS=$((ERRORS + 1))
+elif ! file_contains 'git status --porcelain -- "$TARGET_FILE"' "$ADDRESS_REVIEW_FIX_CYCLE"; then
+  echo "FAIL (pre-existing target-file changes are not guarded)"
+  ERRORS=$((ERRORS + 1))
 elif ! file_contains 'git add -- "${OWNED_FILES[@]}"' "$ADDRESS_REVIEW_FIX_CYCLE"; then
   echo "FAIL (owned-file staging command missing)"
   ERRORS=$((ERRORS + 1))
@@ -192,6 +195,8 @@ elif ! file_contains 'approval_result' "$ADDRESS_REVIEW_WATCH_LOOP" ||
      ! file_contains 'approval_reason' "$ADDRESS_REVIEW_WATCH_LOOP" ||
      ! file_contains 'bot-approval-timeout' "$ADDRESS_REVIEW_WATCH_LOOP" ||
      ! file_contains 'bot-approval-exhausted' "$ADDRESS_REVIEW_WATCH_LOOP" ||
+     ! file_contains 'APPROVAL_STATE_FILE="${STATE_FILE:-${LOOP_STATE_FILE:-}}"' "$ADDRESS_REVIEW_WATCH_LOOP" ||
+     ! file_contains 'set_loop_field "$APPROVAL_STATE_FILE" "approval_result"' "$ADDRESS_REVIEW_WATCH_LOOP" ||
      ! file_contains 'completion_promise" "INCOMPLETE"' "$ADDRESS_REVIEW_WATCH_LOOP" ||
      ! file_contains '<done>INCOMPLETE</done>' "$ADDRESS_REVIEW_WATCH_LOOP"; then
   echo "FAIL (durable incomplete approval outcome contract missing)"

--- a/scripts/test-commands.sh
+++ b/scripts/test-commands.sh
@@ -168,6 +168,38 @@ else
   echo "OK"
 fi
 
+echo -n "Address-review stages only fix-cycle files... "
+ADDRESS_REVIEW_FIX_CYCLE="$ROOT_DIR/plugins/go-workflow/skills/address-review/fix-cycle.md"
+if file_contains 'git add -A' "$ADDRESS_REVIEW_FIX_CYCLE"; then
+  echo "FAIL (broad staging can capture unrelated worktree changes)"
+  ERRORS=$((ERRORS + 1))
+elif ! file_contains 'Stage only files modified during this fix cycle' "$ADDRESS_REVIEW_FIX_CYCLE"; then
+  echo "FAIL (owned-file staging policy missing)"
+  ERRORS=$((ERRORS + 1))
+elif ! file_contains 'git add -- "${OWNED_FILES[@]}"' "$ADDRESS_REVIEW_FIX_CYCLE"; then
+  echo "FAIL (owned-file staging command missing)"
+  ERRORS=$((ERRORS + 1))
+else
+  echo "OK"
+fi
+
+echo -n "Address-review records incomplete bot approval outcomes... "
+ADDRESS_REVIEW_WATCH_LOOP="$ROOT_DIR/plugins/go-workflow/skills/address-review/watch-loop.md"
+if file_contains 'If "exit" → output `<done>COMPLETE</done>`' "$ADDRESS_REVIEW_WATCH_LOOP"; then
+  echo "FAIL (timeout exit is mislabeled complete)"
+  ERRORS=$((ERRORS + 1))
+elif ! file_contains 'approval_result' "$ADDRESS_REVIEW_WATCH_LOOP" ||
+     ! file_contains 'approval_reason' "$ADDRESS_REVIEW_WATCH_LOOP" ||
+     ! file_contains 'bot-approval-timeout' "$ADDRESS_REVIEW_WATCH_LOOP" ||
+     ! file_contains 'bot-approval-exhausted' "$ADDRESS_REVIEW_WATCH_LOOP" ||
+     ! file_contains 'completion_promise" "INCOMPLETE"' "$ADDRESS_REVIEW_WATCH_LOOP" ||
+     ! file_contains '<done>INCOMPLETE</done>' "$ADDRESS_REVIEW_WATCH_LOOP"; then
+  echo "FAIL (durable incomplete approval outcome contract missing)"
+  ERRORS=$((ERRORS + 1))
+else
+  echo "OK"
+fi
+
 if ! "$ROOT_DIR/scripts/test-go-web-templates.sh"; then
   ERRORS=$((ERRORS + 1))
 fi


### PR DESCRIPTION
## Summary

- Stage only paths owned by the active review-fix cycle and stop when the index already contains unrelated staged work.
- Persist machine-readable timeout and retry-exhaustion reasons, and report `INCOMPLETE` instead of `COMPLETE` when required bot approvals are absent.
- Add regression contracts for safe staging and incomplete approval outcomes.

## Test Plan

- `./scripts/test-commands.sh`
- Validate all fenced shell blocks in the touched address-review skill files with `bash -n` and ShellCheck.
- Full configured Detent validation gate: command tests, hook tests, ship E2E gate, shared-sync check, ShellCheck, skill metadata/YAML checks, demo build, and Go tests.

Fixes #268