### PR TITLE
docs(codex): qualify workflow skill names

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -28,6 +28,9 @@ jobs:
       - name: Probe Default-mode shared-skill input behavior
         run: python3 ./scripts/test-codex-default-mode-input.py
 
+      - name: Probe qualified go-workflow skill names
+        run: python3 ./scripts/test-codex-skill-names.py
+
   test-installation:
     runs-on: ubuntu-latest
     steps:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,30 +21,31 @@ The Codex plugin set currently includes `go-workflow`, `go-dev`, `gopher-guides`
 
 ## Workflow Skills (go-workflow plugin)
 
-Invoke explicitly with `$skill-name`:
+Invoke explicitly with `$go-workflow:<skill-name>`. Codex does not resolve bare
+skill names as aliases.
 
 | Skill | Description |
 |-------|-------------|
-| `$start-issue <number>` | Full issue-to-PR workflow: fetch, branch, TDD, verify, submit |
-| `$create-worktree <number>` | Create isolated git worktree for an issue or PR |
-| `$commit` | Auto-generate conventional commit message |
-| `$create-pr` | Create PR following repo template |
-| `$ship` | Ship a PR: verify, push, create PR, watch CI, merge |
-| `$remove-worktree` | Interactively remove a single worktree |
-| `$prune-worktree` | Batch cleanup of completed worktrees |
-| `$review-deep [PR]` | Deep code review with full PR/issue context, then fix findings |
+| `$go-workflow:start-issue <number>` | Full issue-to-PR workflow: fetch, branch, TDD, verify, submit |
+| `$go-workflow:worktree create <number>` | Create isolated git worktree for an issue or PR |
+| `$go-workflow:commit` | Auto-generate conventional commit message |
+| `$go-workflow:create-pr` | Create PR following repo template |
+| `$go-workflow:ship` | Ship a PR: verify, push, create PR, watch CI, merge |
+| `$go-workflow:worktree remove` | Interactively remove a single worktree |
+| `$go-workflow:worktree prune` | Batch cleanup of completed worktrees |
+| `$go-workflow:review-deep [PR]` | Deep code review with full PR/issue context, then fix findings |
 
 ### Example Workflow
 
 ```
-$start-issue 42
+$go-workflow:start-issue 42
 # Codex fetches the issue, creates a worktree, detects bug vs feature,
 # guides you through TDD implementation, verifies, and creates a PR.
 
-$ship
+$go-workflow:ship
 # Verifies build/tests/lint, pushes, watches CI, and merges.
 
-$prune-worktree
+$go-workflow:worktree prune
 # Cleans up worktrees for closed issues.
 ```
 

--- a/README.md
+++ b/README.md
@@ -149,7 +149,7 @@ Workflow skill invocation modes:
 | Slash-only | `start-issue`, `address-review`, `worktree` (`/create-worktree`, `/remove-worktree`, `/prune-worktree`), `e2e-verify`, `ship`, `complete-issue`, `tmux-start` |
 | Auto-triggerable | `commit`, `create-pr`, `review-deep` |
 
-Slash-only skills require explicit invocation, and their descriptions are omitted from the always-loaded auto-invoked skill list. Use `/go-workflow:<command>` in Claude Code or `$<skill>` in Codex. In Claude Code, type the slash command directly; `$start-issue` is Codex syntax and causes a blocked Skill-tool invocation. Auto-triggerable skills remain available from natural-language requests such as "commit these changes" or "review my changes".
+Slash-only skills require explicit invocation, and their descriptions are omitted from the always-loaded auto-invoked skill list. Use `/go-workflow:<command>` in Claude Code or `$go-workflow:<skill>` in Codex. Codex requires the qualified plugin name; bare skill names are not resolver aliases. In Claude Code, type the slash command directly; `$go-workflow:start-issue` is Codex syntax and causes a blocked Skill-tool invocation. Auto-triggerable skills remain available from natural-language requests such as "commit these changes" or "review my changes".
 
 The `start-issue` skill handles the full issue-to-PR workflow:
 1. Fetches issue details including all comments
