### PR TITLE
fix(go-workflow): harden browser e2e gate

### DIFF
--- a/.detent/skills/verify-mcp-stdio-compatibility.md
+++ b/.detent/skills/verify-mcp-stdio-compatibility.md
@@ -23,7 +23,10 @@ when_to_use: Use when auditing or pinning an MCP server after a protocol revisio
    rely on a documented tool count when source references can be enumerated.
 8. Capture non-JSON stdout separately from stderr because STDIO MCP requires
    stdout to contain protocol messages only.
-9. Verify at least one current client from each supported client family can
-   connect through an isolated configuration.
-10. Document the negotiated protocol, unsupported modern version, exact pin,
-    and non-MCP fallback behavior.
+9. After discovery succeeds, invoke one real stateful tool through each current
+   client. A successful connection and `tools/list` do not prove that the
+   server can launch its backing process or preserve tool-call state.
+10. Verify at least one current client from each supported client family can
+    connect through an isolated configuration.
+11. Document the negotiated protocol, unsupported modern version, exact pin,
+    discovery result, first-call result, and non-MCP fallback behavior.

--- a/plugins/go-workflow/lib/ship/local-review.md
+++ b/plugins/go-workflow/lib/ship/local-review.md
@@ -531,8 +531,12 @@ jq --arg required "false" --arg attempted "false" --arg result "skipped" --arg r
 
 Then skip to Step 8.
 
