### PR TITLE
fix(review): retry invalid API responses

### DIFF
--- a/.github/actions/gopher-ai-review/action.yml
+++ b/.github/actions/gopher-ai-review/action.yml
@@ -1,0 +1,153 @@
+name: Gopher AI Code Review
+description: AI-powered Go code review using Gopher Guides best practices
+author: Gopher Guides
+
+branding:
+  icon: check-circle
+  color: blue
+
+inputs:
+  api-key:
+    description: Gopher AI API key
+    required: true
+  api-url:
+    description: Gopher AI review API endpoint
+    required: false
+    default: https://gopherguides.com/api/gopher-ai/review
+  focus:
+    description: Optional review focus
+    required: false
+    default: ""
+  github-token:
+    description: GitHub token for reading pull requests and publishing review status
+    required: true
+  retry-delay-seconds:
+    description: Delay before the single bounded retry
+    required: false
+    default: "2"
+
+outputs:
+  summary:
+    description: One-line review summary
+    value: ${{ steps.review.outputs.summary || steps.check-go.outputs.summary || steps.diff.outputs.summary }}
+  file-count:
+    description: Number of Go files reviewed
+    value: ${{ steps.review.outputs.file_count || steps.check-go.outputs.file_count || '0' }}
+  skip-reason:
+    description: Concrete reason the review did not complete
+    value: ${{ steps.review.outputs.skip_reason || steps.check-go.outputs.skip_reason || steps.diff.outputs.skip_reason }}
+  has-issues:
+    description: Whether the review found issues
+    value: ${{ steps.review.outputs.has_issues || steps.check-go.outputs.has_issues || 'false' }}
+  reviewed-head:
+    description: Pull request head evaluated by this action
+    value: ${{ github.event.pull_request.head.sha || github.sha }}
+
+runs:
+  using: composite
+  steps:
+    - name: Check for eligible Go files
+      id: check-go
+      shell: bash
+      env:
+        GH_TOKEN: ${{ inputs.github-token }}
+        PR_NUMBER: ${{ github.event.pull_request.number }}
+        REPOSITORY: ${{ github.repository }}
+        REVIEWED_HEAD: ${{ github.event.pull_request.head.sha || github.sha }}
+        STATUS_DIR: ${{ github.workspace }}/.gopher-ai-review
+      run: |
+        set -euo pipefail
+        mkdir -p "$STATUS_DIR"
+        CHANGED_FILES=$(gh api --paginate "repos/$REPOSITORY/pulls/$PR_NUMBER/files?per_page=100" --jq '.[].filename')
+        GO_FILES=$(printf '%s\n' "$CHANGED_FILES" | awk '/\.go$/ && !/_test\.go$/ && !/_templ\.go$/ && !/_gen\.go$/')
+        FILE_COUNT=$(printf '%s\n' "$GO_FILES" | awk 'NF { count++ } END { print count + 0 }')
+        printf 'file_count=%s\n' "$FILE_COUNT" >> "$GITHUB_OUTPUT"
+        printf 'reviewed_head=%s\n' "$REVIEWED_HEAD" >> "$GITHUB_OUTPUT"
+
+        if [ "$FILE_COUNT" -eq 0 ]; then
+          printf '%s\n' \
+            'summary=Gopher AI review skipped: no eligible Go files' \
+            'has_issues=false' \
+            'skip_reason=no-eligible-go-files' >> "$GITHUB_OUTPUT"
+          {
+            echo '## Gopher AI Code Review'
+            echo
+            echo 'Review skipped: no eligible Go files changed.'
+            echo
+            echo 'No retry is needed for this head.'
+          } > "$STATUS_DIR/status.md"
+          exit 0
+        fi
+
+        printf 'go_files<<EOF\n%s\nEOF\n' "$GO_FILES" >> "$GITHUB_OUTPUT"
+
+    - name: Get pull request diff
+      if: steps.check-go.outputs.skip_reason != 'no-eligible-go-files'
+      id: diff
+      shell: bash
+      env:
+        GH_TOKEN: ${{ inputs.github-token }}
+        PR_NUMBER: ${{ github.event.pull_request.number }}
+        REPOSITORY: ${{ github.repository }}
+        STATUS_DIR: ${{ github.workspace }}/.gopher-ai-review
+      run: |
+        set -euo pipefail
+        mkdir -p "$STATUS_DIR"
+        if ! gh pr diff "$PR_NUMBER" --repo "$REPOSITORY" > "$GITHUB_WORKSPACE/pr.diff"; then
+          {
+            echo '## Gopher AI Code Review'
+            echo
+            echo 'Review failed: the pull request diff could not be fetched.'
+            echo
+            echo 'No API retry occurred because the review request could not be created.'
+          } > "$STATUS_DIR/status.md"
+          printf '%s\n' \
+            'summary=Gopher AI review failed: diff unavailable' \
+            'skip_reason=diff-unavailable' >> "$GITHUB_OUTPUT"
+          exit 1
+        fi
+
+    - name: Call Gopher AI API
+      if: steps.check-go.outputs.skip_reason != 'no-eligible-go-files'
+      id: review
+      shell: bash
+      env:
+        GOPHER_AI_API_KEY: ${{ inputs.api-key }}
+        GOPHER_AI_API_URL: ${{ inputs.api-url }}
+        GOPHER_AI_DIFF_PATH: ${{ github.workspace }}/pr.diff
+        GOPHER_AI_FOCUS: ${{ inputs.focus }}
+        GOPHER_AI_RETRY_DELAY_SECONDS: ${{ inputs.retry-delay-seconds }}
+        REVIEW_STATUS_DIR: ${{ github.workspace }}/.gopher-ai-review
+      run: ${{ github.action_path }}/review-api.sh
+
+    - name: Upsert exact-head review status
+      if: always() && github.event.pull_request.head.repo.fork != true && github.actor != 'dependabot[bot]'
+      shell: bash
+      env:
+        GH_TOKEN: ${{ inputs.github-token }}
+        PR_NUMBER: ${{ github.event.pull_request.number }}
+        REPOSITORY: ${{ github.repository }}
+        REVIEWED_HEAD: ${{ github.event.pull_request.head.sha || github.sha }}
+        STATUS_DIR: ${{ github.workspace }}/.gopher-ai-review
+      run: |
+        set -euo pipefail
+        MARKER='<!-- gopher-ai-review-summary -->'
+        STATUS_FILE="$STATUS_DIR/status.md"
+        if [ ! -f "$STATUS_FILE" ]; then
+          mkdir -p "$STATUS_DIR"
+          {
+            echo '## Gopher AI Code Review'
+            echo
+            echo 'Review failed before a detailed status could be recorded.'
+          } > "$STATUS_FILE"
+        fi
+
+        BODY=$(printf '%s\n%s\n\n- Head SHA: %s\n' "$MARKER" "$(<"$STATUS_FILE")" "$REVIEWED_HEAD")
+        COMMENT_ID=$(gh api --paginate "repos/$REPOSITORY/issues/$PR_NUMBER/comments?per_page=100" \
+          | jq -s --arg marker "$MARKER" '[add[] | select((.body // "") | contains($marker))] | sort_by(.updated_at, .id) | last | .id // empty')
+
+        if [ -n "$COMMENT_ID" ]; then
+          gh api --method PATCH "repos/$REPOSITORY/issues/comments/$COMMENT_ID" -f body="$BODY" >/dev/null
+        else
+          gh api --method POST "repos/$REPOSITORY/issues/$PR_NUMBER/comments" -f body="$BODY" >/dev/null
+        fi

