### PR TITLE
fix(create-pr): reuse existing pull request

### DIFF
--- a/plugins/go-workflow/hooks/legacy-skill-hashes.txt
+++ b/plugins/go-workflow/hooks/legacy-skill-hashes.txt
@@ -7,7 +7,7 @@
 # this prevents accepting a hash from skill A as proof of ownership for skill B.
 # DO NOT EDIT BY HAND — re-run the regen script after committing SKILL.md changes.
 #
-# Total entries: 275
+# Total entries: 276
 017e2d820506e7bef4a89a4d65839150db1ffdc124852a43dc916023e6d37e16 review-deep
 0232ae1141f76c0ba40045649179a566080de9fc717c6cb08c3961b827fe3e88 create-pr
 0322d4a7ddc204a9bf5addfec4e512edaea92ab8f4ebdd0541ca099330a09408 worktree
@@ -178,6 +178,7 @@ a164e2b1f11394ae1ed9483327be26cabf4f6312ce041058a88e971be5806a6f e2e-verify
 a1a6f04b281f1bcfbe8fde80103929966af8f70bda1c911778aac492046cf46f start-issue
 a1be43f108a567703d37bded1f2afedfdfffac7b1091f0eca4a73324db6a2d7e go-profiling-optimization
 a2a3050b172bc402ab7145d100ece2970d0c1c1ab5b8ca031a8467def04147be go-best-practices
+a2cd098b5ee6d66ec2dacdbe37f51b8f752e5bb1361c3ce77fb77ea71cc880cf create-pr
 a3d00fdd9a8c311b4f5eb4fa3103b590728c9aae4ba6a4114550a0d95899dfe2 start-issue
 a540a70728ccdf333607568344421a1cac01ec3ba8154b497eff803c4944c1ec second-opinion
 a551fb3560982ad79be6d30d55acd31a7346cd890b9a79491a8b6e4c1c7944f6 templui

--- a/plugins/go-workflow/skills/create-pr/SKILL.md
+++ b/plugins/go-workflow/skills/create-pr/SKILL.md
@@ -101,10 +101,30 @@ Include `Fixes #<number>` or `Closes #<number>` in the PR body.
 - Keep under 70 characters
 - Derive from the commits and changes
 
-### Step 8: Create PR
+### Step 8: Reuse or Create PR
+
+Check for an open pull request associated with the current branch before
+attempting to create one:
 
 ```bash
-gh pr create --title "<title>" --body "<body>"
+EXISTING_PR=$(gh pr view \
+  --json number,url,state,headRefName,baseRefName \
+  --jq 'select(.state == "OPEN") | [.number, .url, .headRefName, .baseRefName] | @tsv' \
+  2>/dev/null || true)
+
+if [ -n "$EXISTING_PR" ]; then
+  IFS=$'\t' read -r PR_NUMBER PR_URL PR_HEAD PR_BASE <<< "$EXISTING_PR"
+
+  if [ "$PR_HEAD" != "$CURRENT_BRANCH" ] || [ "$PR_BASE" != "$DEFAULT_BRANCH" ]; then
+    echo "WORKFLOW_RESULT=INCOMPLETE"
+    echo "WORKFLOW_REASON=existing-pr-mismatch"
+    exit 1
+  fi
+
+  echo "Reusing pull request #$PR_NUMBER: $PR_URL"
+else
+  gh pr create --title "<title>" --body "<body>"
+fi
 ```
 
 ### Step 9: Report

--- a/scripts/legacy-skill-hashes.txt
+++ b/scripts/legacy-skill-hashes.txt
@@ -7,7 +7,7 @@
 # this prevents accepting a hash from skill A as proof of ownership for skill B.
 # DO NOT EDIT BY HAND — re-run the regen script after committing SKILL.md changes.
 #
-# Total entries: 275
+# Total entries: 276
 017e2d820506e7bef4a89a4d65839150db1ffdc124852a43dc916023e6d37e16 review-deep
 0232ae1141f76c0ba40045649179a566080de9fc717c6cb08c3961b827fe3e88 create-pr
 0322d4a7ddc204a9bf5addfec4e512edaea92ab8f4ebdd0541ca099330a09408 worktree
@@ -178,6 +178,7 @@ a164e2b1f11394ae1ed9483327be26cabf4f6312ce041058a88e971be5806a6f e2e-verify
 a1a6f04b281f1bcfbe8fde80103929966af8f70bda1c911778aac492046cf46f start-issue
 a1be43f108a567703d37bded1f2afedfdfffac7b1091f0eca4a73324db6a2d7e go-profiling-optimization
 a2a3050b172bc402ab7145d100ece2970d0c1c1ab5b8ca031a8467def04147be go-best-practices
+a2cd098b5ee6d66ec2dacdbe37f51b8f752e5bb1361c3ce77fb77ea71cc880cf create-pr
 a3d00fdd9a8c311b4f5eb4fa3103b590728c9aae4ba6a4114550a0d95899dfe2 start-issue
 a540a70728ccdf333607568344421a1cac01ec3ba8154b497eff803c4944c1ec second-opinion
 a551fb3560982ad79be6d30d55acd31a7346cd890b9a79491a8b6e4c1c7944f6 templui

--- a/scripts/test-decision-gates.sh
+++ b/scripts/test-decision-gates.sh
@@ -103,6 +103,16 @@ assert_contains "$template_gate" "template whose name and required" "template ga
 assert_contains "$template_gate" "first lexical template" "template gate lacks deterministic tie-break"
 assert_contains "$template_gate" "do not request input" "template gate still defers a technical choice"
 
+pr_submission=$(section_text "$CREATE_PR" "### Step 8:" "### Step 9:")
+assert_contains "$pr_submission" "gh pr view" "create-pr does not detect an existing pull request"
+assert_contains "$pr_submission" "headRefName" "create-pr does not verify the existing pull request head"
+assert_contains "$pr_submission" "baseRefName" "create-pr does not verify the existing pull request base"
+assert_contains "$pr_submission" "if [ -n \"\$EXISTING_PR\" ]" "create-pr does not branch on an existing pull request"
+assert_contains "$pr_submission" "Reusing pull request" "create-pr does not report a reused pull request"
+assert_contains "$pr_submission" "WORKFLOW_REASON=existing-pr-mismatch" "create-pr can reuse a mismatched pull request"
+assert_contains "$pr_submission" "else" "create-pr lacks a new pull request path"
+assert_contains "$pr_submission" "gh pr create" "create-pr no longer creates a pull request when none exists"
+
 review_capacity=$(section_text "$REVIEW_PLAN" "Follow the displayed plan" "__END__")
 assert_contains "$review_capacity" "further partitioning" "review planning cannot recover from capacity limits"
 assert_contains "$review_capacity" "higher-capacity backend" "review planning cannot use backend evidence"


### PR DESCRIPTION
## Summary
- detect an open pull request for the current branch before attempting creation
- reuse and report only a pull request whose head and base match the intended submission
- retain the new-pull-request path and add contract coverage for both outcomes

## Test Plan
- `./scripts/test-decision-gates.sh`
- `./scripts/test-commands.sh`
- `./scripts/test-installation.sh`
- configured Detent validation gate

Fixes #292