### PR TITLE
refactor(detent): reduce workflow protocol

### DIFF
--- a/WORKFLOW.md
+++ b/WORKFLOW.md
@@ -33,9 +33,9 @@ Use the current Detent state as the source of truth for which section applies.
 
 1. Move the issue to `In Progress`.
 2. Initialize the Workpad with the plan, acceptance criteria, validation plan, and `in_progress` status.
-3. Fetch `origin/main`, confirm the Detent worktree base, resolve dependencies, then follow `$go-workflow:start-issue <number>`.
+3. Fetch `origin/main`, confirm the Detent worktree base, resolve dependencies, then follow `$go-workflow:start-issue <number>` through PR creation and current-head CI.
 4. Run focused checks and the configured validation gate.
-5. Follow `$go-workflow:commit`, `$go-workflow:create-pr`, and `$go-workflow:address-review`.
+5. Follow `$go-workflow:address-review` for any PR feedback.
 6. Leave the issue in `In Progress`. Set Workpad `status: complete` with no blockers or human action only when the PR is non-draft, references the issue, validation and current-head CI are green, and no actionable review remains. Detent auto-promotes directly to `Merging`; never use `Human Review`.
 
 ### For In Progress

--- a/WORKFLOW.md
+++ b/WORKFLOW.md
@@ -1,17 +1,15 @@
 You are working on {{ issue.identifier }}: {{ issue.title }}.
 Current Detent status: {{ issue.state }}.
 
-Follow AGENTS.md, CLAUDE.md, and README.md in this repository. This repository
-is the Gopher AI cross-platform plugin toolkit for Claude Code, OpenAI Codex
-CLI, and Google Gemini CLI. Keep changes scoped to the issue and preserve the
-repo's plugin architecture under `.agents/plugins`, `.claude-plugin`, and
+Follow AGENTS.md, CLAUDE.md, and README.md. Keep changes scoped to the issue and
+preserve the plugin architecture under `.agents/plugins`, `.claude-plugin`, and
 `plugins/<name>/`.
 
-Keep a single persistent `## Codex Workpad` issue comment updated with the
-plan, validation evidence, blockers, and final handoff. Every Workpad update
-must include one `detent-status` fenced block. Detent reads blocker and
-human-action declarations from that block; narrative sentences are never read
-as blockers.
+## Detent Protocol
+
+Keep one persistent `## Codex Workpad` issue comment updated with the plan, validation
+evidence, blockers, and final handoff. Every update must contain one `detent-status`
+fenced block; Detent reads blockers and human actions only there, never from prose.
 
 ```detent-status
 schema: 1
@@ -20,101 +18,43 @@ blockers: []
 human_action: null
 ```
 
-For dependency blockers, use this order:
+Before coding, resolve every native dependency, Workpad blocker, and issue-body
+`Depends on:` reference. For a dependency blocker, create GitHub's native
+`blocked_by` relation first, then set Workpad `status: blocked` and list its
+`ref` and `reason`. Use an issue-body reference only as a legacy fallback.
 
-1. Create GitHub's native `blocked_by` dependency relation.
+Run the authoritative validation command from `gate.run` in `detent.yaml`; never duplicate it here.
 
-```sh
-BLOCKED_NUMBER=<blocked-issue-number>
-BLOCKER_NUMBER=<blocker-issue-number>
-BLOCKER_ID="$(gh api repos/{owner}/{repo}/issues/$BLOCKER_NUMBER --jq '.id')"
-gh api --method POST "repos/{owner}/{repo}/issues/$BLOCKED_NUMBER/dependencies/blocked_by" -F issue_id="$BLOCKER_ID"
-```
-
-2. Declare the blocker in the Workpad status block.
-
-```detent-status
-schema: 1
-status: blocked
-blockers:
-  - ref: "owner/repo#123"
-    reason: "waiting for the dependency to merge"
-human_action: null
-```
-
-3. Legacy fallback during the deprecation window: if native dependencies are
-   unavailable and the project has not migrated, keep a machine-readable
-   issue-body line such as `Blocked by: #123` or `Depends on: owner/repo#123`.
-
-The configured validation gate is:
-
-```sh
-bash -lc './scripts/test-commands.sh && ./scripts/test-hooks.sh && ./scripts/test-ship-e2e-gate.sh && ./scripts/check-shared-sync.sh && shellcheck agent-skills/scripts/*.sh && for skill_dir in agent-skills/skills/*/; do skill_name=$(basename "$skill_dir"); skill_file="$skill_dir/SKILL.md"; test -f "$skill_file"; lines=$(wc -l < "$skill_file"); test "$lines" -lt 500; name=$(sed -n "/^---$/,/^---$/p" "$skill_file" | awk "/^name:/ {print \$2; exit}"); test "$name" = "$skill_name"; rg -q "^description:" "$skill_file"; done && ruby -ryaml -e "YAML.load_file(ARGV[0])" agent-skills/config/severity.yaml && (cd agent-skills/examples/demo-repo && go build -o /tmp/gopher-ai-demo . && go test ./...)'
-```
-
-## Required Execution Flow
+## State Flow
 
 Use the current Detent state as the source of truth for which section applies.
 
 ### For Todo
 
 1. Move the issue to `In Progress`.