--- a/.github/actions/gopher-ai-review/review-api.sh
+++ b/.github/actions/gopher-ai-review/review-api.sh
@@ -1,0 +1,194 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+: "${GITHUB_OUTPUT:?GITHUB_OUTPUT is required}"
+: "${GITHUB_WORKSPACE:?GITHUB_WORKSPACE is required}"
+: "${GOPHER_AI_API_URL:?GOPHER_AI_API_URL is required}"
+: "${GOPHER_AI_DIFF_PATH:?GOPHER_AI_DIFF_PATH is required}"
+
+STATUS_DIR="${REVIEW_STATUS_DIR:-$GITHUB_WORKSPACE/.gopher-ai-review}"
+RESPONSE_FILE="$GITHUB_WORKSPACE/review_response.json"
+PAYLOAD_FILE="$GITHUB_WORKSPACE/payload.json"
+RETRY_DELAY_SECONDS="${GOPHER_AI_RETRY_DELAY_SECONDS:-2}"
+MAX_ATTEMPTS=2
+
+mkdir -p "$STATUS_DIR"
+
+write_output() {
+  local key="$1"
+  local value="${2//$'\r'/}"
+
+  value="${value//$'\n'/ }"
+  printf '%s=%s\n' "$key" "$value" >> "$GITHUB_OUTPUT"
+}
+
+redacted_response_excerpt() {
+  local response_file="$1"
+  local excerpt
+
+  if jq -e . "$response_file" >/dev/null 2>&1; then
+    excerpt=$(jq -c '
+      def redact:
+        if type == "object" then
+          with_entries(
+            if (.key | test("token|secret|password|api[-_]?key|authorization"; "i")) then
+              .value = "<redacted>"
+            else
+              .value |= redact
+            end
+          )
+        elif type == "array" then map(redact)
+        else .
+        end;
+      redact
+    ' "$response_file")
+  else
+    excerpt=$(tr '\r\n' ' ' < "$response_file" | sed -E \
+      -e 's/(Bearer )[[:alnum:]_.-]+/\1<redacted>/g' \
+      -e 's/("(token|secret|password|authorization|api[-_]?key)"[[:space:]]*:[[:space:]]*")[^"]*/\1<redacted>/Ig')
+  fi
+
+  printf 'Response excerpt: %.500s\n' "$excerpt"
+}
+
+record_failure() {
+  local cause="$1"
+  local attempts="$2"
+
+  write_output summary "Gopher AI review failed: $cause"
+  write_output file_count 0
+  write_output has_issues false
+  write_output api_failed true
+  write_output api_status "$cause"
+  write_output skip_reason "${cause}-retry-exhausted"
+
+  {
+    echo '## Gopher AI Code Review'
+    echo
+    echo "Review failed after $attempts attempts."
+    echo
+    echo "- Cause: \`$cause\`"
+    echo "- Attempts: $attempts of $MAX_ATTEMPTS"
+    echo
+    echo 'No additional retry will occur. The failed review is actionable and the job will remain failed.'
+  } > "$STATUS_DIR/status.md"
+}
+
+if [ -z "${GOPHER_AI_API_KEY:-}" ]; then
+  write_output summary 'Gopher AI review failed: missing API key'
+  write_output file_count 0
+  write_output has_issues false
+  write_output api_failed true
+  write_output api_status missing-api-key
+  write_output skip_reason missing-api-key
+  {
+    echo '## Gopher AI Code Review'
+    echo
+    echo 'Review failed because the Gopher AI API key is not configured.'
+    echo
+    echo 'No retry occurred because authentication is required before a request can be made.'
+  } > "$STATUS_DIR/status.md"
+  exit 1
+fi
+
+if [ ! -s "$GOPHER_AI_DIFF_PATH" ]; then
+  write_output summary 'Gopher AI review failed: empty diff'
+  write_output file_count 0
+  write_output has_issues false
+  write_output api_failed true
+  write_output api_status empty-diff
+  write_output skip_reason empty-diff
+  {
+    echo '## Gopher AI Code Review'
+    echo
+    echo 'Review failed because the pull request diff is empty.'
+    echo
+    echo 'No API retry occurred because the review request could not be created.'
+  } > "$STATUS_DIR/status.md"
+  exit 1
+fi
+
+jq -n --rawfile diff "$GOPHER_AI_DIFF_PATH" --arg focus "${GOPHER_AI_FOCUS:-}" \
+  'if $focus == "" then {diff: $diff} else {diff: $diff, focus: $focus} end' > "$PAYLOAD_FILE"
+
+case "$GOPHER_AI_API_URL" in
+  *\?*format=*) REVIEW_URL=$(printf '%s\n' "$GOPHER_AI_API_URL" | sed -E 's/([?&])format=[^&]*/\1format=github/') ;;
+  *\?*) REVIEW_URL="${GOPHER_AI_API_URL}&format=github" ;;
+  *) REVIEW_URL="${GOPHER_AI_API_URL}?format=github" ;;
+esac
+
+failure_cause=""
+attempt=1
+while [ "$attempt" -le "$MAX_ATTEMPTS" ]; do
+  curl_status=0
+  : > "$RESPONSE_FILE"
+  set +e
+  http_status=$(curl -sS \
+    --output "$RESPONSE_FILE" \
+    --write-out '%{http_code}' \
+    -X POST "$REVIEW_URL" \
+    -H "Authorization: Bearer $GOPHER_AI_API_KEY" \
+    -H 'Content-Type: application/json' \
+    --data-binary "@$PAYLOAD_FILE")
+  curl_status=$?
+  set -e
+
+  if [ "$curl_status" -ne 0 ]; then
+    failure_cause="api-request-failed"
+  elif [ "$http_status" != "200" ]; then
+    failure_cause="http-$http_status"
+  elif ! jq -e . "$RESPONSE_FILE" >/dev/null 2>&1; then
+    failure_cause="invalid-json"
+  elif ! jq -e '
+    type == "object" and
+    (.summary | type == "string" and length > 0) and
+    (.file_count | type == "number" and floor == . and . >= 0) and
+    (.issues | type == "array")
+  ' "$RESPONSE_FILE" >/dev/null 2>&1; then
+    failure_cause="invalid-response-schema"
+  else
+    summary=$(jq -r '.summary' "$RESPONSE_FILE")
+    file_count=$(jq -r '.file_count' "$RESPONSE_FILE")
+    issue_count=$(jq -r '.issues | length' "$RESPONSE_FILE")
+    has_issues=false
+    if [ "$issue_count" -gt 0 ]; then
+      has_issues=true
+    fi
+
+    write_output summary "$summary"
+    write_output file_count "$file_count"
+    write_output has_issues "$has_issues"
+    write_output api_failed false
+    write_output api_status 200
+    write_output skip_reason ""
+    {
+      echo '## Gopher AI Code Review'
+      echo
+      echo 'Review completed.'
+      echo
+      echo "- Summary: $summary"
+      echo "- Files reviewed: $file_count"
+      echo "- Findings returned: $issue_count"
+    } > "$STATUS_DIR/status.md"
+    exit 0
+  fi
+
+  echo "::warning::Gopher AI review attempt $attempt of $MAX_ATTEMPTS failed: $failure_cause"
+  if [ -s "$RESPONSE_FILE" ]; then
+    redacted_response_excerpt "$RESPONSE_FILE"
+  else
+    echo 'Response excerpt: <empty>'
+  fi
+
+  if [ "$attempt" -lt "$MAX_ATTEMPTS" ]; then
+    echo 'Retrying once.'
+    if [ "$RETRY_DELAY_SECONDS" != "0" ]; then
+      sleep "$RETRY_DELAY_SECONDS"
+    fi
+  fi
+  attempt=$((attempt + 1))
+done
+
+record_failure "$failure_cause" "$MAX_ATTEMPTS"
+exit 1

