### PR TITLE
fix(build): use configured archive temp dir

### DIFF
--- a/scripts/build-universal.sh
+++ b/scripts/build-universal.sh
@@ -508,10 +508,14 @@ create_archive() {
     local source_dir="$1"
     local archive="$2"
     local archive_tar="${archive%.gz}"
+    local temp_base="${TMPDIR:-${TMP:-${TEMP:-/tmp}}}"
     local member_list
     local tar_owner_args
 
-    member_list=$(mktemp)
+    if ! member_list=$(mktemp "${temp_base%/}/gopher-ai-archive-members.XXXXXX"); then
+        echo "error: failed to allocate archive member list in $temp_base" >&2
+        return 1
+    fi
     find "$source_dir" -depth \( -name '._*' -o -name '.DS_Store' \) -delete
     find "$source_dir" -type d -exec chmod 0755 {} +
     find "$source_dir" -type f -perm -0100 -exec chmod 0755 {} +

--- a/scripts/build-universal.sh
+++ b/scripts/build-universal.sh
@@ -512,6 +512,9 @@ create_archive() {
     local member_list
     local tar_owner_args
 
+    if [[ "$temp_base" != /* ]]; then
+        temp_base="$PWD/$temp_base"
+    fi
     if ! member_list=$(mktemp "${temp_base%/}/gopher-ai-archive-members.XXXXXX"); then
         echo "error: failed to allocate archive member list in $temp_base" >&2
         return 1

--- a/scripts/test-installation.sh
+++ b/scripts/test-installation.sh
@@ -136,14 +136,64 @@ else
   echo "OK"
 fi
 
-echo -n "Codex distribution builds... "
-if ! "$ROOT_DIR/scripts/build-universal.sh" >/tmp/gopher-ai-build.log 2>&1; then
-  echo "FAIL"
-  sed -n '1,120p' /tmp/gopher-ai-build.log
+ARCHIVE_TEMP_BASE="${TMPDIR:-${TMP:-${TEMP:-/tmp}}}"
+ARCHIVE_TEMP_TEST_ROOT=$(mktemp -d "$ARCHIVE_TEMP_BASE/gopher-ai-universal-archive.XXXXXX")
+ARCHIVE_TEMP_DIR="$ARCHIVE_TEMP_TEST_ROOT/configured"
+ARCHIVE_MKTEMP_BIN="$ARCHIVE_TEMP_TEST_ROOT/bin"
+ARCHIVE_MKTEMP_LOG="$ARCHIVE_TEMP_TEST_ROOT/mktemp.log"
+ARCHIVE_REAL_MKTEMP=$(type -P mktemp)
+mkdir -p "$ARCHIVE_TEMP_DIR" "$ARCHIVE_MKTEMP_BIN"
+printf '%s\n' \
+  '#!/bin/sh' \
+  "printf '%s\n' \"\$*\" >> \"\${GOPHER_AI_MKTEMP_LOG:?}\"" \
+  "if [ \"\${GOPHER_AI_MKTEMP_FAIL:-false}\" = true ]; then exit 73; fi" \
+  "exec \"\${GOPHER_AI_REAL_MKTEMP:?}\" \"\$@\"" \
+  > "$ARCHIVE_MKTEMP_BIN/mktemp"
+chmod +x "$ARCHIVE_MKTEMP_BIN/mktemp"
+
+echo -n "Archive allocation failures stop universal builds... "
+if PATH="$ARCHIVE_MKTEMP_BIN:$PATH" \
+  GOPHER_AI_MKTEMP_FAIL=true \
+  GOPHER_AI_MKTEMP_LOG="$ARCHIVE_MKTEMP_LOG" \
+  GOPHER_AI_REAL_MKTEMP="$ARCHIVE_REAL_MKTEMP" \
+  TMPDIR="$ARCHIVE_TEMP_DIR" \
+  TMP="$ARCHIVE_TEMP_TEST_ROOT/unused-tmp" \
+  TEMP="$ARCHIVE_TEMP_TEST_ROOT/unused-temp" \
+  "$ROOT_DIR/scripts/build-universal.sh" >"$ARCHIVE_TEMP_TEST_ROOT/failure.log" 2>&1; then
+  echo "FAIL (build succeeded)"
+  ERRORS=$((ERRORS + 1))
+elif compgen -G "$ROOT_DIR/dist/*.tar.gz" >/dev/null; then
+  echo "FAIL (archive created)"
   ERRORS=$((ERRORS + 1))
 else
   echo "OK"
 fi
+
+echo -n "Universal archives use the configured temp directory... "
+: > "$ARCHIVE_MKTEMP_LOG"
+if ! PATH="$ARCHIVE_MKTEMP_BIN:$PATH" \
+  GOPHER_AI_MKTEMP_LOG="$ARCHIVE_MKTEMP_LOG" \
+  GOPHER_AI_REAL_MKTEMP="$ARCHIVE_REAL_MKTEMP" \
+  TMPDIR="$ARCHIVE_TEMP_DIR" \
+  TMP="$ARCHIVE_TEMP_TEST_ROOT/unused-tmp" \
+  TEMP="$ARCHIVE_TEMP_TEST_ROOT/unused-temp" \
+  "$ROOT_DIR/scripts/build-universal.sh" >"$ARCHIVE_TEMP_TEST_ROOT/build.log" 2>&1; then
+  echo "FAIL (build failed)"
+  sed -n '1,120p' "$ARCHIVE_TEMP_TEST_ROOT/build.log"
+  ERRORS=$((ERRORS + 1))
+else
+  EXPECTED_ARCHIVE_TEMPLATE="$ARCHIVE_TEMP_DIR/gopher-ai-archive-members.XXXXXX"
+  if ! awk -v expected="$EXPECTED_ARCHIVE_TEMPLATE" \
+    '$0 != expected { exit 1 } END { exit NR == 2 ? 0 : 1 }' \
+    "$ARCHIVE_MKTEMP_LOG"; then
+    echo "FAIL (unexpected mktemp arguments)"
+    sed -n '1,20p' "$ARCHIVE_MKTEMP_LOG"
+    ERRORS=$((ERRORS + 1))
+  else
+    echo "OK"
+  fi
+fi
+rm -rf "$ARCHIVE_TEMP_TEST_ROOT"
 
 EXPECTED_VERSION=$(jq -r '.metadata.version' "$ROOT_DIR/.claude-plugin/marketplace.json")
 CODEX_RELEASE_ASSET="$ROOT_DIR/dist/gopher-ai-codex-plugins-v${EXPECTED_VERSION}.tar.gz"

--- a/scripts/test-installation.sh
+++ b/scripts/test-installation.sh
@@ -171,13 +171,16 @@ fi
 
 echo -n "Universal archives use the configured temp directory... "
 : > "$ARCHIVE_MKTEMP_LOG"
-if ! PATH="$ARCHIVE_MKTEMP_BIN:$PATH" \
-  GOPHER_AI_MKTEMP_LOG="$ARCHIVE_MKTEMP_LOG" \
-  GOPHER_AI_REAL_MKTEMP="$ARCHIVE_REAL_MKTEMP" \
-  TMPDIR="$ARCHIVE_TEMP_DIR" \
-  TMP="$ARCHIVE_TEMP_TEST_ROOT/unused-tmp" \
-  TEMP="$ARCHIVE_TEMP_TEST_ROOT/unused-temp" \
-  "$ROOT_DIR/scripts/build-universal.sh" >"$ARCHIVE_TEMP_TEST_ROOT/build.log" 2>&1; then
+if ! (
+  cd "$ARCHIVE_TEMP_TEST_ROOT"
+  PATH="$ARCHIVE_MKTEMP_BIN:$PATH" \
+    GOPHER_AI_MKTEMP_LOG="$ARCHIVE_MKTEMP_LOG" \
+    GOPHER_AI_REAL_MKTEMP="$ARCHIVE_REAL_MKTEMP" \
+    TMPDIR="configured" \
+    TMP="$ARCHIVE_TEMP_TEST_ROOT/unused-tmp" \
+    TEMP="$ARCHIVE_TEMP_TEST_ROOT/unused-temp" \
+    "$ROOT_DIR/scripts/build-universal.sh" >"$ARCHIVE_TEMP_TEST_ROOT/build.log" 2>&1
+); then
   echo "FAIL (build failed)"
   sed -n '1,120p' "$ARCHIVE_TEMP_TEST_ROOT/build.log"
   ERRORS=$((ERRORS + 1))


### PR DESCRIPTION
## Summary

- resolve archive member-list temp files from `TMPDIR`, `TMP`, `TEMP`, then `/tmp`
- normalize relative configured temp directories before archive creation changes directories
- pass an explicit macOS-compatible template to `mktemp` and fail archive creation on allocation errors
- cover configured-directory precedence, relative paths, and forced allocation failure

Fixes #265

## Test Plan

- `bash -n scripts/build-universal.sh scripts/test-installation.sh`
- `shellcheck scripts/build-universal.sh scripts/test-installation.sh`
- `./scripts/test-installation.sh`
- configured repository validation gate (command tests, hooks, ship E2E gate, shared sync, Agent Skills checks, demo build/tests)