-If `UI_VISIBLE_CHANGES` is non-empty and Chrome DevTools MCP tools are missing,
-persist:
+Resolve the Chrome DevTools namespace from the available tools once. The
+official Chrome DevTools Claude plugin uses `mcp__chrome-devtools__*`; existing
+user configurations may expose `mcp__chrome-devtools-mcp__*`. Examples below
+show the latter, but invoke the namespace that is actually available. If
+`UI_VISIBLE_CHANGES` is non-empty and neither namespace provides the required
+browser tools, persist:
 
 ```bash
 TMP=".local/state/ship.loop.local.json.tmp"
@@ -608,6 +612,29 @@ No merge.
 
 Stop the workflow. Do not continue to push, CI watch, or merge.
 
+### Browser tool-call failures
+
+MCP connection and tool discovery prove only that the client and server can
+complete discovery. The first real browser call can still fail because the
+browser cannot launch, the selected page was lost, a tool schema changed, or
+the client/server connection churned. Treat any browser tool error before all
+required pages are inspected as a blocking runtime failure. A failure on the
+first call records zero pages; a later failure preserves the number already
+inspected. Never downgrade either case to skipped or passed.
+
+### Record browser tool-call failure
+
+```bash
+TMP=".local/state/ship.loop.local.json.tmp"
+jq --arg required "true" --arg attempted "true" --arg result "blocked" --arg reason "browser-tool-call-failed" --argjson pages "${PAGES_TESTED:-0}" \
+   '.e2e_required = $required | .e2e_attempted = $attempted | .e2e_result = $result | .e2e_skip_reason = $reason | .e2e_pages_tested = $pages' \
+   ".local/state/ship.loop.local.json" > "$TMP" && mv "$TMP" ".local/state/ship.loop.local.json"
+```
+
+Display the failed tool, route, and returned error, clean up a server started
+by the workflow, and stop. Do not retry against a reconnected MCP server in the
+same E2E result because its page selection and browser state are not proven.
+
 ### Execute smoke tests
 
 For each changed handler/route/template, identify the URL path and:
@@ -622,8 +649,9 @@ Record per page: URL, HTTP status, console errors, screenshot path.
 
 If any page has an unexpected 4xx/5xx status, console JavaScript errors, failed
 5xx network requests, browser tooling errors, or an uninspected screenshot,
-persist `e2e_result="blocked"` with an explanatory `e2e_skip_reason`, display
-the failed route(s), and stop the workflow. No merge.
+persist `e2e_result="blocked"` with an explanatory `e2e_skip_reason`. Browser
+tooling errors use the recording block above. Display the failed route(s) and
+stop the workflow. No merge.
 
 ### Cleanup and report
 

--- a/plugins/go-workflow/lib/ship/state-fields.md
+++ b/plugins/go-workflow/lib/ship/state-fields.md
@@ -46,9 +46,9 @@ routing and subsequent steps depend on these exact names.
 | `coverage_skip_reason` | string | Step E.3 of coverage-verification.md | Empty when computed; `"all-main"` when every changed file was `package main` |
 | `coverage_tests_generated` | int | Step F of coverage-verification.md | Count of new tests created |
 | `e2e_required` | string | Step 7.6 | `"true"` when the diff is UI-visible and browser E2E is required |
-| `e2e_attempted` | string | Step 7.6e | `"true"` when E2E ran |
+| `e2e_attempted` | string | Step 7.6e | `"true"` after the first browser tool call is issued, even when that call fails |
 | `e2e_result` | string | Step 7.6e | `"passed"` / `"blocked"` / `"skipped"`; `blocked` means required E2E did not pass and merge must stop |
-| `e2e_skip_reason` | string | Step 7.6e | Empty on pass; otherwise machine-readable reason such as `"no-ui-visible-changes"`, `"missing-browser-tooling"`, or `"dev-server-unavailable"` |
+| `e2e_skip_reason` | string | Step 7.6e | Empty on pass; otherwise machine-readable reason such as `"no-ui-visible-changes"`, `"missing-browser-tooling"`, `"browser-tool-call-failed"`, or `"dev-server-unavailable"` |
 | `e2e_pages_tested` | int | Step 7.6e | Number of routes tested |
 | `review_clean` | string | Step 5c | `"true"` when LLM returned no findings — fast-path past Step 6 on re-entry |
 | `review_result` | string | Step 2 recovery, Step 5 | `"void"` when a prior session's review expired or `"skipped"` when a headless worker cannot run it synchronously |

--- a/plugins/go-workflow/skills/e2e-verify/e2e-test-execution.md
+++ b/plugins/go-workflow/skills/e2e-verify/e2e-test-execution.md
@@ -209,11 +209,17 @@ tool calls. If `evaluate_script` is unavailable, use `wait_for` with a
 reasonable timeout before capturing.
 
 After `new_page`, `navigate_page`, or `resize_page`, compare the returned
-`url` with the route being tested. If a page-scoped tool schema exposes an
-explicit page identifier, pass the same identifier to every page-scoped call.
-Otherwise, the current server's selected page is connection state: never
-assume it survives a tool error or MCP reconnect. A mismatch or call error
-uses the `missing-browser-tooling` failure path in §5a.2.
+`url` with the route being tested. Allow an expected canonical or authentication redirect when the application behavior or login flow explains it, and continue
+against the redirected route. For an unexpected URL after a successful tool
+call, navigate to the intended route once more. If the tool still succeeds but
+returns an unexpected URL, record a route failure with `E2E_RESULT='fail'`;
+that is application behavior, not missing tooling.
+
+If a page-scoped tool schema exposes an explicit page identifier, pass the
+same identifier to every page-scoped call. Otherwise, the current server's
+selected page is connection state: never assume it survives a tool error or
+MCP reconnect. A tool error or a lost selected-page target uses the
+`missing-browser-tooling` failure path in §5a.2.
 
 Remove the `document.activeElement?.blur()` statement when testing a
 focus-dependent state such as validation, keyboard navigation, or an active

--- a/plugins/go-workflow/skills/e2e-verify/e2e-test-execution.md
+++ b/plugins/go-workflow/skills/e2e-verify/e2e-test-execution.md
@@ -19,10 +19,12 @@ Skipping is allowed only when there is genuinely nothing to verify. If there
 - No web-facing files were changed in the diff (both `WEB_CHANGES` and `HANDLER_CHANGES` empty), AND
 - The issue/PR body contains no layout-sensitive keywords (see §5a.1).
 
-**Fail** (set `E2E_RESULT="fail"` with the listed reason and stop E2E) when the
-diff IS UI-visible (see §5a.1) and:
+**Fail** (set `E2E_RESULT="missing-browser-tooling"` and stop E2E) when the diff
+IS UI-visible (see §5a.1) and:
 
-- Chrome DevTools MCP tools are NOT available (`mcp__chrome-devtools-mcp__navigate_page` not in the available tools list) → reason `missing-browser-tooling`.
+- Chrome DevTools MCP tools are NOT available
+  (neither `mcp__chrome-devtools__navigate_page` nor
+  `mcp__chrome-devtools-mcp__navigate_page` is in the available tools list).
 
 In every fail case, still proceed to Step 6 to post the failure comment so the
 gate in `SKILL.md` Step 7 can stop the workflow.
@@ -60,6 +62,21 @@ Both this step and `SKILL.md` §7 use the same definition. The diff is
 
 A UI-visible diff requires `E2E_RESULT=pass` to pass the Step 7 gate. A
 non-UI-visible diff is allowed to set `E2E_RESULT=skipped`.
+
+## 5a.2 MCP connection and callability
+
+The official Chrome DevTools Claude plugin exposes
+`mcp__chrome-devtools__*`; existing user configurations may expose
+`mcp__chrome-devtools-mcp__*`. Resolve the available namespace once and use it
+consistently. The examples below show the latter namespace.
+
+Tool discovery is not proof that the browser is usable. The server connects
+successfully but the first browser tool call fails, or a later call may fail
+after some routes were inspected. In either case, set
+`E2E_RESULT='missing-browser-tooling'`, preserve the actual `PAGES_TESTED`
+count, stop the E2E run, and proceed only to Step 6 so the failure is posted.
+Do not report `partial` or `skipped`, and do not continue after an MCP
+reconnection because the selected page and browser state are no longer proven.
 
 ## 5b. Load the Spec (REQUIRED — do this BEFORE any browser testing)
 
@@ -185,64 +202,84 @@ Detect if the app requires authentication:
 
 ## 5g. Visual Stabilization Protocol
 
-**Before every screenshot**, execute this stabilization sequence to ensure deterministic, accurate captures. Use `mcp__chrome-devtools-mcp__evaluate_script` to run the JavaScript snippets below. If `evaluate_script` is not available, at minimum use `wait_for` with a reasonable timeout before capturing.
+**Before every screenshot**, use
+`mcp__chrome-devtools-mcp__evaluate_script` once with the self-contained
+function below. One call avoids relying on JavaScript state created by earlier
+tool calls. If `evaluate_script` is unavailable, use `wait_for` with a
+reasonable timeout before capturing.
 
-1. **Wait for network idle** — inject and execute:
-   ```javascript
-   // Poll-based: wait until no new resource entries appear for 500ms
-   // This catches both existing in-flight and new requests
-   await new Promise(resolve => {
-     let lastCount = performance.getEntriesByType('resource').length;
-     let stableChecks = 0;
-     const interval = setInterval(() => {
-       const currentCount = performance.getEntriesByType('resource').length;
-       if (currentCount === lastCount) {
-         stableChecks++;
-         if (stableChecks >= 5) { // 5 × 100ms = 500ms stable
-           clearInterval(interval);
-           resolve();
-         }
-       } else {
-         lastCount = currentCount;
-         stableChecks = 0;
-       }
-     }, 100);
-     // Fallback: resolve after 5s regardless
-     setTimeout(() => { clearInterval(interval); resolve(); }, 5000);
-   });
-   ```
+After `new_page`, `navigate_page`, or `resize_page`, compare the returned
+`url` with the route being tested. If a page-scoped tool schema exposes an
+explicit page identifier, pass the same identifier to every page-scoped call.
+Otherwise, the current server's selected page is connection state: never
+assume it survives a tool error or MCP reconnect. A mismatch or call error
+uses the `missing-browser-tooling` failure path in §5a.2.
 
-2. **Wait for fonts and images** — inject and execute:
-   ```javascript
-   await document.fonts.ready;
-   await Promise.all(
-     Array.from(document.images)
-       .filter(img => !img.complete)
-       .map(img => new Promise(resolve => {
-         // Use addEventListener to avoid clobbering app handlers
-         img.addEventListener('load', resolve, { once: true });
-         img.addEventListener('error', resolve, { once: true });
-       }))
-   );
-   ```
+Remove the `document.activeElement?.blur()` statement when testing a
+focus-dependent state such as validation, keyboard navigation, or an active
+input.
 
-3. **Disable animations** — inject CSS to freeze all motion:
-   ```javascript
-   const style = document.createElement('style');
-   style.textContent = '*, *::before, *::after { animation-duration: 0s !important; transition-duration: 0s !important; scroll-behavior: auto !important; }';
-   document.head.appendChild(style);
-   ```
+```javascript
+async () => {
+  await new Promise(resolve => {
+    let lastCount = performance.getEntriesByType('resource').length;
+    let stableChecks = 0;
+    const finish = () => {
+      clearInterval(interval);
+      clearTimeout(deadline);
+      resolve();
+    };
+    const interval = setInterval(() => {
+      const currentCount = performance.getEntriesByType('resource').length;
+      if (currentCount === lastCount) {
+        stableChecks++;
+        if (stableChecks >= 5) {
+          finish();
+        }
+      } else {
+        lastCount = currentCount;
+        stableChecks = 0;
+      }
+    }, 100);
+    const deadline = setTimeout(finish, 5000);
+  });
 
-4. **Conditionally blur active element** — only blur if you are NOT testing a focus-dependent state (e.g., form validation errors, keyboard navigation, active input fields). If the current test is verifying a focused state, skip this step:
-   ```javascript
-   // Skip this if you're testing focus/validation states
-   document.activeElement?.blur();
-   ```
+  if (document.fonts?.ready) {
+    await Promise.race([
+      document.fonts.ready,
+      new Promise(resolve => setTimeout(resolve, 5000))
+    ]);
+  }
 
-5. **Brief settle** — allow a final paint:
-   ```javascript
-   await new Promise(resolve => setTimeout(resolve, 300));
-   ```
+  await Promise.race([
+    Promise.all(
+      Array.from(document.images)
+        .filter(image => !image.complete)
+        .map(image => new Promise(resolve => {
+          image.addEventListener('load', resolve, { once: true });
+          image.addEventListener('error', resolve, { once: true });
+        }))
+    ),
+    new Promise(resolve => setTimeout(resolve, 5000))
+  ]);
+
+  let style = document.getElementById('gopher-ai-e2e-stabilization');
+  if (!style) {
+    style = document.createElement('style');
+    style.id = 'gopher-ai-e2e-stabilization';
+    style.textContent = '*, *::before, *::after { animation-duration: 0s !important; transition-duration: 0s !important; scroll-behavior: auto !important; }';
+    document.head.appendChild(style);
+  }
+
+  document.activeElement?.blur();
+  await new Promise(resolve => requestAnimationFrame(() => requestAnimationFrame(resolve)));
+
+  return {
+    url: location.href,
+    readyState: document.readyState
+  };
+}
+```
 
 ## 5h. Route Testing (the core of E2E)
 
@@ -367,8 +404,9 @@ Collect results:
   `E2E_RESULT='fail'`.
 - Console JavaScript errors → record in findings. Not load-bearing on their
   own, but combined with a visual defect they reinforce the fail.
-- MCP tool call fails mid-test → `E2E_RESULT='fail'` with reason
-  `missing-browser-tooling`. The browser cannot inspect what it cannot reach.
+- MCP tool call fails on the first call or mid-test →
+  `E2E_RESULT='missing-browser-tooling'`. Preserve `PAGES_TESTED`; the browser
+  cannot inspect what it cannot reach.
 - Any route where a screenshot was taken but not read → contributes to
   `E2E_RESULT='uninspected-screenshots'` (also a fail).
 

--- a/plugins/go-workflow/skills/e2e-verify/pr-results-comment.md
+++ b/plugins/go-workflow/skills/e2e-verify/pr-results-comment.md
@@ -96,7 +96,8 @@ The Verification Outcome section is **required for every comment**, regardless
 of mode. It makes the gate visible to humans reading the PR.
 
 **Conditional sections:**
-- If E2E was skipped (MCP unavailable or no web components): replace the E2E Visual Verification Results section with: `*E2E tests skipped: $SKIP_REASON*`
+- If E2E was skipped because there are no web components: replace the E2E Visual Verification Results section with: `*E2E tests skipped: $SKIP_REASON*`
+- If E2E was blocked by unavailable or failed MCP tooling: replace the E2E Visual Verification Results section with: `*E2E tests blocked: missing browser tooling. Pages tested: $PAGES_TESTED.*`
 - If build failed: add a prominent warning at the top: `> **Build failed — E2E tests were not run.**`
 - If investigate mode: add an "Investigation Findings" section with gap analysis
 

--- a/scripts/test-ship-e2e-gate.sh
+++ b/scripts/test-ship-e2e-gate.sh
@@ -75,6 +75,10 @@ require_text "$E2E_EXECUTION" "first browser tool call fails" \
   "e2e verification must cover a connected server that fails on first use"
 require_text "$E2E_EXECUTION" "E2E_RESULT='missing-browser-tooling'" \
   "e2e verification must map runtime browser failures to a blocking result"
+require_text "$E2E_EXECUTION" "expected canonical or authentication redirect" \
+  "e2e verification must allow expected navigation redirects"
+reject_text "$E2E_EXECUTION" "A mismatch or call error" \
+  "e2e verification must not classify every URL mismatch as missing tooling"
 for skill_file in "$SHIP_SKILL" "$COMPLETE_ISSUE" "$E2E_SKILL"; do
   require_text "$skill_file" "mcp__chrome-devtools__\\*" \
     "$(basename "$(dirname "$skill_file")") must allow the official Chrome DevTools namespace"

--- a/scripts/test-ship-e2e-gate.sh
+++ b/scripts/test-ship-e2e-gate.sh
@@ -8,7 +8,6 @@ ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
 
 LOCAL_REVIEW="$ROOT_DIR/plugins/go-workflow/lib/ship/local-review.md"
 E2E_EXECUTION="$ROOT_DIR/plugins/go-workflow/skills/e2e-verify/e2e-test-execution.md"
-E2E_SKILL="$ROOT_DIR/plugins/go-workflow/skills/e2e-verify/SKILL.md"
 SHIP_SKILL="$ROOT_DIR/plugins/go-workflow/skills/ship/SKILL.md"
 MERGE_DOC="$ROOT_DIR/plugins/go-workflow/lib/ship/merge.md"
 STATE_FIELDS="$ROOT_DIR/plugins/go-workflow/lib/ship/state-fields.md"
@@ -79,12 +78,6 @@ require_text "$E2E_EXECUTION" "expected canonical or authentication redirect" \
   "e2e verification must allow expected navigation redirects"
 reject_text "$E2E_EXECUTION" "A mismatch or call error" \
   "e2e verification must not classify every URL mismatch as missing tooling"
-for skill_file in "$SHIP_SKILL" "$COMPLETE_ISSUE" "$E2E_SKILL"; do
-  require_text "$skill_file" "mcp__chrome-devtools__\\*" \
-    "$(basename "$(dirname "$skill_file")") must allow the official Chrome DevTools namespace"
-  require_text "$skill_file" "mcp__chrome-devtools-mcp__\\*" \
-    "$(basename "$(dirname "$skill_file")") must retain the legacy Chrome DevTools namespace"
-done
 
 BROWSER_FAILURE_BLOCK=$(mktemp "${TMPDIR:-/tmp}/gopher-ai-browser-failure-XXXXXX")
 BROWSER_FAILURE_TMP=$(mktemp -d "${TMPDIR:-/tmp}/gopher-ai-browser-failure-fixture-XXXXXX")

--- a/scripts/test-ship-e2e-gate.sh
+++ b/scripts/test-ship-e2e-gate.sh
@@ -7,6 +7,8 @@ SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
 
 LOCAL_REVIEW="$ROOT_DIR/plugins/go-workflow/lib/ship/local-review.md"
+E2E_EXECUTION="$ROOT_DIR/plugins/go-workflow/skills/e2e-verify/e2e-test-execution.md"
+E2E_SKILL="$ROOT_DIR/plugins/go-workflow/skills/e2e-verify/SKILL.md"
 SHIP_SKILL="$ROOT_DIR/plugins/go-workflow/skills/ship/SKILL.md"
 MERGE_DOC="$ROOT_DIR/plugins/go-workflow/lib/ship/merge.md"
 STATE_FIELDS="$ROOT_DIR/plugins/go-workflow/lib/ship/state-fields.md"
@@ -65,6 +67,64 @@ reject_text "$SHIP_SKILL" "skip coverage \\+ e2e phases entirely" \
   "ship skill still says --skip-coverage skips E2E entirely"
 reject_text "$SHIP_SKILL" "E2E smoke tests passed \\(or skipped .*[Mm]CP unavailable" \
   "ship completion criteria still allows MCP-unavailable E2E skip"
+require_text "$LOCAL_REVIEW" "browser-tool-call-failed" \
+  "ship local review must distinguish runtime browser failures from absent tooling"
+require_text "$E2E_EXECUTION" "server connects" \
+  "e2e verification must distinguish connection from callability"
+require_text "$E2E_EXECUTION" "first browser tool call fails" \
+  "e2e verification must cover a connected server that fails on first use"
+require_text "$E2E_EXECUTION" "E2E_RESULT='missing-browser-tooling'" \
+  "e2e verification must map runtime browser failures to a blocking result"
+for skill_file in "$SHIP_SKILL" "$COMPLETE_ISSUE" "$E2E_SKILL"; do
+  require_text "$skill_file" "mcp__chrome-devtools__\\*" \
+    "$(basename "$(dirname "$skill_file")") must allow the official Chrome DevTools namespace"
+  require_text "$skill_file" "mcp__chrome-devtools-mcp__\\*" \
+    "$(basename "$(dirname "$skill_file")") must retain the legacy Chrome DevTools namespace"
+done
+
+BROWSER_FAILURE_BLOCK=$(mktemp "${TMPDIR:-/tmp}/gopher-ai-browser-failure-XXXXXX")
+BROWSER_FAILURE_TMP=$(mktemp -d "${TMPDIR:-/tmp}/gopher-ai-browser-failure-fixture-XXXXXX")
+awk '
+  /^### Record browser tool-call failure$/ { section=1 }
+  section && /^```bash$/ { block=1; next }
+  block && /^```$/ { exit }
+  block { print }
+' "$LOCAL_REVIEW" > "$BROWSER_FAILURE_BLOCK"
+
+mkdir -p "$BROWSER_FAILURE_TMP/.local/state"
+printf '%s\n' \
+  '{"e2e_required":"true","e2e_attempted":"false","e2e_result":"passed","e2e_skip_reason":"","e2e_pages_tested":5}' \
+  > "$BROWSER_FAILURE_TMP/.local/state/ship.loop.local.json"
+
+BROWSER_FAILURE_STATE=$(cd "$BROWSER_FAILURE_TMP" && \
+  PAGES_TESTED=0 bash -c 'source "$1"' _ "$BROWSER_FAILURE_BLOCK" >/dev/null && \
+  jq -c '{
+    required: .e2e_required,
+    attempted: .e2e_attempted,
+    result: .e2e_result,
+    reason: .e2e_skip_reason,
+    pages: .e2e_pages_tested
+  }' .local/state/ship.loop.local.json)
+
+if [ "$BROWSER_FAILURE_STATE" != '{"required":"true","attempted":"true","result":"blocked","reason":"browser-tool-call-failed","pages":0}' ]; then
+  fail "connected server first-call failure must persist blocked attempted state"
+fi
+
+printf '%s\n' \
+  '{"e2e_required":"true","e2e_attempted":"true","e2e_result":"passed","e2e_skip_reason":"","e2e_pages_tested":2}' \
+  > "$BROWSER_FAILURE_TMP/.local/state/ship.loop.local.json"
+
+PARTIAL_BROWSER_FAILURE_STATE=$(cd "$BROWSER_FAILURE_TMP" && \
+  PAGES_TESTED=2 bash -c 'source "$1"' _ "$BROWSER_FAILURE_BLOCK" >/dev/null && \
+  jq -c '{result: .e2e_result, reason: .e2e_skip_reason, pages: .e2e_pages_tested}' \
+    .local/state/ship.loop.local.json)
+
+if [ "$PARTIAL_BROWSER_FAILURE_STATE" != '{"result":"blocked","reason":"browser-tool-call-failed","pages":2}' ]; then
+  fail "mid-run browser failure must remain blocked and preserve inspected pages"
+fi
+
+rm -f "$BROWSER_FAILURE_BLOCK"
+rm -rf "$BROWSER_FAILURE_TMP"
 
 require_text "$SHIP_SKILL" "SHIP_MERGE_STRATEGY.*--squash.*--rebase.*--merge" \
   "ship skill must document explicit strategy before squash-first fallback"
@@ -82,9 +142,9 @@ require_text "$MERGE_DOC" "Configured merge strategy.*is not allowed" \
 require_text "$MERGE_DOC" "gh pr merge \"\\\$PR_NUM\" --delete-branch" \
   "ship merge queues must omit the merge-strategy flag"
 
-MERGE_STRATEGY_BLOCK=$(mktemp /tmp/gopher-ai-merge-strategy-XXXXXX)
-MERGE_FIXTURE_PLUGIN_ROOT=$(mktemp -d /tmp/gopher-ai-merge-fixture-XXXXXX)
-MERGE_FIXTURE_WORKTREE=$(mktemp -d /tmp/gopher-ai-merge-worktree-XXXXXX)
+MERGE_STRATEGY_BLOCK=$(mktemp "${TMPDIR:-/tmp}/gopher-ai-merge-strategy-XXXXXX")
+MERGE_FIXTURE_PLUGIN_ROOT=$(mktemp -d "${TMPDIR:-/tmp}/gopher-ai-merge-fixture-XXXXXX")
+MERGE_FIXTURE_WORKTREE=$(mktemp -d "${TMPDIR:-/tmp}/gopher-ai-merge-worktree-XXXXXX")
 mkdir -p "$MERGE_FIXTURE_PLUGIN_ROOT/scripts"
 cp "$ROOT_DIR/plugins/go-workflow/scripts/cleanup-loop.sh" "$MERGE_FIXTURE_PLUGIN_ROOT/scripts/cleanup-loop.sh"
 awk '
@@ -263,7 +323,7 @@ fi
 rm -f "$CI_SHIFT_BLOCK"
 rm -rf "$DIRTY_HEAD_SHIFT_TMP"
 
-HEADLESS_TMP=$(mktemp -d /tmp/ship-headless-e2e-XXXXXX)
+HEADLESS_TMP=$(mktemp -d "${TMPDIR:-/tmp}/ship-headless-e2e-XXXXXX")
 mkdir -p "$HEADLESS_TMP/.local/state" "$HEADLESS_TMP/hooks" "$HEADLESS_TMP/lib"
 cp "$STOP_HOOK" "$HEADLESS_TMP/hooks/stop-hook.sh"
 cp "$LOOP_LIB" "$HEADLESS_TMP/lib/loop-state.sh"


### PR DESCRIPTION
## Summary

- accept both the official and legacy Chrome DevTools MCP namespaces without enumerating individual browser tools
- block UI-visible shipping when a connected browser server fails on its first or a later tool call while preserving partial inspection evidence
- make screenshot stabilization self-contained and reject page state after MCP reconnects
- strengthen the reusable STDIO compatibility audit with a real post-discovery tool call

## Test Plan

- `./scripts/test-ship-e2e-gate.sh`
- `./scripts/test-installation.sh`
- full configured repository validation gate
- Claude Code 2.1.220 compatibility probe against chrome-devtools-mcp 1.6.0
- direct MCP 2026-07-28 discovery probe plus 2025-11-25 fallback initialization and tool audit

Fixes #261