--- a/.github/workflows/gopher-ai-review.yml
+++ b/.github/workflows/gopher-ai-review.yml
@@ -1,0 +1,51 @@
+name: Gopher AI Code Review
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+
+permissions:
+  contents: read
+  issues: write
+  pull-requests: write
+
+concurrency:
+  group: gopher-ai-review-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  review:
+    name: AI Code Review
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Run Gopher AI review
+        id: review
+        uses: ./.github/actions/gopher-ai-review
+        with:
+          api-key: ${{ secrets.GOPHER_AI_API_KEY }}
+          github-token: ${{ github.token }}
+
+      - name: Publish review status in job summary
+        if: always()
+        env:
+          FILE_COUNT: ${{ steps.review.outputs.file-count || '0' }}
+          HAS_ISSUES: ${{ steps.review.outputs.has-issues || 'false' }}
+          REVIEWED_HEAD: ${{ steps.review.outputs.reviewed-head || github.event.pull_request.head.sha }}
+          SKIP_REASON: ${{ steps.review.outputs.skip-reason || 'none' }}
+          SUMMARY: ${{ steps.review.outputs.summary || 'review did not complete' }}
+        run: |
+          {
+            echo '## Gopher AI Code Review'
+            echo "- Summary: **$SUMMARY**"
+            echo "- Files reviewed: **$FILE_COUNT**"
+            echo "- Skip reason: **$SKIP_REASON**"
+            echo "- Issues found: **$HAS_ISSUES**"
+            echo "- Reviewed head: **$REVIEWED_HEAD**"
+          } >> "$GITHUB_STEP_SUMMARY"
+          if [ -f .gopher-ai-review/status.md ]; then
+            echo >> "$GITHUB_STEP_SUMMARY"
+            sed -n '1,160p' .gopher-ai-review/status.md >> "$GITHUB_STEP_SUMMARY"
+          fi