@@ -324,14 +324,14 @@ To migrate manually: `./scripts/install-codex.sh --user` (refresh the marketplac
 **Workflow skills** (from `go-workflow` plugin):
 
 ```
-$start-issue 42    # Full issue-to-PR workflow
-$review-deep       # Deep review with full PR/issue context + fix
-$create-worktree 42  # Create isolated worktree
-$commit            # Auto-generate commit message
-$create-pr         # Create PR with template
-$ship              # Verify, push, CI watch, merge
-$remove-worktree   # Remove a single worktree
-$prune-worktree    # Batch cleanup completed worktrees
+$go-workflow:start-issue 42     # Full issue-to-PR workflow
+$go-workflow:review-deep        # Deep review with full PR/issue context + fix
+$go-workflow:worktree create 42 # Create isolated worktree
+$go-workflow:commit             # Auto-generate commit message
+$go-workflow:create-pr          # Create PR with template
+$go-workflow:ship               # Verify, push, CI watch, merge
+$go-workflow:worktree remove    # Remove a single worktree
+$go-workflow:worktree prune     # Batch cleanup completed worktrees
 ```
 
 ### Google Gemini CLI

--- a/plugins/go-workflow/README.md
+++ b/plugins/go-workflow/README.md
@@ -35,7 +35,7 @@ Or install via marketplace:
 | Slash-only | `start-issue`, `address-review`, `worktree` (`/create-worktree`, `/remove-worktree`, `/prune-worktree`), `e2e-verify`, `ship`, `complete-issue`, `tmux-start` |
 | Auto-triggerable | `commit`, `create-pr`, `review-deep` |
 
-Slash-only skills still run through their slash commands, but their descriptions are omitted from the always-loaded auto-invoked skill list. Use `/go-workflow:<command>` in Claude Code or `$<skill>` in Codex. In Claude Code, type the slash command directly; `$start-issue` is Codex syntax and causes a blocked Skill-tool invocation. Auto-triggerable skills remain available from natural-language requests such as "commit these changes" or "review my changes".
+Slash-only skills still run through their slash commands, but their descriptions are omitted from the always-loaded auto-invoked skill list. Use `/go-workflow:<command>` in Claude Code or `$go-workflow:<skill>` in Codex. Codex requires the qualified plugin name; bare skill names are not resolver aliases. In Claude Code, type the slash command directly; `$go-workflow:start-issue` is Codex syntax and causes a blocked Skill-tool invocation. Auto-triggerable skills remain available from natural-language requests such as "commit these changes" or "review my changes".
 
 ## Workflows
 
@@ -63,20 +63,22 @@ rolling model aliases in agent prompt frontmatter:
 | Spec Review | Sonnet |
 | Quality Review | Sonnet |
 
-Set `CLAUDE_CODE_SUBAGENT_MODEL=<model>` before running `$start-issue` or
-`$complete-issue` to override all subagent models for that run. Use
+Set `CLAUDE_CODE_SUBAGENT_MODEL=<model>` before running
+`$go-workflow:start-issue` or `$go-workflow:complete-issue` to override all
+subagent models for that run. Use
 `--no-agents` to switch to the single-session workflow.
 
 #### Codex Model Defaults
 
-The `$ship` and `$complete-issue` Codex review stages omit model flags by
-default. A `model = "..."` pin in `~/.codex/config.toml` overrides the provider
-default for those stages; leaving it unset lets the Codex CLI use its latest
-recommended model automatically.
+The `$go-workflow:ship` and `$go-workflow:complete-issue` Codex review stages
+omit model flags by default. A `model = "..."` pin in `~/.codex/config.toml`
+overrides the provider default for those stages; leaving it unset lets the
+Codex CLI use its latest recommended model automatically.
 
 ### Address Review
 
-The `$address-review` skill handles PR review feedback automatically:
+The `$go-workflow:address-review` skill handles PR review feedback
+automatically:
 
 1. **Fetches all feedback** - Review threads (line comments) and pending reviews
 2. **Addresses each comment** - Makes code fixes based on feedback

--- a/scripts/test-codex-skill-names.py
+++ b/scripts/test-codex-skill-names.py
@@ -1,0 +1,197 @@
+#!/usr/bin/env python3
+
+import json
+import os
+import queue
+import re
+import subprocess
+import tempfile
+import threading
+import time
+from pathlib import Path
+
+
+ROOT_DIR = Path(__file__).resolve().parent.parent
+DOCUMENTATION_FILES = (
+    ROOT_DIR / "AGENTS.md",
+    ROOT_DIR / "README.md",
+    ROOT_DIR / "plugins/go-workflow/README.md",
+)
+QUALIFIED_SKILL_PATTERN = re.compile(r"\$(go-workflow:[a-z][a-z0-9-]*)")
+BARE_SKILL_PATTERN = re.compile(r"\$([a-z][a-z0-9-]*)")
+WORKTREE_SLASH_COMMANDS = {"create-worktree", "remove-worktree", "prune-worktree"}
+
+
+class AppServerClient:
+    def __init__(self, env):
+        self.process = subprocess.Popen(
+            ["codex", "app-server", "--stdio"],
+            stdin=subprocess.PIPE,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+            bufsize=1,
+            env=env,
+        )
+        self.messages = queue.Queue()
+        self.stderr = []
+        self.next_request_id = 1
+        self.stdout_thread = threading.Thread(target=self.read_stdout, daemon=True)
+        self.stderr_thread = threading.Thread(target=self.read_stderr, daemon=True)
+        self.stdout_thread.start()
+        self.stderr_thread.start()
+
+    def read_stdout(self):
+        for line in self.process.stdout:
+            self.messages.put(json.loads(line))
+        self.messages.put(None)
+
+    def read_stderr(self):
+        self.stderr.extend(self.process.stderr)
+
+    def send(self, message):
+        self.process.stdin.write(json.dumps(message, separators=(",", ":")) + "\n")
+        self.process.stdin.flush()
+
+    def request(self, method, params):
+        request_id = self.next_request_id
+        self.next_request_id += 1
+        self.send({"method": method, "id": request_id, "params": params})
+        deadline = time.monotonic() + 15
+        deferred = []
+        while time.monotonic() < deadline:
+            try:
+                message = self.messages.get(timeout=deadline - time.monotonic())
+            except queue.Empty as error:
+                raise AssertionError(f"timed out waiting for {method}") from error
+            if message is None:
+                raise AssertionError(
+                    f"app-server exited while waiting for {method}: {''.join(self.stderr)}"
+                )
+            if message.get("id") == request_id:
+                if "error" in message:
+                    raise AssertionError(f"{method} failed: {message['error']}")
+                for item in deferred:
+                    self.messages.put(item)
+                return message["result"]
+            deferred.append(message)
+        raise AssertionError(f"timed out waiting for {method}")
+
+    def close(self):
+        if self.process.poll() is None:
+            self.process.terminate()
+            try:
+                self.process.wait(timeout=5)
+            except subprocess.TimeoutExpired:
+                self.process.kill()
+                self.process.wait(timeout=5)
+
+
+def run_codex(env, *args):
+    subprocess.run(
+        ["codex", *args],
+        cwd=ROOT_DIR,
+        env=env,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+
+def documented_skill_names():
+    names = set()
+    for path in DOCUMENTATION_FILES:
+        names.update(QUALIFIED_SKILL_PATTERN.findall(path.read_text(encoding="utf-8")))
+    if not names:
+        raise AssertionError("documentation contains no qualified go-workflow skills")
+    return names
+
+
+def documented_bare_names():
+    names = set()
+    for path in DOCUMENTATION_FILES:
+        names.update(BARE_SKILL_PATTERN.findall(path.read_text(encoding="utf-8")))
+    return names
+
+
+def main():
+    temp_base = os.environ.get("TMPDIR") or os.environ.get("TMP") or os.environ.get("TEMP")
+    with tempfile.TemporaryDirectory(prefix="gopher-ai-skill-names-", dir=temp_base) as root:
+        test_root = Path(root)
+        codex_home = test_root / ".codex"
+        codex_home.mkdir()
+        env = os.environ.copy()
+        env.update({"HOME": str(test_root), "CODEX_HOME": str(codex_home)})
+
+        run_codex(env, "plugin", "marketplace", "add", str(ROOT_DIR), "--json")
+        run_codex(env, "plugin", "add", "go-workflow@gopher-ai", "--json")
+
+        client = AppServerClient(env)
+        try:
+            client.request(
+                "initialize",
+                {
+                    "clientInfo": {
+                        "name": "gopher_ai_skill_name_probe",
+                        "title": "Gopher AI Skill Name Probe",
+                        "version": "1.0.0",
+                    },
+                    "capabilities": {"experimentalApi": True},
+                },
+            )
+            client.send({"method": "initialized", "params": {}})
+            response = client.request(
+                "skills/list",
+                {"cwds": [str(ROOT_DIR)], "forceReload": True},
+            )
+        finally:
+            client.close()
+
+        if len(response["data"]) != 1:
+            raise AssertionError(
+                f"expected one workspace entry, got {len(response['data'])}"
+            )
+
+        entry = response["data"][0]
+        if entry["errors"]:
+            raise AssertionError(f"skills/list returned errors: {entry['errors']}")
+
+        resolver_names = {skill["name"] for skill in entry["skills"]}
+        workflow_resolver_names = {
+            name for name in resolver_names if name.startswith("go-workflow:")
+        }
+        documented_names = documented_skill_names()
+        missing_names = documented_names - resolver_names
+        if missing_names:
+            raise AssertionError(
+                f"documented skills missing from skills/list: {sorted(missing_names)}"
+            )
+
+        bare_aliases = {
+            name.removeprefix("go-workflow:") for name in documented_names
+        } & resolver_names
+        if bare_aliases:
+            raise AssertionError(
+                f"skills/list unexpectedly advertised bare aliases: {sorted(bare_aliases)}"
+            )
+
+        resolver_suffixes = {
+            name.removeprefix("go-workflow:") for name in workflow_resolver_names
+        }
+        bare_references = documented_bare_names() & (
+            resolver_suffixes | WORKTREE_SLASH_COMMANDS
+        )
+        if bare_references:
+            raise AssertionError(
+                "documentation contains bare Codex skill references: "
+                f"{sorted(bare_references)}"
+            )
+
+    print(
+        "Codex qualified skill-name probe passed: "
+        + ", ".join(sorted(documented_names))
+    )
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

- qualify Codex workflow skill invocations with the `go-workflow` plugin name
- document that bare names are not resolver aliases and route worktree actions through the actual `worktree` skill
- add a live app-server smoke probe that verifies documented names against `skills/list`

Fixes #270

## Test Plan

- `python3 ./scripts/test-codex-skill-names.py`
- configured repository validation gate (command, hook, ship E2E, shared-sync, shell, YAML, build, and Go test checks)