### PR TITLE
chore(detent): enable ambient gh worker auth

### DIFF
--- a/detent.yaml
+++ b/detent.yaml
@@ -224,3 +224,9 @@ backlog_admission:
             - jarvislanou
     auto_admit: true
     auto_admit_min_confidence: 0.9
+
+worker:
+  # Ambient gh worker auth (v0.66.0, detent#1798): workers resolve gh auth token
+  # into their isolated environment. Shared-budget mode by design -- the
+  # reserved-headroom brake throttles workers before the orchestrator starves.
+  github_token: gh


### PR DESCRIPTION
Sets worker.github_token: gh (v0.66.0, digitaldrywood/detent#1798): workers resolve the operator's gh auth token into their isolated environment as explicit shared-budget mode. Validation accepted and runtime classification verified live before committing (classifyCredential: shared REST budget, governor observing). Restores the product premise: gh CLI available, no minted credentials.