--- a/scripts/test-commands.sh
+++ b/scripts/test-commands.sh
@@ -15,6 +15,7 @@ bash "$ROOT_DIR/scripts/test-ship-ollama-model.sh"
 bash "$ROOT_DIR/scripts/test-review-deep-actions.sh"
 bash "$ROOT_DIR/scripts/test-decision-gates.sh"
 bash "$ROOT_DIR/scripts/test-github-rest.sh"
+bash "$ROOT_DIR/scripts/test-gopher-ai-review-action.sh"
 
 # Find all command .md files
 COMMAND_FILES=$(find "$ROOT_DIR/plugins" "$ROOT_DIR/shared" -path "*/commands/*.md" -type f 2>/dev/null | sort)

--- a/scripts/test-gopher-ai-review-action.sh
+++ b/scripts/test-gopher-ai-review-action.sh
@@ -1,0 +1,170 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+ACTION_DIR="$ROOT_DIR/.github/actions/gopher-ai-review"
+ACTION_FILE="$ACTION_DIR/action.yml"
+REVIEW_SCRIPT="$ACTION_DIR/review-api.sh"
+WORKFLOW_FILE="$ROOT_DIR/.github/workflows/gopher-ai-review.yml"
+TEST_ROOT=$(mktemp -d "${TMPDIR:-/tmp}/gopher-ai-review-action-test.XXXXXX")
+trap 'rm -rf "$TEST_ROOT"' EXIT
+
+fail() {
+  echo "FAIL: $1" >&2
+  exit 1
+}
+
+assert_contains() {
+  local file="$1"
+  local expected="$2"
+  local message="$3"
+
+  rg -Fq -- "$expected" "$file" || fail "$message"
+}
+
+test_action_contract() {
+  [ -f "$ACTION_FILE" ] || fail "reusable action is missing"
+  [ -x "$REVIEW_SCRIPT" ] || fail "API review helper is missing or not executable"
+  [ -f "$WORKFLOW_FILE" ] || fail "consumer workflow is missing"
+
+  assert_contains "$ACTION_FILE" "\${{ github.action_path }}/review-api.sh" "action does not execute its packaged helper"
+  assert_contains "$ACTION_FILE" "\${{ github.event.pull_request.head.sha || github.sha }}" "action does not publish the reviewed head SHA"
+
+  while IFS='|' read -r action message; do
+    assert_contains "$WORKFLOW_FILE" "$action" "$message"
+  done <<'EOF'
+opened|workflow does not review newly opened pull requests
+synchronize|workflow does not re-review newly pushed heads
+reopened|workflow does not review reopened pull requests
+ready_for_review|workflow does not review pull requests leaving draft state
+EOF
+}
+
+write_fake_curl() {
+  local bin_dir="$1"
+
+  mkdir -p "$bin_dir"
+  cat > "$bin_dir/curl" <<'EOF'
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+output_file=""
+url=""
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --output)
+      output_file="$2"
+      shift 2
+      ;;
+    --write-out|-X|-H|--data-binary)
+      shift 2
+      ;;
+    -s|-S|-sS|--silent|--show-error)
+      shift
+      ;;
+    *)
+      url="$1"
+      shift
+      ;;
+  esac
+done
+
+[ -n "$output_file" ]
+count=0
+if [ -f "$FAKE_CURL_STATE" ]; then
+  count=$(cat "$FAKE_CURL_STATE")
+fi
+count=$((count + 1))
+printf '%s\n' "$count" > "$FAKE_CURL_STATE"
+printf '%s\n' "$url" >> "$FAKE_CURL_URLS"
+
+case "$FAKE_CURL_SCENARIO:$count" in
+  schema_then_success:1)
+    printf '%s\n' '{"content":"training response","sources":[]}' > "$output_file"
+    ;;
+  schema_then_success:2)
+    printf '%s\n' '{"summary":"No issues found","file_count":1,"issues":[]}' > "$output_file"
+    ;;
+  invalid_json_then_success:1)
+    printf '%s\n' '{"api_key":"do-not-log","summary":' > "$output_file"
+    ;;
+  invalid_json_then_success:2)
+    printf '%s\n' '{"summary":"No issues found","file_count":1,"issues":[]}' > "$output_file"
+    ;;
+  schema_exhausted:*)
+    printf '%s\n' '{"content":"still the wrong contract","sources":[]}' > "$output_file"
+    ;;
+  *)
+    exit 97
+    ;;
+esac
+
+printf '200'
+EOF
+  chmod +x "$bin_dir/curl"
+}
+
+run_response_case() {
+  local name="$1"
+  local scenario="$2"
+  local want_status="$3"
+  local want_api_failed="$4"
+  local want_skip_reason="$5"
+  local case_root="$TEST_ROOT/$name"
+  local bin_dir="$case_root/bin"
+  local command_status=0
+
+  mkdir -p "$case_root/workspace/status"
+  printf '%s\n' 'diff --git a/sample.go b/sample.go' > "$case_root/workspace/pr.diff"
+  : > "$case_root/output"
+  : > "$case_root/urls"
+  write_fake_curl "$bin_dir"
+
+  PATH="$bin_dir:$PATH" \
+  FAKE_CURL_SCENARIO="$scenario" \
+  FAKE_CURL_STATE="$case_root/count" \
+  FAKE_CURL_URLS="$case_root/urls" \
+  GITHUB_OUTPUT="$case_root/output" \
+  GITHUB_WORKSPACE="$case_root/workspace" \
+  REVIEW_STATUS_DIR="$case_root/workspace/status" \
+  GOPHER_AI_API_KEY="example-key" \
+  GOPHER_AI_API_URL="https://example.test/api/gopher-ai/review?format=json" \
+  GOPHER_AI_FOCUS="" \
+  GOPHER_AI_DIFF_PATH="$case_root/workspace/pr.diff" \
+  GOPHER_AI_RETRY_DELAY_SECONDS=0 \
+  "$REVIEW_SCRIPT" > "$case_root/log" 2>&1 || command_status=$?
+
+  [ "$command_status" -eq "$want_status" ] || fail "$name exit status = $command_status, want $want_status"
+  [ "$(cat "$case_root/count")" = "2" ] || fail "$name did not make exactly two bounded attempts"
+  assert_contains "$case_root/urls" '?format=github' "$name did not request the GitHub response contract"
+  assert_contains "$case_root/output" "api_failed=$want_api_failed" "$name emitted the wrong API failure disposition"
+  assert_contains "$case_root/output" "skip_reason=$want_skip_reason" "$name emitted the wrong skip reason"
+  assert_contains "$case_root/log" 'attempt 1 of 2' "$name did not identify the failed attempt"
+  assert_contains "$case_root/log" 'Response excerpt:' "$name did not log the actual response excerpt"
+  if rg -Fq -- 'do-not-log' "$case_root/log"; then
+    fail "$name exposed a secret from the malformed response"
+  fi
+
+  if [ "$want_status" -eq 0 ]; then
+    assert_contains "$case_root/log" 'Retrying once.' "$name did not announce the bounded retry"
+    assert_contains "$case_root/output" 'summary=No issues found' "$name did not accept the recovered response"
+  else
+    assert_contains "$case_root/workspace/status/status.md" 'No additional retry will occur.' "$name did not make retry exhaustion concrete"
+    assert_contains "$case_root/workspace/status/status.md" 'invalid-response-schema' "$name did not report the concrete terminal cause"
+  fi
+}
+
+test_action_contract
+
+while IFS='|' read -r name scenario want_status want_api_failed want_skip_reason; do
+  run_response_case "$name" "$scenario" "$want_status" "$want_api_failed" "$want_skip_reason"
+done <<'EOF'
+schema-drift-recovers|schema_then_success|0|false|
+malformed-response-recovers|invalid_json_then_success|0|false|
+schema-retry-exhausted|schema_exhausted|1|true|invalid-response-schema-retry-exhausted
+EOF
+
+echo "Gopher AI review action tests passed"

