### PR TITLE
fix(test): normalize archive temp base

### DIFF
--- a/scripts/test-installation.sh
+++ b/scripts/test-installation.sh
@@ -137,6 +137,7 @@ else
 fi
 
 ARCHIVE_TEMP_BASE="${TMPDIR:-${TMP:-${TEMP:-/tmp}}}"
+ARCHIVE_TEMP_BASE="${ARCHIVE_TEMP_BASE%/}"
 ARCHIVE_TEMP_TEST_ROOT=$(mktemp -d "$ARCHIVE_TEMP_BASE/gopher-ai-universal-archive.XXXXXX")
 ARCHIVE_TEMP_DIR="$ARCHIVE_TEMP_TEST_ROOT/configured"
 ARCHIVE_MKTEMP_BIN="$ARCHIVE_TEMP_TEST_ROOT/bin"
@@ -176,7 +177,7 @@ if ! (
   PATH="$ARCHIVE_MKTEMP_BIN:$PATH" \
     GOPHER_AI_MKTEMP_LOG="$ARCHIVE_MKTEMP_LOG" \
     GOPHER_AI_REAL_MKTEMP="$ARCHIVE_REAL_MKTEMP" \
-    TMPDIR="configured" \
+    TMPDIR="configured/" \
     TMP="$ARCHIVE_TEMP_TEST_ROOT/unused-tmp" \
     TEMP="$ARCHIVE_TEMP_TEST_ROOT/unused-temp" \
     "$ROOT_DIR/scripts/build-universal.sh" >"$ARCHIVE_TEMP_TEST_ROOT/build.log" 2>&1


### PR DESCRIPTION
## Summary
- Normalize the archive test temp base before allocating fixtures so macOS trailing-slash temp paths match the builder contract.
- Exercise the builder with a trailing-slash relative temp directory so Linux-only CI guards the behavior.

## Test Plan
- Focused archive allocation checks with trailing-slash ambient and configured temp directories.
- Shell syntax, ShellCheck, and whitespace validation.
- Authoritative Detent validation gate.

Fixes #294