-2. Create or update the persistent `## Codex Workpad` comment with the plan,
-   acceptance criteria, validation plan, and the `in_progress` `detent-status`
-   block shown above.
-3. Fetch current `origin/main`, confirm this worktree is based on it, and
-   confirm every native dependency relation, `detent-status` blocker, and
-   issue-body `Depends on:` reference is merged or otherwise terminal before
-   coding.
-4. Reproduce or confirm the reported behavior before changing code when the
-   issue is a bug.
-5. Implement the smallest complete change that satisfies the issue.
-6. Run focused checks for touched files, then run the configured validation
-   gate.
-7. Commit and push the branch.
-8. Open or update a pull request that references the issue.
-9. Re-check pull request comments, inline review comments, and CI after the
-   latest push.
-10. Do NOT move the issue to `Human Review`. Leave the issue in `In Progress`
-    and update the Workpad `detent-status` block to `status: complete` with
-    `blockers: []` once the pull request is open, not a draft, references the
-    issue, validation is green, and no actionable review comments remain.
-    Detent auto-promotes the issue directly to `Merging` when the PR gate
-    (CI) is green.
+2. Initialize the Workpad with the plan, acceptance criteria, validation plan, and `in_progress` status.
+3. Fetch `origin/main`, confirm the Detent worktree base, resolve dependencies, then follow `$go-workflow:start-issue <number>`.
+4. Run focused checks and the configured validation gate.
+5. Follow `$go-workflow:commit`, `$go-workflow:create-pr`, and `$go-workflow:address-review`.
+6. Leave the issue in `In Progress`. Set Workpad `status: complete` with no blockers or human action only when the PR is non-draft, references the issue, validation and current-head CI are green, and no actionable review remains. Detent auto-promotes directly to `Merging`; never use `Human Review`.
 
 ### For In Progress
 
-1. Re-read the issue, pull request, comments, and `## Codex Workpad`, including
-   the `detent-status` block.
-2. Continue from the current repository and tracker state.
-3. If implementation is complete, run the full pre-review gate, then update
-   the Workpad block to `status: complete` with `blockers: []` and
-   `human_action: null` only when the gate passes. Do NOT move the issue to
-   `Human Review`; leave it in `In Progress` and let Detent auto-promote it
-   to `Merging` once the PR gate is green.
+Re-read the issue, PR, comments, and Workpad, then continue from the current state.
+When implementation is complete, run the full gate and apply Todo's completion rule.
 
 ### For Rework
 
-1. Re-read all human, CI, and bot feedback.
-2. Move the issue to `In Progress`.
-3. Fix the requested changes.
-4. Push updates to the pull request.
-5. Run the full pre-review gate again.
-6. When the gate passes, update the Workpad `detent-status` block to
-   `status: complete` and leave the issue in `In Progress`; Detent
-   auto-promotes it back to `Merging` once the PR gate is green. Do NOT move
-   it to `Human Review`.
+Re-read all human, CI, and bot feedback, move the issue to `In Progress`, and follow
+`$go-workflow:address-review`. Rerun the full gate and apply Todo's completion rule.
 
 ### For Merging
 
-1. Confirm `$go-workflow:ship` is available in the Codex environment. If it is
-   unavailable, keep the issue in `Merging` and record the missing ship
-   workflow as `human_action` in the `detent-status` block.
-2. Invoke and follow `$go-workflow:ship`.
-3. Do not call `gh pr merge` directly outside the ship workflow.
-4. End with exactly one terminal outcome:
-   - pull request merged and issue moved to `Done`;
+1. Follow `$go-workflow:ship`; never call `gh pr merge` outside it. If unavailable,
+   remain in `Merging` and record `human_action`.
+2. End with exactly one terminal outcome:
+   - PR merged and issue moved to `Done`;
    - issue moved to `Rework` with an actionable defect;
-   - issue remains in `Merging` with a concrete external blocker recorded in
-     the `detent-status` block and described in the `## Codex Workpad`.
-5. Move the issue to `Done` only after the pull request is merged.
+   - issue remains in `Merging` with an external blocker recorded in the
+     `detent-status` block and Workpad.
+3. Move the issue to `Done` only after the pull request is merged.


### PR DESCRIPTION
## Summary

- reduce `WORKFLOW.md` to Detent-owned protocol and tracker semantics
- delegate commit, PR, review, and merge mechanics to qualified go-workflow skills
- reference `detent.yaml` as the validation gate source instead of duplicating the command

## Test Plan

- `./scripts/test-commands.sh`
- `./scripts/test-hooks.sh`
- `./scripts/test-ship-e2e-gate.sh`
- `./scripts/check-shared-sync.sh`
- configured shellcheck, Agent Skill metadata, YAML, build, and Go test checks

Fixes #285