--- a/scripts/test-gopher-ai-review-action.sh
+++ b/scripts/test-gopher-ai-review-action.sh
@@ -21,7 +21,7 @@ assert_contains() {
   local expected="$2"
   local message="$3"
 
-  rg -Fq -- "$expected" "$file" || fail "$message"
+  awk -v expected="$expected" 'index($0, expected) { found = 1 } END { exit found ? 0 : 1 }' "$file" || fail "$message"
 }
 
 test_action_contract() {
@@ -144,7 +144,7 @@ run_response_case() {
   assert_contains "$case_root/output" "skip_reason=$want_skip_reason" "$name emitted the wrong skip reason"
   assert_contains "$case_root/log" 'attempt 1 of 2' "$name did not identify the failed attempt"
   assert_contains "$case_root/log" 'Response excerpt:' "$name did not log the actual response excerpt"
-  if rg -Fq -- 'do-not-log' "$case_root/log"; then
+  if awk 'index($0, "do-not-log") { found = 1 } END { exit found ? 0 : 1 }' "$case_root/log"; then
     fail "$name exposed a secret from the malformed response"
   fi
 


### PR DESCRIPTION
## Summary

- package a self-contained Gopher AI review action that requests the GitHub response contract
- retry malformed or schema-drift responses once, log a redacted response excerpt, and fail actionably after exhaustion
- review every newly pushed pull request head and publish the exact reviewed SHA

Fixes #317

## Test Plan

- `./scripts/test-gopher-ai-review-action.sh`
- ShellCheck, YAML parsing, and action workflow lint
- authoritative validation command from `gate.run` in `detent.yaml`