### PR TITLE
feat(detent): enable scheduled backlog admission

### DIFF
--- a/WORKFLOW.md
+++ b/WORKFLOW.md
@@ -58,3 +58,38 @@ Re-read all human, CI, and bot feedback, move the issue to `In Progress`, and fo
    - issue remains in `Merging` with an external blocker recorded in the
      `detent-status` block and Workpad.
 3. Move the issue to `Done` only after the pull request is merged.
+
+## Admission Criteria
+
+Used by the scheduled admission pass to decide which `Backlog` issues to
+admit to `Todo`. Each subsection is a scoring dimension; a proposal must
+quote the rule it relied on, verbatim, and an issue satisfying no
+dimension is not proposed.
+
+### Alignment
+
+Admit, in this order of preference:
+
+1. **Toolchain defects agents actually hit.** A reproducible failure in
+   a skill, command, hook, or gate script that blocks an agent run,
+   fails the e2e gate, or produces rework — including flaky tests in
+   `scripts/` that intermittently fail the completion gate.
+2. **Work that removes a standing human step.** Anything that turns a
+   recurring manual intervention in the plugin workflow into something
+   the tooling does itself.
+
+Do not admit: umbrella or epic issues (decompose first), or speculative
+new skills and commands with no named consumer.
+
+### Readiness
+
+A precise symptom plus expected behavior satisfies this; a wish with no
+checkable end state fails it. An issue whose `Depends on:` reference is
+not merged into `origin/main` is not ready; leave it in `Backlog` and
+say what is missing.
+
+### Size
+
+Admit only what can plausibly be finished and validated in a single
+agent run against the full completion gate. Decompose oversized work
+and admit the pieces.

--- a/detent.yaml
+++ b/detent.yaml
@@ -175,3 +175,24 @@ budget:
     pricing_path: priv/pricing/models.yaml
 hooks:
     timeout_ms: 60000
+# Scheduled admission (mirrors the detent project's setup, 2026-07-31). A
+# read-only agent scores Backlog issues against the "Admission Criteria"
+# section of WORKFLOW.md; auto_admit moves high-confidence ones to Todo and
+# writes a recommended detent-agent effort onto the issue on admit. Schedule
+# inherits the shipped default (*/15). Enabled after gopher-ai#295 sat in
+# Backlog with nothing watching it while detent auto-gated for two days.
+backlog_admission:
+    enabled: true
+    sources:
+        states:
+            - Backlog
+    target_state: Todo
+    criteria_section: Admission Criteria
+    authors:
+        allow:
+            - corylanou
+            - loganlanou
+            - michaelhvisser
+            - jarvislanou
+    auto_admit: true
+    auto_admit_min_confidence: 0.9


### PR DESCRIPTION
Enables the scheduled admission pass for this project, mirroring the detent project's setup.

- `WORKFLOW.md`: new `## Admission Criteria` section (Alignment / Readiness / Size) sized to this repo — toolchain defects agents hit rank first, umbrella issues and speculative skills are excluded.
- `detent.yaml`: `backlog_admission` block — Backlog → Todo, four-author allowlist, `auto_admit` at 0.9 confidence, schedule inherits the shipped `*/15` default. Admission writes a recommended `detent-agent` effort on admit.

Context: gopher-ai#295 sat in Backlog with nothing watching it while the detent project auto-gated for two days. `detent doctor --project gopher-ai` validates the config (3 dimensions parsed).