### PR TITLE
fix(workflow): bound stop-hook recovery loops

### DIFF
--- a/.detent/skills/isolate-git-fixtures-under-detent-tmpdir.md
+++ b/.detent/skills/isolate-git-fixtures-under-detent-tmpdir.md
@@ -1,0 +1,22 @@
+---
+name: isolate-git-fixtures-under-detent-tmpdir
+description: Prevent temporary test fixtures from inheriting the enclosing Git worktree when Detent routes temporary directories beneath the repository.
+when_to_use: Use when tests create disposable directories under TMPDIR and commands inside them unexpectedly resolve the Detent worktree as their Git repository.
+---
+
+# Isolate Git Fixtures Under Detent TMPDIR
+
+Resolve the temporary base from `TMPDIR`, `TMP`, or `TEMP`. When that base is inside the repository root, prepend it to `GIT_CEILING_DIRECTORIES` before creating fixtures.
+
+```bash
+FIXTURE_TMP_BASE="${TMPDIR:-${TMP:-${TEMP:-/tmp}}}"
+case "$FIXTURE_TMP_BASE/" in
+  "$ROOT_DIR/"*)
+    export GIT_CEILING_DIRECTORIES="$FIXTURE_TMP_BASE${GIT_CEILING_DIRECTORIES:+:$GIT_CEILING_DIRECTORIES}"
+    ;;
+esac
+```
+
+Keep fixtures under the Detent-provided temporary base. Initialize an explicit repository inside a fixture only when the test needs Git behavior.
+
+Verify both the standalone focused test and the authoritative project gate. A passing nested invocation is not enough if the parent test already exports the ceiling.

--- a/plugins/go-dev/lib/loop-state.sh
+++ b/plugins/go-dev/lib/loop-state.sh
@@ -18,6 +18,17 @@ resolve_loop_owner_root() {
   printf '%s\n' "$root"
 }
 
+resolve_loop_worktree_root() {
+  local root
+  root=$(git rev-parse --show-toplevel 2>/dev/null || true)
+  if [ -z "$root" ]; then
+    root=$(pwd -P)
+  elif [ -d "$root" ]; then
+    root=$(cd "$root" && pwd -P)
+  fi
+  printf '%s\n' "$root"
+}
+
 loop_state_directory() {
   printf '%s/.local/state\n' "$(resolve_loop_owner_root)"
 }
@@ -246,6 +257,22 @@ increment_iteration() {
   ensure_loop_state_schema "$state_file" || return 1
   jq '.iteration = ((.iteration // 0) + 1)' "$state_file" > "$tmp_file" && mv "$tmp_file" "$state_file"
   loop_log "increment_iteration: file=$state_file"
+}
+
+record_loop_block_attempt() {
+  local state_file="$1"
+  local fingerprint="$2"
+  local tmp_file="${state_file}.tmp.$$"
+  ensure_loop_state_schema "$state_file" || return 1
+  jq --arg fingerprint "$fingerprint" '
+    if (.last_block_fingerprint // "") == $fingerprint then
+      .unchanged_block_count = ((.unchanged_block_count // 0) + 1)
+    else
+      .last_block_fingerprint = $fingerprint |
+      .unchanged_block_count = 1
+    end
+  ' "$state_file" > "$tmp_file" && mv "$tmp_file" "$state_file"
+  jq -r '.unchanged_block_count' "$state_file"
 }
 
 set_loop_phase() {

--- a/plugins/go-dev/scripts/setup-loop.sh
+++ b/plugins/go-dev/scripts/setup-loop.sh
@@ -98,6 +98,7 @@ if [ "$ACTIVE_COUNT" -ne 0 ]; then
 fi
 
 SESSION_ID="${CLAUDE_SESSION_ID:-}"
+WORKTREE_PATH=$(resolve_loop_worktree_root)
 
 MAX_ITER_JSON="null"
 if [ -n "$MAX_ITERATIONS" ]; then
@@ -131,6 +132,7 @@ jq -n \
   --arg phase "$INITIAL_PHASE" \
   --arg started_at "$(date -u +"%Y-%m-%dT%H:%M:%SZ")" \
   --arg session_id "$SESSION_ID" \
+  --arg worktree_path "$WORKTREE_PATH" \
   --argjson phase_messages "$PHASE_MSGS_JSON" \
   '{
     schema_version: $schema_version,
@@ -144,6 +146,7 @@ jq -n \
     bot_review_baseline: "",
     started_at: $started_at,
     session_id: $session_id,
+    worktree_path: $worktree_path,
     awaiting_driver_input: false,
     driver_input_reason: "",
     phase_messages: $phase_messages,

--- a/plugins/go-dev/scripts/setup-loop.sh
+++ b/plugins/go-dev/scripts/setup-loop.sh
@@ -99,6 +99,7 @@ fi
 
 SESSION_ID="${CLAUDE_SESSION_ID:-}"
 WORKTREE_PATH=$(resolve_loop_worktree_root)
+SESSION_WORKTREE_PATH="$WORKTREE_PATH"
 
 MAX_ITER_JSON="null"
 if [ -n "$MAX_ITERATIONS" ]; then
@@ -132,6 +133,7 @@ jq -n \
   --arg phase "$INITIAL_PHASE" \
   --arg started_at "$(date -u +"%Y-%m-%dT%H:%M:%SZ")" \
   --arg session_id "$SESSION_ID" \
+  --arg session_worktree_path "$SESSION_WORKTREE_PATH" \
   --arg worktree_path "$WORKTREE_PATH" \
   --argjson phase_messages "$PHASE_MSGS_JSON" \
   '{
@@ -146,6 +148,7 @@ jq -n \
     bot_review_baseline: "",
     started_at: $started_at,
     session_id: $session_id,
+    session_worktree_path: $session_worktree_path,
     worktree_path: $worktree_path,
     awaiting_driver_input: false,
     driver_input_reason: "",

--- a/plugins/go-web/lib/loop-state.sh
+++ b/plugins/go-web/lib/loop-state.sh
@@ -18,6 +18,17 @@ resolve_loop_owner_root() {
   printf '%s\n' "$root"
 }
 
+resolve_loop_worktree_root() {
+  local root
+  root=$(git rev-parse --show-toplevel 2>/dev/null || true)
+  if [ -z "$root" ]; then
+    root=$(pwd -P)
+  elif [ -d "$root" ]; then
+    root=$(cd "$root" && pwd -P)
+  fi
+  printf '%s\n' "$root"
+}
+
 loop_state_directory() {
   printf '%s/.local/state\n' "$(resolve_loop_owner_root)"
 }
@@ -246,6 +257,22 @@ increment_iteration() {
   ensure_loop_state_schema "$state_file" || return 1
   jq '.iteration = ((.iteration // 0) + 1)' "$state_file" > "$tmp_file" && mv "$tmp_file" "$state_file"
   loop_log "increment_iteration: file=$state_file"
+}
+
+record_loop_block_attempt() {
+  local state_file="$1"
+  local fingerprint="$2"
+  local tmp_file="${state_file}.tmp.$$"
+  ensure_loop_state_schema "$state_file" || return 1
+  jq --arg fingerprint "$fingerprint" '
+    if (.last_block_fingerprint // "") == $fingerprint then
+      .unchanged_block_count = ((.unchanged_block_count // 0) + 1)
+    else
+      .last_block_fingerprint = $fingerprint |
+      .unchanged_block_count = 1
+    end
+  ' "$state_file" > "$tmp_file" && mv "$tmp_file" "$state_file"
+  jq -r '.unchanged_block_count' "$state_file"
 }
 
 set_loop_phase() {

--- a/plugins/go-web/scripts/setup-loop.sh
+++ b/plugins/go-web/scripts/setup-loop.sh
@@ -98,6 +98,7 @@ if [ "$ACTIVE_COUNT" -ne 0 ]; then
 fi
 
 SESSION_ID="${CLAUDE_SESSION_ID:-}"
+WORKTREE_PATH=$(resolve_loop_worktree_root)
 
 MAX_ITER_JSON="null"
 if [ -n "$MAX_ITERATIONS" ]; then
@@ -131,6 +132,7 @@ jq -n \
   --arg phase "$INITIAL_PHASE" \
   --arg started_at "$(date -u +"%Y-%m-%dT%H:%M:%SZ")" \
   --arg session_id "$SESSION_ID" \
+  --arg worktree_path "$WORKTREE_PATH" \
   --argjson phase_messages "$PHASE_MSGS_JSON" \
   '{
     schema_version: $schema_version,
@@ -144,6 +146,7 @@ jq -n \
     bot_review_baseline: "",
     started_at: $started_at,
     session_id: $session_id,
+    worktree_path: $worktree_path,
     awaiting_driver_input: false,
     driver_input_reason: "",
     phase_messages: $phase_messages,

--- a/plugins/go-web/scripts/setup-loop.sh
+++ b/plugins/go-web/scripts/setup-loop.sh
@@ -99,6 +99,7 @@ fi
 
 SESSION_ID="${CLAUDE_SESSION_ID:-}"
 WORKTREE_PATH=$(resolve_loop_worktree_root)
+SESSION_WORKTREE_PATH="$WORKTREE_PATH"
 
 MAX_ITER_JSON="null"
 if [ -n "$MAX_ITERATIONS" ]; then
@@ -132,6 +133,7 @@ jq -n \
   --arg phase "$INITIAL_PHASE" \
   --arg started_at "$(date -u +"%Y-%m-%dT%H:%M:%SZ")" \
   --arg session_id "$SESSION_ID" \
+  --arg session_worktree_path "$SESSION_WORKTREE_PATH" \
   --arg worktree_path "$WORKTREE_PATH" \
   --argjson phase_messages "$PHASE_MSGS_JSON" \
   '{
@@ -146,6 +148,7 @@ jq -n \
     bot_review_baseline: "",
     started_at: $started_at,
     session_id: $session_id,
+    session_worktree_path: $session_worktree_path,
     worktree_path: $worktree_path,
     awaiting_driver_input: false,
     driver_input_reason: "",

--- a/plugins/go-workflow/hooks/stop-hook.sh
+++ b/plugins/go-workflow/hooks/stop-hook.sh
@@ -242,8 +242,14 @@ repository_state_fingerprint() {
   local upstream
   local upstream_head
   local filesystem_entry
+  local filesystem_root
+  local generated_project
   local relative_entry
   local entry_type
+  local entry_metadata
+  local entry_size
+  local scanned_entries=0
+  local remaining_content_bytes=8388608
   head=$(git -C "$worktree_path" rev-parse HEAD 2>/dev/null || true)
   upstream=$(git -C "$worktree_path" rev-parse --abbrev-ref '@{upstream}' 2>/dev/null || true)
   upstream_head=$(git -C "$worktree_path" rev-parse '@{upstream}' 2>/dev/null || true)
@@ -262,9 +268,30 @@ repository_state_fingerprint() {
       done < <(git -C "$worktree_path" ls-files --others --exclude-standard -z -- \
         . ':(exclude).local/state/**' 2>/dev/null)
     else
+      filesystem_root="$worktree_path"
+      case "${LOOP_NAME:-}" in
+        create-go-project-*)
+          generated_project="${LOOP_NAME#create-go-project-}"
+          case "$generated_project" in
+            ''|*[!A-Za-z0-9_-]*) ;;
+            *)
+              if [ -d "$worktree_path/$generated_project" ] &&
+                 [ ! -L "$worktree_path/$generated_project" ]; then
+                filesystem_root="$worktree_path/$generated_project"
+              fi
+              ;;
+          esac
+          ;;
+      esac
+      printf '%s\n' "$filesystem_root"
       while IFS= read -r -d '' filesystem_entry; do
         [ "$filesystem_entry" != "$TRANSCRIPT_PATH" ] || continue
-        relative_entry="${filesystem_entry#"$worktree_path"/}"
+        scanned_entries=$((scanned_entries + 1))
+        if [ "$scanned_entries" -gt 512 ]; then
+          printf '%s\n' "entry-limit:512"
+          break
+        fi
+        relative_entry="${filesystem_entry#"$filesystem_root"/}"
         if [ -L "$filesystem_entry" ]; then
           entry_type="link"
         elif [ -d "$filesystem_entry" ]; then
@@ -274,12 +301,28 @@ repository_state_fingerprint() {
         fi
         printf '%s\0%s\0' "$entry_type" "$relative_entry"
         if [ "$entry_type" = "file" ]; then
-          cksum < "$filesystem_entry" 2>/dev/null || true
+          entry_metadata=$(stat -f '%z:%m' "$filesystem_entry" 2>/dev/null || \
+            stat -c '%s:%Y' "$filesystem_entry" 2>/dev/null || true)
+          printf '%s\0' "$entry_metadata"
+          entry_size="${entry_metadata%%:*}"
+          case "$entry_size" in
+            ''|*[!0-9]*) entry_size=0 ;;
+          esac
+          if [ "$remaining_content_bytes" -gt 0 ]; then
+            if [ "$entry_size" -le "$remaining_content_bytes" ]; then
+              cksum < "$filesystem_entry" 2>/dev/null || true
+              remaining_content_bytes=$((remaining_content_bytes - entry_size))
+            else
+              head -c "$remaining_content_bytes" "$filesystem_entry" 2>/dev/null | cksum || true
+              remaining_content_bytes=0
+            fi
+          fi
         elif [ "$entry_type" = "link" ]; then
           readlink "$filesystem_entry" 2>/dev/null || true
         fi
-      done < <(find "$worktree_path" \
-        \( -type d -name .git -o -type d -path "$worktree_path/.local/state" \) -prune -o \
+      done < <(find "$filesystem_root" \
+        \( -type d \( -name .git -o -name node_modules -o -name vendor -o -name .cache \) \
+          -o -type d -path "$worktree_path/.local/state" \) -prune -o \
         \( -type d -o -type f -o -type l \) -print0 2>/dev/null)
     fi
   } | cksum | awk '{print $1 ":" $2}'
@@ -520,7 +563,7 @@ if [ "$UNCHANGED_BLOCK_COUNT" -gt "$MAX_UNCHANGED_BLOCKS" ]; then
   cleanup_loop "$STATE_FILE"
   exit 0
 fi
-SYSTEM_MSG="$SYSTEM_MSG Unchanged repository-state block $UNCHANGED_BLOCK_COUNT of $MAX_UNCHANGED_BLOCKS; the loop self-expires before another identical block."
+SYSTEM_MSG="$SYSTEM_MSG Unchanged worktree-state block $UNCHANGED_BLOCK_COUNT of $MAX_UNCHANGED_BLOCKS; the loop self-expires before another identical block."
 
 loop_log "stop-hook: blocking exit, reason='$REASON' unchanged_blocks=$UNCHANGED_BLOCK_COUNT"
 

--- a/plugins/go-workflow/hooks/stop-hook.sh
+++ b/plugins/go-workflow/hooks/stop-hook.sh
@@ -77,19 +77,19 @@ transcript_owns_loop() {
 session_owns_loop_state() {
   local state_file="$1"
   local stored_session_id
-  local stored_worktree_path
+  local stored_session_worktree_path
   local loop_name
 
   [ -f "$state_file" ] && [ -r "$state_file" ] && jq empty "$state_file" 2>/dev/null || return 1
 
   stored_session_id=$(jq -r '.session_id // empty' "$state_file" 2>/dev/null)
-  stored_worktree_path=$(jq -r '.worktree_path // empty' "$state_file" 2>/dev/null)
+  stored_session_worktree_path=$(jq -r '.session_worktree_path // empty' "$state_file" 2>/dev/null)
   loop_name=$(jq -r '.loop_name // empty' "$state_file" 2>/dev/null)
 
-  if [ -n "$stored_worktree_path" ]; then
-    [ -d "$stored_worktree_path" ] || return 1
-    stored_worktree_path=$(cd "$stored_worktree_path" && pwd -P)
-    [ "$stored_worktree_path" = "$CURRENT_WORKTREE_PATH" ] || return 1
+  if [ -n "$stored_session_worktree_path" ]; then
+    [ -d "$stored_session_worktree_path" ] || return 1
+    stored_session_worktree_path=$(cd "$stored_session_worktree_path" && pwd -P)
+    [ "$stored_session_worktree_path" = "$CURRENT_WORKTREE_PATH" ] || return 1
   fi
 
   if [ -n "$stored_session_id" ]; then
@@ -102,9 +102,15 @@ session_owns_loop_state() {
 
 state_has_stale_worktree() {
   local state_file="$1"
-  local stored_worktree_path
-  stored_worktree_path=$(jq -r '.worktree_path // empty' "$state_file" 2>/dev/null)
-  [ -n "$stored_worktree_path" ] && [ ! -d "$stored_worktree_path" ]
+  local field
+  local stored_path
+  for field in session_worktree_path worktree_path; do
+    stored_path=$(jq -r --arg field "$field" '.[$field] // empty' "$state_file" 2>/dev/null)
+    if [ -n "$stored_path" ] && [ ! -d "$stored_path" ]; then
+      return 0
+    fi
+  done
+  return 1
 }
 
 repository_target_required_for() {
@@ -126,9 +132,12 @@ loop_requires_repository_target() {
 
 repository_has_target() {
   local worktree_path="$1"
+  local base_branch="${2:-}"
   local current_branch
   local upstream
   local default_ref
+  local default_branch
+  local remote
   local candidate
   local ahead
 
@@ -140,25 +149,66 @@ repository_has_target() {
 
   upstream=$(git -C "$worktree_path" rev-parse --abbrev-ref '@{upstream}' 2>/dev/null || true)
   if [ -n "$upstream" ]; then
-    ahead=$(git -C "$worktree_path" rev-list --count "$upstream"..HEAD 2>/dev/null || printf '0')
+    ahead=$(git -C "$worktree_path" rev-list --count "$upstream"..HEAD 2>/dev/null) || return 2
     if [ "$ahead" -gt 0 ]; then
       return 0
     fi
   fi
 
   current_branch=$(git -C "$worktree_path" branch --show-current 2>/dev/null || true)
-  default_ref=$(git -C "$worktree_path" symbolic-ref --quiet --short refs/remotes/origin/HEAD 2>/dev/null || true)
+  default_ref=""
+  default_branch=""
+  if [ -n "$base_branch" ]; then
+    case "$base_branch" in
+      refs/heads/*)
+        default_branch="${base_branch#refs/heads/}"
+        candidate="$base_branch"
+        ;;
+      refs/remotes/*)
+        candidate="$base_branch"
+        default_branch="${base_branch#refs/remotes/}"
+        default_branch="${default_branch#*/}"
+        ;;
+      *)
+        default_branch="$base_branch"
+        candidate="$base_branch"
+        ;;
+    esac
+    if git -C "$worktree_path" rev-parse --verify --quiet "$candidate^{commit}" >/dev/null; then
+      default_ref="$candidate"
+    else
+      for remote in $(git -C "$worktree_path" remote); do
+        candidate="$remote/$base_branch"
+        if git -C "$worktree_path" rev-parse --verify --quiet "$candidate^{commit}" >/dev/null; then
+          default_ref="$candidate"
+          break
+        fi
+      done
+    fi
+  fi
   if [ -z "$default_ref" ]; then
-    for candidate in origin/main origin/master main master; do
-      if git -C "$worktree_path" rev-parse --verify --quiet "$candidate^{commit}" >/dev/null; then
+    for remote in $(git -C "$worktree_path" remote); do
+      candidate=$(git -C "$worktree_path" symbolic-ref --quiet --short "refs/remotes/$remote/HEAD" 2>/dev/null || true)
+      if [ -n "$candidate" ] &&
+         git -C "$worktree_path" rev-parse --verify --quiet "$candidate^{commit}" >/dev/null; then
         default_ref="$candidate"
+        default_branch="${candidate#"$remote"/}"
         break
       fi
     done
   fi
-  if [ -n "$current_branch" ] && [ -n "$default_ref" ] &&
-     [ "$current_branch" != "${default_ref#origin/}" ]; then
-    ahead=$(git -C "$worktree_path" rev-list --count "$default_ref"..HEAD 2>/dev/null || printf '0')
+  if [ -z "$default_ref" ]; then
+    for candidate in origin/main origin/master main master; do
+      if git -C "$worktree_path" rev-parse --verify --quiet "$candidate^{commit}" >/dev/null; then
+        default_ref="$candidate"
+        default_branch="${candidate#origin/}"
+        break
+      fi
+    done
+  fi
+  [ -n "$default_ref" ] || return 2
+  if [ -n "$current_branch" ] && [ "$current_branch" != "$default_branch" ]; then
+    ahead=$(git -C "$worktree_path" rev-list --count "$default_ref"..HEAD 2>/dev/null) || return 2
     if [ "$ahead" -gt 0 ]; then
       return 0
     fi
@@ -172,13 +222,15 @@ state_has_no_repository_target() {
   local owner_workflow
   local phase
   local worktree_path
+  local base_branch
   local target_status=0
   owner_workflow=$(jq -r '.owner_workflow // empty' "$state_file" 2>/dev/null)
   phase=$(jq -r '.phase // empty' "$state_file" 2>/dev/null)
   worktree_path=$(jq -r '.worktree_path // empty' "$state_file" 2>/dev/null)
+  base_branch=$(jq -r '.base_branch // empty' "$state_file" 2>/dev/null)
   repository_target_required_for "$owner_workflow" "$phase" || return 1
   [ -n "$worktree_path" ] && [ -d "$worktree_path" ] || return 1
-  repository_has_target "$worktree_path" || target_status=$?
+  repository_has_target "$worktree_path" "$base_branch" || target_status=$?
   [ "$target_status" -eq 1 ]
 }
 
@@ -289,6 +341,12 @@ if [ -z "$STORED_SESSION_ID" ] && [ -n "$CURRENT_SESSION_ID" ]; then
   set_loop_field "$STATE_FILE" "session_id" "$CURRENT_SESSION_ID" '[]'
   loop_log "stop-hook: claimed loop state '$STATE_FILE' for session '$CURRENT_SESSION_ID'"
 fi
+STORED_SESSION_WORKTREE_PATH=$(jq -r '.session_worktree_path // empty' "$STATE_FILE")
+if [ -z "$STORED_SESSION_WORKTREE_PATH" ]; then
+  set_loop_field "$STATE_FILE" "session_worktree_path" "$CURRENT_WORKTREE_PATH" '[]'
+  STORED_SESSION_WORKTREE_PATH="$CURRENT_WORKTREE_PATH"
+  loop_log "stop-hook: claimed loop state '$STATE_FILE' for session worktree '$CURRENT_WORKTREE_PATH'"
+fi
 STORED_WORKTREE_PATH=$(jq -r '.worktree_path // empty' "$STATE_FILE")
 if [ -z "$STORED_WORKTREE_PATH" ]; then
   set_loop_field "$STATE_FILE" "worktree_path" "$CURRENT_WORKTREE_PATH" '[]'
@@ -330,7 +388,8 @@ fi
 
 TARGET_STATUS=0
 if loop_requires_repository_target; then
-  repository_has_target "$STORED_WORKTREE_PATH" || TARGET_STATUS=$?
+  STORED_BASE_BRANCH=$(jq -r '.base_branch // empty' "$STATE_FILE")
+  repository_has_target "$STORED_WORKTREE_PATH" "$STORED_BASE_BRANCH" || TARGET_STATUS=$?
   if [ "$TARGET_STATUS" -eq 1 ]; then
     loop_log "stop-hook: no repository target remains; cleaning up '$STATE_FILE'"
     cleanup_loop "$STATE_FILE"

--- a/plugins/go-workflow/hooks/stop-hook.sh
+++ b/plugins/go-workflow/hooks/stop-hook.sh
@@ -301,8 +301,13 @@ repository_state_fingerprint() {
         fi
         printf '%s\0%s\0' "$entry_type" "$relative_entry"
         if [ "$entry_type" = "file" ]; then
-          entry_metadata=$(stat -f '%z:%m' "$filesystem_entry" 2>/dev/null || \
-            stat -c '%s:%Y' "$filesystem_entry" 2>/dev/null || true)
+          if entry_metadata=$(stat -c '%s:%Y' -- "$filesystem_entry" 2>/dev/null); then
+            :
+          elif entry_metadata=$(stat -f '%z:%m' "$filesystem_entry" 2>/dev/null); then
+            :
+          else
+            entry_metadata=""
+          fi
           printf '%s\0' "$entry_metadata"
           entry_size="${entry_metadata%%:*}"
           case "$entry_size" in

--- a/plugins/go-workflow/hooks/stop-hook.sh
+++ b/plugins/go-workflow/hooks/stop-hook.sh
@@ -241,22 +241,47 @@ repository_state_fingerprint() {
   local head
   local upstream
   local upstream_head
+  local filesystem_entry
+  local relative_entry
+  local entry_type
   head=$(git -C "$worktree_path" rev-parse HEAD 2>/dev/null || true)
   upstream=$(git -C "$worktree_path" rev-parse --abbrev-ref '@{upstream}' 2>/dev/null || true)
   upstream_head=$(git -C "$worktree_path" rev-parse '@{upstream}' 2>/dev/null || true)
   {
     printf '%s\n' "$worktree_path" "$phase" "$reason" "$head" "$upstream" "$upstream_head"
-    git -C "$worktree_path" status --porcelain=v1 --untracked-files=all -- \
-      . ':(exclude).local/state/**' 2>/dev/null || true
-    git -C "$worktree_path" diff --no-ext-diff --binary --cached -- \
-      . ':(exclude).local/state/**' 2>/dev/null || true
-    git -C "$worktree_path" diff --no-ext-diff --binary -- \
-      . ':(exclude).local/state/**' 2>/dev/null || true
-    while IFS= read -r -d '' untracked_file; do
-      printf '%s\0' "$untracked_file"
-      git -C "$worktree_path" hash-object -- "$untracked_file" 2>/dev/null || true
-    done < <(git -C "$worktree_path" ls-files --others --exclude-standard -z -- \
-      . ':(exclude).local/state/**' 2>/dev/null)
+    if git -C "$worktree_path" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+      git -C "$worktree_path" status --porcelain=v1 --untracked-files=all -- \
+        . ':(exclude).local/state/**' 2>/dev/null || true
+      git -C "$worktree_path" diff --no-ext-diff --binary --cached -- \
+        . ':(exclude).local/state/**' 2>/dev/null || true
+      git -C "$worktree_path" diff --no-ext-diff --binary -- \
+        . ':(exclude).local/state/**' 2>/dev/null || true
+      while IFS= read -r -d '' untracked_file; do
+        printf '%s\0' "$untracked_file"
+        git -C "$worktree_path" hash-object -- "$untracked_file" 2>/dev/null || true
+      done < <(git -C "$worktree_path" ls-files --others --exclude-standard -z -- \
+        . ':(exclude).local/state/**' 2>/dev/null)
+    else
+      while IFS= read -r -d '' filesystem_entry; do
+        [ "$filesystem_entry" != "$TRANSCRIPT_PATH" ] || continue
+        relative_entry="${filesystem_entry#"$worktree_path"/}"
+        if [ -L "$filesystem_entry" ]; then
+          entry_type="link"
+        elif [ -d "$filesystem_entry" ]; then
+          entry_type="directory"
+        else
+          entry_type="file"
+        fi
+        printf '%s\0%s\0' "$entry_type" "$relative_entry"
+        if [ "$entry_type" = "file" ]; then
+          cksum < "$filesystem_entry" 2>/dev/null || true
+        elif [ "$entry_type" = "link" ]; then
+          readlink "$filesystem_entry" 2>/dev/null || true
+        fi
+      done < <(find "$worktree_path" \
+        \( -type d -name .git -o -type d -path "$worktree_path/.local/state" \) -prune -o \
+        \( -type d -o -type f -o -type l \) -print0 2>/dev/null)
+    fi
   } | cksum | awk '{print $1 ":" $2}'
 }
 

--- a/plugins/go-workflow/hooks/stop-hook.sh
+++ b/plugins/go-workflow/hooks/stop-hook.sh
@@ -19,6 +19,7 @@ HOOK_INPUT=$(cat)
 # Extract transcript path from hook input
 TRANSCRIPT_PATH=$(echo "$HOOK_INPUT" | jq -r '.transcript_path // empty' 2>/dev/null)
 CURRENT_SESSION_ID=$(echo "$HOOK_INPUT" | jq -r '.session_id // empty' 2>/dev/null)
+HOOK_CWD=$(echo "$HOOK_INPUT" | jq -r '.cwd // empty' 2>/dev/null)
 if [ -z "$CURRENT_SESSION_ID" ] && [ -n "$TRANSCRIPT_PATH" ]; then
   CURRENT_SESSION_ID=$(basename "$TRANSCRIPT_PATH" .jsonl 2>/dev/null || true)
 fi
@@ -33,14 +34,33 @@ fi
 
 source "$LIB_PATH"
 
-loop_log "stop-hook: entered, transcript=$TRANSCRIPT_PATH"
+resolve_current_worktree() {
+  local candidate="$HOOK_CWD"
+  local root
+  if [ -z "$candidate" ] || [ ! -d "$candidate" ]; then
+    candidate=$(pwd -P)
+  fi
+  root=$(git -C "$candidate" rev-parse --show-toplevel 2>/dev/null || true)
+  if [ -n "$root" ] && [ -d "$root" ]; then
+    root=$(cd "$root" && pwd -P)
+  else
+    root=$(cd "$candidate" && pwd -P)
+  fi
+  printf '%s\n' "$root"
+}
+
+CURRENT_WORKTREE_PATH=$(resolve_current_worktree)
+
+loop_log "stop-hook: entered, transcript=$TRANSCRIPT_PATH worktree=$CURRENT_WORKTREE_PATH"
 
 block_stop() {
   local reason="$1"
   local message="$2"
+  local state_context="${3:-${STATE_FILE:-unknown}}"
   if ! printf '%s' "$reason" | grep '[^[:space:]]' >/dev/null; then
     reason="Loop execution is blocked by invalid state."
   fi
+  message="$message State file(s): $state_context. Cancel with /go-workflow:cancel-loop."
   jq -n --arg reason "$reason" --arg msg "$message" \
     '{"decision": "block", "reason": $reason, "systemMessage": $msg}'
 }
@@ -57,19 +77,135 @@ transcript_owns_loop() {
 session_owns_loop_state() {
   local state_file="$1"
   local stored_session_id
+  local stored_worktree_path
   local loop_name
 
   [ -f "$state_file" ] && [ -r "$state_file" ] && jq empty "$state_file" 2>/dev/null || return 1
 
   stored_session_id=$(jq -r '.session_id // empty' "$state_file" 2>/dev/null)
+  stored_worktree_path=$(jq -r '.worktree_path // empty' "$state_file" 2>/dev/null)
   loop_name=$(jq -r '.loop_name // empty' "$state_file" 2>/dev/null)
 
-  if [ -n "$stored_session_id" ] && [ -n "$CURRENT_SESSION_ID" ]; then
-    [ "$stored_session_id" = "$CURRENT_SESSION_ID" ]
+  if [ -n "$stored_worktree_path" ]; then
+    [ -d "$stored_worktree_path" ] || return 1
+    stored_worktree_path=$(cd "$stored_worktree_path" && pwd -P)
+    [ "$stored_worktree_path" = "$CURRENT_WORKTREE_PATH" ] || return 1
+  fi
+
+  if [ -n "$stored_session_id" ]; then
+    [ -n "$CURRENT_SESSION_ID" ] && [ "$stored_session_id" = "$CURRENT_SESSION_ID" ]
     return
   fi
 
   transcript_owns_loop "$loop_name"
+}
+
+state_has_stale_worktree() {
+  local state_file="$1"
+  local stored_worktree_path
+  stored_worktree_path=$(jq -r '.worktree_path // empty' "$state_file" 2>/dev/null)
+  [ -n "$stored_worktree_path" ] && [ ! -d "$stored_worktree_path" ]
+}
+
+repository_target_required_for() {
+  local owner_workflow="$1"
+  local phase="$2"
+  case "$owner_workflow:$phase" in
+    ship:reviewing|ship:pushing)
+      return 0
+      ;;
+    *)
+      return 1
+      ;;
+  esac
+}
+
+loop_requires_repository_target() {
+  repository_target_required_for "$OWNER_WORKFLOW" "$PHASE"
+}
+
+repository_has_target() {
+  local worktree_path="$1"
+  local current_branch
+  local upstream
+  local default_ref
+  local candidate
+  local ahead
+
+  git -C "$worktree_path" rev-parse --is-inside-work-tree >/dev/null 2>&1 || return 2
+
+  if ! git -C "$worktree_path" diff --cached --quiet --; then
+    return 0
+  fi
+
+  upstream=$(git -C "$worktree_path" rev-parse --abbrev-ref '@{upstream}' 2>/dev/null || true)
+  if [ -n "$upstream" ]; then
+    ahead=$(git -C "$worktree_path" rev-list --count "$upstream"..HEAD 2>/dev/null || printf '0')
+    if [ "$ahead" -gt 0 ]; then
+      return 0
+    fi
+  fi
+
+  current_branch=$(git -C "$worktree_path" branch --show-current 2>/dev/null || true)
+  default_ref=$(git -C "$worktree_path" symbolic-ref --quiet --short refs/remotes/origin/HEAD 2>/dev/null || true)
+  if [ -z "$default_ref" ]; then
+    for candidate in origin/main origin/master main master; do
+      if git -C "$worktree_path" rev-parse --verify --quiet "$candidate^{commit}" >/dev/null; then
+        default_ref="$candidate"
+        break
+      fi
+    done
+  fi
+  if [ -n "$current_branch" ] && [ -n "$default_ref" ] &&
+     [ "$current_branch" != "${default_ref#origin/}" ]; then
+    ahead=$(git -C "$worktree_path" rev-list --count "$default_ref"..HEAD 2>/dev/null || printf '0')
+    if [ "$ahead" -gt 0 ]; then
+      return 0
+    fi
+  fi
+
+  return 1
+}
+
+state_has_no_repository_target() {
+  local state_file="$1"
+  local owner_workflow
+  local phase
+  local worktree_path
+  local target_status=0
+  owner_workflow=$(jq -r '.owner_workflow // empty' "$state_file" 2>/dev/null)
+  phase=$(jq -r '.phase // empty' "$state_file" 2>/dev/null)
+  worktree_path=$(jq -r '.worktree_path // empty' "$state_file" 2>/dev/null)
+  repository_target_required_for "$owner_workflow" "$phase" || return 1
+  [ -n "$worktree_path" ] && [ -d "$worktree_path" ] || return 1
+  repository_has_target "$worktree_path" || target_status=$?
+  [ "$target_status" -eq 1 ]
+}
+
+repository_state_fingerprint() {
+  local worktree_path="$1"
+  local phase="$2"
+  local reason="$3"
+  local head
+  local upstream
+  local upstream_head
+  head=$(git -C "$worktree_path" rev-parse HEAD 2>/dev/null || true)
+  upstream=$(git -C "$worktree_path" rev-parse --abbrev-ref '@{upstream}' 2>/dev/null || true)
+  upstream_head=$(git -C "$worktree_path" rev-parse '@{upstream}' 2>/dev/null || true)
+  {
+    printf '%s\n' "$worktree_path" "$phase" "$reason" "$head" "$upstream" "$upstream_head"
+    git -C "$worktree_path" status --porcelain=v1 --untracked-files=all -- \
+      . ':(exclude).local/state/**' 2>/dev/null || true
+    git -C "$worktree_path" diff --no-ext-diff --binary --cached -- \
+      . ':(exclude).local/state/**' 2>/dev/null || true
+    git -C "$worktree_path" diff --no-ext-diff --binary -- \
+      . ':(exclude).local/state/**' 2>/dev/null || true
+    while IFS= read -r -d '' untracked_file; do
+      printf '%s\0' "$untracked_file"
+      git -C "$worktree_path" hash-object -- "$untracked_file" 2>/dev/null || true
+    done < <(git -C "$worktree_path" ls-files --others --exclude-standard -z -- \
+      . ':(exclude).local/state/**' 2>/dev/null)
+  } | cksum | awk '{print $1 ":" $2}'
 }
 
 # Find any active loop state file
@@ -78,7 +214,17 @@ STATE_FILES=$(find_active_loops)
 OWNED_STATE_FILES=""
 while IFS= read -r CANDIDATE_STATE_FILE; do
   [ -n "$CANDIDATE_STATE_FILE" ] || continue
+  if state_has_stale_worktree "$CANDIDATE_STATE_FILE"; then
+    loop_log "stop-hook: pruning stale loop state '$CANDIDATE_STATE_FILE'"
+    cleanup_loop "$CANDIDATE_STATE_FILE"
+    continue
+  fi
   if session_owns_loop_state "$CANDIDATE_STATE_FILE"; then
+    if state_has_no_repository_target "$CANDIDATE_STATE_FILE"; then
+      loop_log "stop-hook: pruning targetless loop state '$CANDIDATE_STATE_FILE'"
+      cleanup_loop "$CANDIDATE_STATE_FILE"
+      continue
+    fi
     if [ -z "$OWNED_STATE_FILES" ]; then
       OWNED_STATE_FILES="$CANDIDATE_STATE_FILE"
     else
@@ -101,7 +247,8 @@ if [ "$STATE_COUNT" -ne 1 ]; then
   MULTIPLE_REASON=$(printf 'Multiple active loop states were found; ownership is ambiguous:\n%s' "$STATE_FILES")
   loop_log "stop-hook: refusing ambiguous active loops: $STATE_FILES"
   block_stop "$MULTIPLE_REASON" \
-    "$MULTIPLE_REASON Cancel the orphaned loop states or restore one caller-owned state before continuing."
+    "$MULTIPLE_REASON Cancel the orphaned loop states or restore one caller-owned state before continuing." \
+    "$STATE_FILES"
   exit 0
 fi
 
@@ -142,6 +289,12 @@ if [ -z "$STORED_SESSION_ID" ] && [ -n "$CURRENT_SESSION_ID" ]; then
   set_loop_field "$STATE_FILE" "session_id" "$CURRENT_SESSION_ID" '[]'
   loop_log "stop-hook: claimed loop state '$STATE_FILE' for session '$CURRENT_SESSION_ID'"
 fi
+STORED_WORKTREE_PATH=$(jq -r '.worktree_path // empty' "$STATE_FILE")
+if [ -z "$STORED_WORKTREE_PATH" ]; then
+  set_loop_field "$STATE_FILE" "worktree_path" "$CURRENT_WORKTREE_PATH" '[]'
+  STORED_WORKTREE_PATH="$CURRENT_WORKTREE_PATH"
+  loop_log "stop-hook: claimed loop state '$STATE_FILE' for worktree '$CURRENT_WORKTREE_PATH'"
+fi
 
 # Validate iteration is a number
 if ! [[ "$ITERATION" =~ ^[0-9]+$ ]]; then
@@ -170,6 +323,16 @@ if [ -n "$COMPLETION_PROMISE" ] && [ -n "$TRANSCRIPT_PATH" ] && [ -f "$TRANSCRIP
   loop_log "stop-hook: checking completion promise '$COMPLETION_PROMISE'"
   if check_completion_promise "$COMPLETION_PROMISE" "$TRANSCRIPT_PATH"; then
     loop_log "stop-hook: completion promise found, cleaning up"
+    cleanup_loop "$STATE_FILE"
+    exit 0
+  fi
+fi
+
+TARGET_STATUS=0
+if loop_requires_repository_target; then
+  repository_has_target "$STORED_WORKTREE_PATH" || TARGET_STATUS=$?
+  if [ "$TARGET_STATUS" -eq 1 ]; then
+    loop_log "stop-hook: no repository target remains; cleaning up '$STATE_FILE'"
     cleanup_loop "$STATE_FILE"
     exit 0
   fi
@@ -265,8 +428,16 @@ if ! printf '%s' "$REASON" | grep '[^[:space:]]' >/dev/null; then
   REASON="Continue working on the task."
 fi
 
-loop_log "stop-hook: blocking exit, reason='$REASON'"
+MAX_UNCHANGED_BLOCKS=3
+BLOCK_FINGERPRINT=$(repository_state_fingerprint "$STORED_WORKTREE_PATH" "$PHASE" "$REASON")
+UNCHANGED_BLOCK_COUNT=$(record_loop_block_attempt "$STATE_FILE" "$BLOCK_FINGERPRINT")
+if [ "$UNCHANGED_BLOCK_COUNT" -gt "$MAX_UNCHANGED_BLOCKS" ]; then
+  loop_log "stop-hook: unchanged block cap reached ($UNCHANGED_BLOCK_COUNT > $MAX_UNCHANGED_BLOCKS); cleaning up '$STATE_FILE'"
+  cleanup_loop "$STATE_FILE"
+  exit 0
+fi
+SYSTEM_MSG="$SYSTEM_MSG Unchanged repository-state block $UNCHANGED_BLOCK_COUNT of $MAX_UNCHANGED_BLOCKS; the loop self-expires before another identical block."
 
-# Block exit and re-feed prompt
-jq -n --arg reason "$REASON" --arg msg "$SYSTEM_MSG" \
-  '{"decision": "block", "reason": $reason, "systemMessage": $msg}'
+loop_log "stop-hook: blocking exit, reason='$REASON' unchanged_blocks=$UNCHANGED_BLOCK_COUNT"
+
+block_stop "$REASON" "$SYSTEM_MSG" "$STATE_FILE"

--- a/plugins/go-workflow/lib/loop-state.sh
+++ b/plugins/go-workflow/lib/loop-state.sh
@@ -18,6 +18,17 @@ resolve_loop_owner_root() {
   printf '%s\n' "$root"
 }
 
+resolve_loop_worktree_root() {
+  local root
+  root=$(git rev-parse --show-toplevel 2>/dev/null || true)
+  if [ -z "$root" ]; then
+    root=$(pwd -P)
+  elif [ -d "$root" ]; then
+    root=$(cd "$root" && pwd -P)
+  fi
+  printf '%s\n' "$root"
+}
+
 loop_state_directory() {
   printf '%s/.local/state\n' "$(resolve_loop_owner_root)"
 }
@@ -246,6 +257,22 @@ increment_iteration() {
   ensure_loop_state_schema "$state_file" || return 1
   jq '.iteration = ((.iteration // 0) + 1)' "$state_file" > "$tmp_file" && mv "$tmp_file" "$state_file"
   loop_log "increment_iteration: file=$state_file"
+}
+
+record_loop_block_attempt() {
+  local state_file="$1"
+  local fingerprint="$2"
+  local tmp_file="${state_file}.tmp.$$"
+  ensure_loop_state_schema "$state_file" || return 1
+  jq --arg fingerprint "$fingerprint" '
+    if (.last_block_fingerprint // "") == $fingerprint then
+      .unchanged_block_count = ((.unchanged_block_count // 0) + 1)
+    else
+      .last_block_fingerprint = $fingerprint |
+      .unchanged_block_count = 1
+    end
+  ' "$state_file" > "$tmp_file" && mv "$tmp_file" "$state_file"
+  jq -r '.unchanged_block_count' "$state_file"
 }
 
 set_loop_phase() {

--- a/plugins/go-workflow/scripts/setup-loop.sh
+++ b/plugins/go-workflow/scripts/setup-loop.sh
@@ -98,6 +98,7 @@ if [ "$ACTIVE_COUNT" -ne 0 ]; then
 fi
 
 SESSION_ID="${CLAUDE_SESSION_ID:-}"
+WORKTREE_PATH=$(resolve_loop_worktree_root)
 
 MAX_ITER_JSON="null"
 if [ -n "$MAX_ITERATIONS" ]; then
@@ -131,6 +132,7 @@ jq -n \
   --arg phase "$INITIAL_PHASE" \
   --arg started_at "$(date -u +"%Y-%m-%dT%H:%M:%SZ")" \
   --arg session_id "$SESSION_ID" \
+  --arg worktree_path "$WORKTREE_PATH" \
   --argjson phase_messages "$PHASE_MSGS_JSON" \
   '{
     schema_version: $schema_version,
@@ -144,6 +146,7 @@ jq -n \
     bot_review_baseline: "",
     started_at: $started_at,
     session_id: $session_id,
+    worktree_path: $worktree_path,
     awaiting_driver_input: false,
     driver_input_reason: "",
     phase_messages: $phase_messages,

--- a/plugins/go-workflow/scripts/setup-loop.sh
+++ b/plugins/go-workflow/scripts/setup-loop.sh
@@ -99,6 +99,7 @@ fi
 
 SESSION_ID="${CLAUDE_SESSION_ID:-}"
 WORKTREE_PATH=$(resolve_loop_worktree_root)
+SESSION_WORKTREE_PATH="$WORKTREE_PATH"
 
 MAX_ITER_JSON="null"
 if [ -n "$MAX_ITERATIONS" ]; then
@@ -132,6 +133,7 @@ jq -n \
   --arg phase "$INITIAL_PHASE" \
   --arg started_at "$(date -u +"%Y-%m-%dT%H:%M:%SZ")" \
   --arg session_id "$SESSION_ID" \
+  --arg session_worktree_path "$SESSION_WORKTREE_PATH" \
   --arg worktree_path "$WORKTREE_PATH" \
   --argjson phase_messages "$PHASE_MSGS_JSON" \
   '{
@@ -146,6 +148,7 @@ jq -n \
     bot_review_baseline: "",
     started_at: $started_at,
     session_id: $session_id,
+    session_worktree_path: $session_worktree_path,
     worktree_path: $worktree_path,
     awaiting_driver_input: false,
     driver_input_reason: "",

--- a/plugins/llm-tools/lib/loop-state.sh
+++ b/plugins/llm-tools/lib/loop-state.sh
@@ -18,6 +18,17 @@ resolve_loop_owner_root() {
   printf '%s\n' "$root"
 }
 
+resolve_loop_worktree_root() {
+  local root
+  root=$(git rev-parse --show-toplevel 2>/dev/null || true)
+  if [ -z "$root" ]; then
+    root=$(pwd -P)
+  elif [ -d "$root" ]; then
+    root=$(cd "$root" && pwd -P)
+  fi
+  printf '%s\n' "$root"
+}
+
 loop_state_directory() {
   printf '%s/.local/state\n' "$(resolve_loop_owner_root)"
 }
@@ -246,6 +257,22 @@ increment_iteration() {
   ensure_loop_state_schema "$state_file" || return 1
   jq '.iteration = ((.iteration // 0) + 1)' "$state_file" > "$tmp_file" && mv "$tmp_file" "$state_file"
   loop_log "increment_iteration: file=$state_file"
+}
+
+record_loop_block_attempt() {
+  local state_file="$1"
+  local fingerprint="$2"
+  local tmp_file="${state_file}.tmp.$$"
+  ensure_loop_state_schema "$state_file" || return 1
+  jq --arg fingerprint "$fingerprint" '
+    if (.last_block_fingerprint // "") == $fingerprint then
+      .unchanged_block_count = ((.unchanged_block_count // 0) + 1)
+    else
+      .last_block_fingerprint = $fingerprint |
+      .unchanged_block_count = 1
+    end
+  ' "$state_file" > "$tmp_file" && mv "$tmp_file" "$state_file"
+  jq -r '.unchanged_block_count' "$state_file"
 }
 
 set_loop_phase() {

--- a/plugins/llm-tools/scripts/setup-loop.sh
+++ b/plugins/llm-tools/scripts/setup-loop.sh
@@ -98,6 +98,7 @@ if [ "$ACTIVE_COUNT" -ne 0 ]; then
 fi
 
 SESSION_ID="${CLAUDE_SESSION_ID:-}"
+WORKTREE_PATH=$(resolve_loop_worktree_root)
 
 MAX_ITER_JSON="null"
 if [ -n "$MAX_ITERATIONS" ]; then
@@ -131,6 +132,7 @@ jq -n \
   --arg phase "$INITIAL_PHASE" \
   --arg started_at "$(date -u +"%Y-%m-%dT%H:%M:%SZ")" \
   --arg session_id "$SESSION_ID" \
+  --arg worktree_path "$WORKTREE_PATH" \
   --argjson phase_messages "$PHASE_MSGS_JSON" \
   '{
     schema_version: $schema_version,
@@ -144,6 +146,7 @@ jq -n \
     bot_review_baseline: "",
     started_at: $started_at,
     session_id: $session_id,
+    worktree_path: $worktree_path,
     awaiting_driver_input: false,
     driver_input_reason: "",
     phase_messages: $phase_messages,

--- a/plugins/llm-tools/scripts/setup-loop.sh
+++ b/plugins/llm-tools/scripts/setup-loop.sh
@@ -99,6 +99,7 @@ fi
 
 SESSION_ID="${CLAUDE_SESSION_ID:-}"
 WORKTREE_PATH=$(resolve_loop_worktree_root)
+SESSION_WORKTREE_PATH="$WORKTREE_PATH"
 
 MAX_ITER_JSON="null"
 if [ -n "$MAX_ITERATIONS" ]; then
@@ -132,6 +133,7 @@ jq -n \
   --arg phase "$INITIAL_PHASE" \
   --arg started_at "$(date -u +"%Y-%m-%dT%H:%M:%SZ")" \
   --arg session_id "$SESSION_ID" \
+  --arg session_worktree_path "$SESSION_WORKTREE_PATH" \
   --arg worktree_path "$WORKTREE_PATH" \
   --argjson phase_messages "$PHASE_MSGS_JSON" \
   '{
@@ -146,6 +148,7 @@ jq -n \
     bot_review_baseline: "",
     started_at: $started_at,
     session_id: $session_id,
+    session_worktree_path: $session_worktree_path,
     worktree_path: $worktree_path,
     awaiting_driver_input: false,
     driver_input_reason: "",

--- a/plugins/tailwind/lib/loop-state.sh
+++ b/plugins/tailwind/lib/loop-state.sh
@@ -18,6 +18,17 @@ resolve_loop_owner_root() {
   printf '%s\n' "$root"
 }
 
+resolve_loop_worktree_root() {
+  local root
+  root=$(git rev-parse --show-toplevel 2>/dev/null || true)
+  if [ -z "$root" ]; then
+    root=$(pwd -P)
+  elif [ -d "$root" ]; then
+    root=$(cd "$root" && pwd -P)
+  fi
+  printf '%s\n' "$root"
+}
+
 loop_state_directory() {
   printf '%s/.local/state\n' "$(resolve_loop_owner_root)"
 }
@@ -246,6 +257,22 @@ increment_iteration() {
   ensure_loop_state_schema "$state_file" || return 1
   jq '.iteration = ((.iteration // 0) + 1)' "$state_file" > "$tmp_file" && mv "$tmp_file" "$state_file"
   loop_log "increment_iteration: file=$state_file"
+}
+
+record_loop_block_attempt() {
+  local state_file="$1"
+  local fingerprint="$2"
+  local tmp_file="${state_file}.tmp.$$"
+  ensure_loop_state_schema "$state_file" || return 1
+  jq --arg fingerprint "$fingerprint" '
+    if (.last_block_fingerprint // "") == $fingerprint then
+      .unchanged_block_count = ((.unchanged_block_count // 0) + 1)
+    else
+      .last_block_fingerprint = $fingerprint |
+      .unchanged_block_count = 1
+    end
+  ' "$state_file" > "$tmp_file" && mv "$tmp_file" "$state_file"
+  jq -r '.unchanged_block_count' "$state_file"
 }
 
 set_loop_phase() {

--- a/plugins/tailwind/scripts/setup-loop.sh
+++ b/plugins/tailwind/scripts/setup-loop.sh
@@ -98,6 +98,7 @@ if [ "$ACTIVE_COUNT" -ne 0 ]; then
 fi
 
 SESSION_ID="${CLAUDE_SESSION_ID:-}"
+WORKTREE_PATH=$(resolve_loop_worktree_root)
 
 MAX_ITER_JSON="null"
 if [ -n "$MAX_ITERATIONS" ]; then
@@ -131,6 +132,7 @@ jq -n \
   --arg phase "$INITIAL_PHASE" \
   --arg started_at "$(date -u +"%Y-%m-%dT%H:%M:%SZ")" \
   --arg session_id "$SESSION_ID" \
+  --arg worktree_path "$WORKTREE_PATH" \
   --argjson phase_messages "$PHASE_MSGS_JSON" \
   '{
     schema_version: $schema_version,
@@ -144,6 +146,7 @@ jq -n \
     bot_review_baseline: "",
     started_at: $started_at,
     session_id: $session_id,
+    worktree_path: $worktree_path,
     awaiting_driver_input: false,
     driver_input_reason: "",
     phase_messages: $phase_messages,

--- a/plugins/tailwind/scripts/setup-loop.sh
+++ b/plugins/tailwind/scripts/setup-loop.sh
@@ -99,6 +99,7 @@ fi
 
 SESSION_ID="${CLAUDE_SESSION_ID:-}"
 WORKTREE_PATH=$(resolve_loop_worktree_root)
+SESSION_WORKTREE_PATH="$WORKTREE_PATH"
 
 MAX_ITER_JSON="null"
 if [ -n "$MAX_ITERATIONS" ]; then
@@ -132,6 +133,7 @@ jq -n \
   --arg phase "$INITIAL_PHASE" \
   --arg started_at "$(date -u +"%Y-%m-%dT%H:%M:%SZ")" \
   --arg session_id "$SESSION_ID" \
+  --arg session_worktree_path "$SESSION_WORKTREE_PATH" \
   --arg worktree_path "$WORKTREE_PATH" \
   --argjson phase_messages "$PHASE_MSGS_JSON" \
   '{
@@ -146,6 +148,7 @@ jq -n \
     bot_review_baseline: "",
     started_at: $started_at,
     session_id: $session_id,
+    session_worktree_path: $session_worktree_path,
     worktree_path: $worktree_path,
     awaiting_driver_input: false,
     driver_input_reason: "",

--- a/scripts/test-hooks.sh
+++ b/scripts/test-hooks.sh
@@ -533,8 +533,9 @@ STALE_WORKTREE_STATE="$STALE_WORKTREE_ROOT/.local/state/ship.loop.local.json"
 STALE_WORKTREE_TRANSCRIPT="$STALE_WORKTREE_ROOT/transcript.jsonl"
 mkdir -p "$(dirname "$STALE_WORKTREE_STATE")"
 jq -n \
+  --arg owner "$STALE_WORKTREE_ROOT" \
   --arg missing "$STALE_WORKTREE_ROOT/missing-worktree" \
-  '{schema_version:2,owner_workflow:"ship",loop_name:"ship",iteration:1,max_iterations:50,completion_promise:"SHIPPED",terminal_promises:["SHIPPED","INCOMPLETE"],components:{},phase:"pushing",original_prompt:"ship",session_id:"owner-session",worktree_path:$missing}' \
+  '{schema_version:2,owner_workflow:"ship",loop_name:"ship",iteration:1,max_iterations:50,completion_promise:"SHIPPED",terminal_promises:["SHIPPED","INCOMPLETE"],components:{},phase:"pushing",original_prompt:"ship",session_id:"owner-session",session_worktree_path:$owner,worktree_path:$missing}' \
   > "$STALE_WORKTREE_STATE"
 printf '%s\n' '{"role":"user","message":{"content":[{"type":"tool_result","content":"Loop initialized: ship"}]}}' > "$STALE_WORKTREE_TRANSCRIPT"
 STALE_WORKTREE_OUTPUT=$(
@@ -561,7 +562,7 @@ git -C "$WORKTREE_MAIN" worktree add -qb linked-fixture "$WORKTREE_LINKED" >/dev
 mkdir -p "$WORKTREE_MAIN/.local/state"
 jq -n \
   --arg worktree "$WORKTREE_MAIN" \
-  '{schema_version:2,owner_workflow:"start-issue",loop_name:"start-issue-42",iteration:1,max_iterations:50,completion_promise:"COMPLETE",terminal_promises:["COMPLETE","INCOMPLETE"],components:{},phase:"implementing",original_prompt:"issue 42",session_id:"owner-session",worktree_path:$worktree}' \
+  '{schema_version:2,owner_workflow:"start-issue",loop_name:"start-issue-42",iteration:1,max_iterations:50,completion_promise:"COMPLETE",terminal_promises:["COMPLETE","INCOMPLETE"],components:{},phase:"implementing",original_prompt:"issue 42",session_id:"owner-session",session_worktree_path:$worktree,worktree_path:$worktree}' \
   > "$WORKTREE_MAIN/.local/state/start-issue-42.loop.local.json"
 WORKTREE_TRANSCRIPT="$WORKTREE_LINKED/transcript.jsonl"
 printf '%s\n' \
@@ -583,18 +584,20 @@ else
   ERRORS=$((ERRORS + 1))
 fi
 
-echo -n "  Linked-worktree Stop hook resumes state scoped to that worktree... "
+echo -n "  Stop hook separates the session checkout from a linked workflow target... "
 rm -f "$WORKTREE_MAIN/.local/state/start-issue-42.loop.local.json"
 jq -n \
-  --arg worktree "$WORKTREE_LINKED" \
-  '{schema_version:2,owner_workflow:"start-issue",loop_name:"start-issue-43",iteration:1,max_iterations:50,completion_promise:"COMPLETE",terminal_promises:["COMPLETE","INCOMPLETE"],components:{},phase:"implementing",original_prompt:"issue 43",session_id:"owner-session",worktree_path:$worktree}' \
+  --arg owner "$WORKTREE_MAIN" \
+  --arg target "$WORKTREE_LINKED" \
+  '{schema_version:2,owner_workflow:"start-issue",loop_name:"start-issue-43",iteration:1,max_iterations:50,completion_promise:"COMPLETE",terminal_promises:["COMPLETE","INCOMPLETE"],components:{},phase:"implementing",original_prompt:"issue 43",session_id:"owner-session",session_worktree_path:$owner,worktree_path:$target}' \
   > "$WORKTREE_MAIN/.local/state/start-issue-43.loop.local.json"
+WORKTREE_TRANSCRIPT="$WORKTREE_MAIN/transcript.jsonl"
 printf '%s\n' \
   '{"role":"user","message":{"content":[{"type":"tool_result","content":"Loop initialized: start-issue-43"}]}}' \
   '{"role":"assistant","message":{"content":[{"type":"text","text":"<done>COMPLETE</done>"}]}}' \
   > "$WORKTREE_TRANSCRIPT"
 WORKTREE_OUTPUT=$(
-  cd "$WORKTREE_LINKED"
+  cd "$WORKTREE_MAIN"
   jq -n --arg transcript "$WORKTREE_TRANSCRIPT" --arg session "owner-session" \
     '{transcript_path: $transcript, session_id: $session}' | "$CORE_STOP_HOOK"
 )
@@ -615,7 +618,7 @@ for NO_TARGET_PHASE in reviewing pushing; do
   jq -n \
     --arg worktree "$WORKTREE_MAIN" \
     --arg phase "$NO_TARGET_PHASE" \
-    '{schema_version:2,owner_workflow:"ship",loop_name:"ship",iteration:1,max_iterations:50,completion_promise:"SHIPPED",terminal_promises:["SHIPPED","INCOMPLETE"],components:{},phase:$phase,original_prompt:"ship",session_id:"owner-session",worktree_path:$worktree}' \
+    '{schema_version:2,owner_workflow:"ship",loop_name:"ship",iteration:1,max_iterations:50,completion_promise:"SHIPPED",terminal_promises:["SHIPPED","INCOMPLETE"],components:{},phase:$phase,original_prompt:"ship",session_id:"owner-session",session_worktree_path:$worktree,worktree_path:$worktree}' \
     > "$NO_TARGET_STATE"
   NO_TARGET_OUTPUT=$(
     cd "$WORKTREE_MAIN"
@@ -636,7 +639,7 @@ fi
 echo -n "  Stop hook preserves targetless recovery state owned by another session... "
 jq -n \
   --arg worktree "$WORKTREE_MAIN" \
-  '{schema_version:2,owner_workflow:"ship",loop_name:"ship",iteration:1,max_iterations:50,completion_promise:"SHIPPED",terminal_promises:["SHIPPED","INCOMPLETE"],components:{},phase:"pushing",original_prompt:"ship",session_id:"foreign-session",worktree_path:$worktree}' \
+  '{schema_version:2,owner_workflow:"ship",loop_name:"ship",iteration:1,max_iterations:50,completion_promise:"SHIPPED",terminal_promises:["SHIPPED","INCOMPLETE"],components:{},phase:"pushing",original_prompt:"ship",session_id:"foreign-session",session_worktree_path:$worktree,worktree_path:$worktree}' \
   > "$NO_TARGET_STATE"
 FOREIGN_NO_TARGET_BEFORE=$(cksum "$NO_TARGET_STATE")
 FOREIGN_NO_TARGET_OUTPUT=$(
@@ -659,7 +662,7 @@ for CLEAN_WAIT_PHASE in ci-watch bot-watching merging; do
   jq -n \
     --arg worktree "$WORKTREE_MAIN" \
     --arg phase "$CLEAN_WAIT_PHASE" \
-    '{schema_version:2,owner_workflow:"ship",loop_name:"ship",iteration:1,max_iterations:50,completion_promise:"SHIPPED",terminal_promises:["SHIPPED","INCOMPLETE"],components:{},phase:$phase,original_prompt:"ship",session_id:"owner-session",worktree_path:$worktree}' \
+    '{schema_version:2,owner_workflow:"ship",loop_name:"ship",iteration:1,max_iterations:50,completion_promise:"SHIPPED",terminal_promises:["SHIPPED","INCOMPLETE"],components:{},phase:$phase,original_prompt:"ship",session_id:"owner-session",session_worktree_path:$worktree,worktree_path:$worktree}' \
     > "$NO_TARGET_STATE"
   CLEAN_WAIT_OUTPUT=$(
     cd "$WORKTREE_MAIN"
@@ -690,7 +693,7 @@ STAGED_TARGET_TRANSCRIPT="$STAGED_TARGET_ROOT/transcript.jsonl"
 mkdir -p "$(dirname "$STAGED_TARGET_STATE")"
 jq -n \
   --arg worktree "$STAGED_TARGET_ROOT" \
-  '{schema_version:2,owner_workflow:"ship",loop_name:"ship",iteration:1,max_iterations:50,completion_promise:"SHIPPED",terminal_promises:["SHIPPED","INCOMPLETE"],components:{},phase:"pushing",original_prompt:"ship",session_id:"owner-session",worktree_path:$worktree}' \
+  '{schema_version:2,owner_workflow:"ship",loop_name:"ship",iteration:1,max_iterations:50,completion_promise:"SHIPPED",terminal_promises:["SHIPPED","INCOMPLETE"],components:{},phase:"pushing",original_prompt:"ship",session_id:"owner-session",session_worktree_path:$worktree,worktree_path:$worktree}' \
   > "$STAGED_TARGET_STATE"
 printf '%s\n' '{"role":"user","message":{"content":[{"type":"tool_result","content":"Loop initialized: ship"}]}}' > "$STAGED_TARGET_TRANSCRIPT"
 STAGED_TARGET_OUTPUT=$(
@@ -723,7 +726,7 @@ UNPUSHED_TRANSCRIPT="$UNPUSHED_WORKTREE/transcript.jsonl"
 mkdir -p "$(dirname "$UNPUSHED_STATE")"
 jq -n \
   --arg worktree "$UNPUSHED_WORKTREE" \
-  '{schema_version:2,owner_workflow:"ship",loop_name:"ship",iteration:1,max_iterations:50,completion_promise:"SHIPPED",terminal_promises:["SHIPPED","INCOMPLETE"],components:{},phase:"pushing",original_prompt:"ship",session_id:"owner-session",worktree_path:$worktree}' \
+  '{schema_version:2,owner_workflow:"ship",loop_name:"ship",iteration:1,max_iterations:50,completion_promise:"SHIPPED",terminal_promises:["SHIPPED","INCOMPLETE"],components:{},phase:"pushing",original_prompt:"ship",session_id:"owner-session",session_worktree_path:$worktree,worktree_path:$worktree}' \
   > "$UNPUSHED_STATE"
 printf '%s\n' '{"role":"user","message":{"content":[{"type":"tool_result","content":"Loop initialized: ship"}]}}' > "$UNPUSHED_TRANSCRIPT"
 UNPUSHED_OUTPUT=$(
@@ -739,6 +742,41 @@ else
   ERRORS=$((ERRORS + 1))
 fi
 
+echo -n "  Stop hook uses the persisted nonstandard base branch... "
+NONSTANDARD_FIXTURE=$(mktemp -d "$HOOK_TMP_BASE/gopher-ai-stop-hook-nonstandard-base.XXXXXX")
+NONSTANDARD_REMOTE="$NONSTANDARD_FIXTURE/remote.git"
+NONSTANDARD_WORKTREE="$NONSTANDARD_FIXTURE/worktree"
+git init --bare -q "$NONSTANDARD_REMOTE"
+git init -b develop -q "$NONSTANDARD_WORKTREE"
+git -C "$NONSTANDARD_WORKTREE" -c user.name='Hook Tests' -c user.email='hooks@example.com' \
+  commit --allow-empty -qm 'test: initialize nonstandard base'
+git -C "$NONSTANDARD_WORKTREE" remote add origin "$NONSTANDARD_REMOTE"
+git -C "$NONSTANDARD_WORKTREE" push -qu origin develop
+git -C "$NONSTANDARD_WORKTREE" checkout -qb feature
+git -C "$NONSTANDARD_WORKTREE" -c user.name='Hook Tests' -c user.email='hooks@example.com' \
+  commit --allow-empty -qm 'test: create fully pushed feature'
+git -C "$NONSTANDARD_WORKTREE" push -qu -u origin feature
+NONSTANDARD_STATE="$NONSTANDARD_WORKTREE/.local/state/ship.loop.local.json"
+NONSTANDARD_TRANSCRIPT="$NONSTANDARD_WORKTREE/transcript.jsonl"
+mkdir -p "$(dirname "$NONSTANDARD_STATE")"
+jq -n \
+  --arg worktree "$NONSTANDARD_WORKTREE" \
+  '{schema_version:2,owner_workflow:"ship",loop_name:"ship",iteration:1,max_iterations:50,completion_promise:"SHIPPED",terminal_promises:["SHIPPED","INCOMPLETE"],components:{},phase:"pushing",base_branch:"develop",original_prompt:"ship",session_id:"owner-session",session_worktree_path:$worktree,worktree_path:$worktree}' \
+  > "$NONSTANDARD_STATE"
+printf '%s\n' '{"role":"user","message":{"content":[{"type":"tool_result","content":"Loop initialized: ship"}]}}' > "$NONSTANDARD_TRANSCRIPT"
+NONSTANDARD_OUTPUT=$(
+  cd "$NONSTANDARD_WORKTREE"
+  jq -n --arg transcript "$NONSTANDARD_TRANSCRIPT" --arg session "owner-session" \
+    '{transcript_path: $transcript, session_id: $session}' | "$CORE_STOP_HOOK"
+)
+if printf '%s\n' "$NONSTANDARD_OUTPUT" | jq -e '.decision == "block"' >/dev/null 2>&1 &&
+   [ -e "$NONSTANDARD_STATE" ]; then
+  echo "OK"
+else
+  echo "FAIL"
+  ERRORS=$((ERRORS + 1))
+fi
+
 git -C "$WORKTREE_LINKED" -c user.name='Hook Tests' -c user.email='hooks@example.com' \
   commit --allow-empty -qm 'test: create repository target'
 RETRY_STATE="$WORKTREE_MAIN/.local/state/ship.loop.local.json"
@@ -747,7 +785,7 @@ RETRY_TRANSCRIPT="$WORKTREE_LINKED/retry.jsonl"
 echo -n "  Stop hook accepts a non-default branch ahead of the default branch... "
 jq -n \
   --arg worktree "$WORKTREE_LINKED" \
-  '{schema_version:2,owner_workflow:"ship",loop_name:"ship",iteration:1,max_iterations:50,completion_promise:"SHIPPED",terminal_promises:["SHIPPED","INCOMPLETE"],components:{},phase:"pushing",original_prompt:"ship",session_id:"owner-session",worktree_path:$worktree}' \
+  '{schema_version:2,owner_workflow:"ship",loop_name:"ship",iteration:1,max_iterations:50,completion_promise:"SHIPPED",terminal_promises:["SHIPPED","INCOMPLETE"],components:{},phase:"pushing",original_prompt:"ship",session_id:"owner-session",session_worktree_path:$worktree,worktree_path:$worktree}' \
   > "$RETRY_STATE"
 printf '%s\n' '{"role":"user","message":{"content":[{"type":"tool_result","content":"Loop initialized: ship"}]}}' > "$RETRY_TRANSCRIPT"
 NONDEFAULT_TARGET_OUTPUT=$(
@@ -767,7 +805,7 @@ echo -n "  Stop hook resets the retry cap after content-only progress... "
 printf '%s\n' 'first revision' > "$WORKTREE_LINKED/progress.txt"
 jq -n \
   --arg worktree "$WORKTREE_LINKED" \
-  '{schema_version:2,owner_workflow:"ship",loop_name:"ship",iteration:1,max_iterations:50,completion_promise:"SHIPPED",terminal_promises:["SHIPPED","INCOMPLETE"],components:{},phase:"pushing",original_prompt:"ship",session_id:"owner-session",worktree_path:$worktree}' \
+  '{schema_version:2,owner_workflow:"ship",loop_name:"ship",iteration:1,max_iterations:50,completion_promise:"SHIPPED",terminal_promises:["SHIPPED","INCOMPLETE"],components:{},phase:"pushing",original_prompt:"ship",session_id:"owner-session",session_worktree_path:$worktree,worktree_path:$worktree}' \
   > "$RETRY_STATE"
 printf '%s\n' '{"role":"user","message":{"content":[{"type":"tool_result","content":"Loop initialized: ship"}]}}' > "$RETRY_TRANSCRIPT"
 for _ in 1 2; do
@@ -803,7 +841,7 @@ SELF_STATE_TRANSCRIPT="$SELF_STATE_ROOT/transcript.jsonl"
 mkdir -p "$(dirname "$SELF_STATE_FILE")"
 jq -n \
   --arg worktree "$SELF_STATE_ROOT" \
-  '{schema_version:2,owner_workflow:"ship",loop_name:"ship",iteration:1,max_iterations:50,completion_promise:"SHIPPED",terminal_promises:["SHIPPED","INCOMPLETE"],components:{},phase:"pushing",original_prompt:"ship",session_id:"owner-session",worktree_path:$worktree}' \
+  '{schema_version:2,owner_workflow:"ship",loop_name:"ship",iteration:1,max_iterations:50,completion_promise:"SHIPPED",terminal_promises:["SHIPPED","INCOMPLETE"],components:{},phase:"pushing",original_prompt:"ship",session_id:"owner-session",session_worktree_path:$worktree,worktree_path:$worktree}' \
   > "$SELF_STATE_FILE"
 printf '%s\n' '{"role":"user","message":{"content":[{"type":"tool_result","content":"Loop initialized: ship"}]}}' > "$SELF_STATE_TRANSCRIPT"
 for _ in 1 2; do
@@ -840,7 +878,7 @@ fi
 echo -n "  Stop hook caps identical blocks and includes recovery details... "
 jq -n \
   --arg worktree "$WORKTREE_LINKED" \
-  '{schema_version:2,owner_workflow:"ship",loop_name:"ship",iteration:1,max_iterations:50,completion_promise:"SHIPPED",terminal_promises:["SHIPPED","INCOMPLETE"],components:{},phase:"pushing",original_prompt:"ship",session_id:"owner-session",worktree_path:$worktree}' \
+  '{schema_version:2,owner_workflow:"ship",loop_name:"ship",iteration:1,max_iterations:50,completion_promise:"SHIPPED",terminal_promises:["SHIPPED","INCOMPLETE"],components:{},phase:"pushing",original_prompt:"ship",session_id:"owner-session",session_worktree_path:$worktree,worktree_path:$worktree}' \
   > "$RETRY_STATE"
 printf '%s\n' '{"role":"user","message":{"content":[{"type":"tool_result","content":"Loop initialized: ship"}]}}' > "$RETRY_TRANSCRIPT"
 RETRY_FIRST=""

--- a/scripts/test-hooks.sh
+++ b/scripts/test-hooks.sh
@@ -831,29 +831,37 @@ fi
 
 echo -n "  Stop hook tracks filesystem progress before Git initialization... "
 NONREPOSITORY_ROOT=$(mktemp -d "$HOOK_TMP_BASE/gopher-ai-stop-hook-nonrepository.XXXXXX")
-NONREPOSITORY_STATE="$NONREPOSITORY_ROOT/.local/state/create-go-project.loop.local.json"
+NONREPOSITORY_STATE="$NONREPOSITORY_ROOT/.local/state/create-go-project-example-project.loop.local.json"
 NONREPOSITORY_TRANSCRIPT="$NONREPOSITORY_ROOT/transcript.jsonl"
 mkdir -p "$(dirname "$NONREPOSITORY_STATE")" "$NONREPOSITORY_ROOT/example-project"
 jq -n \
   --arg worktree "$NONREPOSITORY_ROOT" \
-  '{schema_version:2,owner_workflow:"create-go-project-example",loop_name:"create-go-project-example",iteration:1,max_iterations:50,completion_promise:"COMPLETE",terminal_promises:["COMPLETE","INCOMPLETE"],components:{},phase:"implementing",original_prompt:"create example project",session_id:"owner-session",session_worktree_path:$worktree,worktree_path:$worktree}' \
+  '{schema_version:2,owner_workflow:"create-go-project-example-project",loop_name:"create-go-project-example-project",iteration:1,max_iterations:50,completion_promise:"COMPLETE",terminal_promises:["COMPLETE","INCOMPLETE"],components:{},phase:"implementing",original_prompt:"create example project",session_id:"owner-session",session_worktree_path:$worktree,worktree_path:$worktree}' \
   > "$NONREPOSITORY_STATE"
-printf '%s\n' '{"role":"user","message":{"content":[{"type":"tool_result","content":"Loop initialized: create-go-project-example"}]}}' > "$NONREPOSITORY_TRANSCRIPT"
+printf '%s\n' '{"role":"user","message":{"content":[{"type":"tool_result","content":"Loop initialized: create-go-project-example-project"}]}}' > "$NONREPOSITORY_TRANSCRIPT"
 printf '%s\n' 'first revision' > "$NONREPOSITORY_ROOT/example-project/main.go"
 for _ in 1 2; do
   (
     cd "$NONREPOSITORY_ROOT"
     jq -n --arg transcript "$NONREPOSITORY_TRANSCRIPT" --arg session "owner-session" \
-      '{transcript_path: $transcript, session_id: $session}' | "$CORE_STOP_HOOK"
+    '{transcript_path: $transcript, session_id: $session}' | "$CORE_STOP_HOOK"
   ) >/dev/null
 done
+printf '%s\n' 'unrelated revision' > "$NONREPOSITORY_ROOT/unrelated.txt"
+(
+  cd "$NONREPOSITORY_ROOT"
+  jq -n --arg transcript "$NONREPOSITORY_TRANSCRIPT" --arg session "owner-session" \
+    '{transcript_path: $transcript, session_id: $session}' | "$CORE_STOP_HOOK"
+) >/dev/null
+NONREPOSITORY_SCOPED_COUNT=$(jq -r '.unchanged_block_count' "$NONREPOSITORY_STATE")
 printf '%s\n' 'second revision' > "$NONREPOSITORY_ROOT/example-project/main.go"
 NONREPOSITORY_OUTPUT=$(
   cd "$NONREPOSITORY_ROOT"
   jq -n --arg transcript "$NONREPOSITORY_TRANSCRIPT" --arg session "owner-session" \
     '{transcript_path: $transcript, session_id: $session}' | "$CORE_STOP_HOOK"
 )
-if printf '%s\n' "$NONREPOSITORY_OUTPUT" | jq -e '.decision == "block"' >/dev/null 2>&1 &&
+if [ "$NONREPOSITORY_SCOPED_COUNT" -eq 3 ] &&
+   printf '%s\n' "$NONREPOSITORY_OUTPUT" | jq -e '.decision == "block"' >/dev/null 2>&1 &&
    jq -e '.unchanged_block_count == 1' "$NONREPOSITORY_STATE" >/dev/null 2>&1; then
   echo "OK"
 else

--- a/scripts/test-hooks.sh
+++ b/scripts/test-hooks.sh
@@ -282,7 +282,9 @@ REASON_MUTATION_ROOT=$(mktemp -d "$HOOK_TMP_BASE/gopher-ai-stop-hook-reason-muta
 mkdir -p "$REASON_MUTATION_ROOT/hooks" "$REASON_MUTATION_ROOT/lib" "$REASON_MUTATION_ROOT/.local/state"
 cp "$ROOT_DIR/shared/hooks/stop-hook.sh" "$REASON_MUTATION_ROOT/hooks/stop-hook.sh"
 cp "$ROOT_DIR/shared/lib/loop-state.sh" "$REASON_MUTATION_ROOT/lib/loop-state.sh"
-sed 's/^  REASON="Continue working on the task\."$/  REASON=""/' \
+sed \
+  -e 's/^  REASON="Continue working on the task\."$/  REASON=""/' \
+  -e 's/^    reason="Loop execution is blocked by invalid state\."$/    reason=""/' \
   "$REASON_MUTATION_ROOT/hooks/stop-hook.sh" > "$REASON_MUTATION_ROOT/hooks/stop-hook-mutated.sh"
 printf '%s\n' '{"loop_name":"start-issue-302","iteration":1,"max_iterations":50,"completion_promise":"COMPLETE","phase":"","original_prompt":"","session_id":""}' \
   > "$REASON_MUTATION_ROOT/.local/state/start-issue-302.loop.local.json"
@@ -525,48 +527,345 @@ else
   ERRORS=$((ERRORS + 1))
 fi
 
-echo -n "  Linked-worktree Stop hook resolves the primary owner state... "
-WORKTREE_FIXTURE=$(mktemp -d "$HOOK_TMP_BASE/gopher-ai-stop-hook-worktree.XXXXXX")
-WORKTREE_MAIN="$WORKTREE_FIXTURE/main"
-WORKTREE_LINKED="$WORKTREE_FIXTURE/linked"
-mkdir -p "$WORKTREE_MAIN"
-git -C "$WORKTREE_MAIN" init -q
-git -C "$WORKTREE_MAIN" -c user.name='Hook Tests' -c user.email='hooks@example.com' \
-  commit --allow-empty -qm 'test: initialize owner root'
-git -C "$WORKTREE_MAIN" worktree add -qb linked-fixture "$WORKTREE_LINKED" >/dev/null
-mkdir -p "$WORKTREE_MAIN/.local/state"
-printf '%s\n' '{"schema_version":2,"owner_workflow":"start-issue","loop_name":"start-issue-42","iteration":1,"max_iterations":50,"completion_promise":"COMPLETE","terminal_promises":["COMPLETE","INCOMPLETE"],"components":{},"phase":"implementing","original_prompt":"issue 42","session_id":""}' > "$WORKTREE_MAIN/.local/state/start-issue-42.loop.local.json"
-WORKTREE_TRANSCRIPT="$WORKTREE_LINKED/transcript.jsonl"
-printf '%s\n' \
-  '{"role":"user","message":{"content":[{"type":"tool_result","content":"Loop initialized: start-issue-42"}]}}' \
-  '{"role":"assistant","message":{"content":[{"type":"text","text":"<done>COMPLETE</done>"}]}}' \
-  > "$WORKTREE_TRANSCRIPT"
-WORKTREE_OUTPUT=$(
-  cd "$WORKTREE_LINKED"
-  printf '%s\n' "{\"transcript_path\":\"$WORKTREE_TRANSCRIPT\"}" | "$CORE_STOP_HOOK"
+echo -n "  Stop hook prunes owned state whose worktree no longer exists... "
+STALE_WORKTREE_ROOT=$(mktemp -d "$HOOK_TMP_BASE/gopher-ai-stop-hook-stale-worktree.XXXXXX")
+STALE_WORKTREE_STATE="$STALE_WORKTREE_ROOT/.local/state/ship.loop.local.json"
+STALE_WORKTREE_TRANSCRIPT="$STALE_WORKTREE_ROOT/transcript.jsonl"
+mkdir -p "$(dirname "$STALE_WORKTREE_STATE")"
+jq -n \
+  --arg missing "$STALE_WORKTREE_ROOT/missing-worktree" \
+  '{schema_version:2,owner_workflow:"ship",loop_name:"ship",iteration:1,max_iterations:50,completion_promise:"SHIPPED",terminal_promises:["SHIPPED","INCOMPLETE"],components:{},phase:"pushing",original_prompt:"ship",session_id:"owner-session",worktree_path:$missing}' \
+  > "$STALE_WORKTREE_STATE"
+printf '%s\n' '{"role":"user","message":{"content":[{"type":"tool_result","content":"Loop initialized: ship"}]}}' > "$STALE_WORKTREE_TRANSCRIPT"
+STALE_WORKTREE_OUTPUT=$(
+  cd "$STALE_WORKTREE_ROOT"
+  jq -n --arg transcript "$STALE_WORKTREE_TRANSCRIPT" --arg session "owner-session" \
+    '{transcript_path: $transcript, session_id: $session}' | "$CORE_STOP_HOOK"
 )
-if [ -z "$WORKTREE_OUTPUT" ] && [ ! -e "$WORKTREE_MAIN/.local/state/start-issue-42.loop.local.json" ]; then
+if [ -z "$STALE_WORKTREE_OUTPUT" ] && [ ! -e "$STALE_WORKTREE_STATE" ]; then
   echo "OK"
 else
   echo "FAIL"
   ERRORS=$((ERRORS + 1))
 fi
 
-echo -n "  Linked-worktree ambient stray state is ignored... "
-mkdir -p "$WORKTREE_MAIN/.local/state" "$WORKTREE_LINKED/.local/state"
-printf '%s\n' '{"schema_version":2,"owner_workflow":"start-issue","loop_name":"start-issue-43","iteration":1,"max_iterations":50,"completion_promise":"COMPLETE","terminal_promises":["COMPLETE","INCOMPLETE"],"components":{},"phase":"implementing","original_prompt":"issue 43","session_id":""}' > "$WORKTREE_MAIN/.local/state/start-issue-43.loop.local.json"
-printf '%s\n' '{"loop_name":"direct-smoke","iteration":1,"completion_promise":"DONE","phase":"testing"}' > "$WORKTREE_LINKED/.local/state/direct-smoke.loop.local.json"
+echo -n "  Linked-worktree Stop hook ignores state owned by another worktree... "
+WORKTREE_FIXTURE=$(mktemp -d "$HOOK_TMP_BASE/gopher-ai-stop-hook-worktree.XXXXXX")
+WORKTREE_MAIN="$WORKTREE_FIXTURE/main"
+WORKTREE_LINKED="$WORKTREE_FIXTURE/linked"
+mkdir -p "$WORKTREE_MAIN"
+git -C "$WORKTREE_MAIN" init -b main -q
+git -C "$WORKTREE_MAIN" -c user.name='Hook Tests' -c user.email='hooks@example.com' \
+  commit --allow-empty -qm 'test: initialize owner root'
+git -C "$WORKTREE_MAIN" worktree add -qb linked-fixture "$WORKTREE_LINKED" >/dev/null
+mkdir -p "$WORKTREE_MAIN/.local/state"
+jq -n \
+  --arg worktree "$WORKTREE_MAIN" \
+  '{schema_version:2,owner_workflow:"start-issue",loop_name:"start-issue-42",iteration:1,max_iterations:50,completion_promise:"COMPLETE",terminal_promises:["COMPLETE","INCOMPLETE"],components:{},phase:"implementing",original_prompt:"issue 42",session_id:"owner-session",worktree_path:$worktree}' \
+  > "$WORKTREE_MAIN/.local/state/start-issue-42.loop.local.json"
+WORKTREE_TRANSCRIPT="$WORKTREE_LINKED/transcript.jsonl"
+printf '%s\n' \
+  '{"role":"user","message":{"content":[{"type":"tool_result","content":"Loop initialized: start-issue-42"}]}}' \
+  '{"role":"assistant","message":{"content":[{"type":"text","text":"<done>COMPLETE</done>"}]}}' \
+  > "$WORKTREE_TRANSCRIPT"
+WORKTREE_STATE_BEFORE=$(cksum "$WORKTREE_MAIN/.local/state/start-issue-42.loop.local.json")
+WORKTREE_OUTPUT=$(
+  cd "$WORKTREE_LINKED"
+  jq -n --arg transcript "$WORKTREE_TRANSCRIPT" --arg session "owner-session" \
+    '{transcript_path: $transcript, session_id: $session}' | "$CORE_STOP_HOOK"
+)
+if [ -z "$WORKTREE_OUTPUT" ] &&
+   [ -e "$WORKTREE_MAIN/.local/state/start-issue-42.loop.local.json" ] &&
+   [ "$WORKTREE_STATE_BEFORE" = "$(cksum "$WORKTREE_MAIN/.local/state/start-issue-42.loop.local.json")" ]; then
+  echo "OK"
+else
+  echo "FAIL"
+  ERRORS=$((ERRORS + 1))
+fi
+
+echo -n "  Linked-worktree Stop hook resumes state scoped to that worktree... "
+rm -f "$WORKTREE_MAIN/.local/state/start-issue-42.loop.local.json"
+jq -n \
+  --arg worktree "$WORKTREE_LINKED" \
+  '{schema_version:2,owner_workflow:"start-issue",loop_name:"start-issue-43",iteration:1,max_iterations:50,completion_promise:"COMPLETE",terminal_promises:["COMPLETE","INCOMPLETE"],components:{},phase:"implementing",original_prompt:"issue 43",session_id:"owner-session",worktree_path:$worktree}' \
+  > "$WORKTREE_MAIN/.local/state/start-issue-43.loop.local.json"
 printf '%s\n' \
   '{"role":"user","message":{"content":[{"type":"tool_result","content":"Loop initialized: start-issue-43"}]}}' \
   '{"role":"assistant","message":{"content":[{"type":"text","text":"<done>COMPLETE</done>"}]}}' \
   > "$WORKTREE_TRANSCRIPT"
 WORKTREE_OUTPUT=$(
   cd "$WORKTREE_LINKED"
-  printf '%s\n' "{\"transcript_path\":\"$WORKTREE_TRANSCRIPT\"}" | "$CORE_STOP_HOOK"
+  jq -n --arg transcript "$WORKTREE_TRANSCRIPT" --arg session "owner-session" \
+    '{transcript_path: $transcript, session_id: $session}' | "$CORE_STOP_HOOK"
 )
 if [ -z "$WORKTREE_OUTPUT" ] &&
-   [ ! -e "$WORKTREE_MAIN/.local/state/start-issue-43.loop.local.json" ] &&
-   [ -e "$WORKTREE_LINKED/.local/state/direct-smoke.loop.local.json" ]; then
+   [ ! -e "$WORKTREE_MAIN/.local/state/start-issue-43.loop.local.json" ]; then
+  echo "OK"
+else
+  echo "FAIL"
+  ERRORS=$((ERRORS + 1))
+fi
+
+echo -n "  Stop hook clears targetless ship recovery phases... "
+NO_TARGET_STATE="$WORKTREE_MAIN/.local/state/ship.loop.local.json"
+NO_TARGET_TRANSCRIPT="$WORKTREE_MAIN/no-target.jsonl"
+printf '%s\n' '{"role":"user","message":{"content":[{"type":"tool_result","content":"Loop initialized: ship"}]}}' > "$NO_TARGET_TRANSCRIPT"
+NO_TARGET_FAILURES=0
+for NO_TARGET_PHASE in reviewing pushing; do
+  jq -n \
+    --arg worktree "$WORKTREE_MAIN" \
+    --arg phase "$NO_TARGET_PHASE" \
+    '{schema_version:2,owner_workflow:"ship",loop_name:"ship",iteration:1,max_iterations:50,completion_promise:"SHIPPED",terminal_promises:["SHIPPED","INCOMPLETE"],components:{},phase:$phase,original_prompt:"ship",session_id:"owner-session",worktree_path:$worktree}' \
+    > "$NO_TARGET_STATE"
+  NO_TARGET_OUTPUT=$(
+    cd "$WORKTREE_MAIN"
+    jq -n --arg transcript "$NO_TARGET_TRANSCRIPT" --arg session "owner-session" \
+      '{transcript_path: $transcript, session_id: $session}' | "$CORE_STOP_HOOK"
+  )
+  if [ -n "$NO_TARGET_OUTPUT" ] || [ -e "$NO_TARGET_STATE" ]; then
+    NO_TARGET_FAILURES=$((NO_TARGET_FAILURES + 1))
+  fi
+done
+if [ "$NO_TARGET_FAILURES" -eq 0 ]; then
+  echo "OK"
+else
+  echo "FAIL"
+  ERRORS=$((ERRORS + 1))
+fi
+
+echo -n "  Stop hook preserves targetless recovery state owned by another session... "
+jq -n \
+  --arg worktree "$WORKTREE_MAIN" \
+  '{schema_version:2,owner_workflow:"ship",loop_name:"ship",iteration:1,max_iterations:50,completion_promise:"SHIPPED",terminal_promises:["SHIPPED","INCOMPLETE"],components:{},phase:"pushing",original_prompt:"ship",session_id:"foreign-session",worktree_path:$worktree}' \
+  > "$NO_TARGET_STATE"
+FOREIGN_NO_TARGET_BEFORE=$(cksum "$NO_TARGET_STATE")
+FOREIGN_NO_TARGET_OUTPUT=$(
+  cd "$WORKTREE_MAIN"
+  jq -n --arg transcript "$NO_TARGET_TRANSCRIPT" --arg session "owner-session" \
+    '{transcript_path: $transcript, session_id: $session}' | "$CORE_STOP_HOOK"
+)
+if [ -z "$FOREIGN_NO_TARGET_OUTPUT" ] &&
+   [ -e "$NO_TARGET_STATE" ] &&
+   [ "$FOREIGN_NO_TARGET_BEFORE" = "$(cksum "$NO_TARGET_STATE")" ]; then
+  echo "OK"
+else
+  echo "FAIL"
+  ERRORS=$((ERRORS + 1))
+fi
+
+echo -n "  Stop hook preserves clean pushed-PR wait phases... "
+CLEAN_WAIT_FAILURES=0
+for CLEAN_WAIT_PHASE in ci-watch bot-watching merging; do
+  jq -n \
+    --arg worktree "$WORKTREE_MAIN" \
+    --arg phase "$CLEAN_WAIT_PHASE" \
+    '{schema_version:2,owner_workflow:"ship",loop_name:"ship",iteration:1,max_iterations:50,completion_promise:"SHIPPED",terminal_promises:["SHIPPED","INCOMPLETE"],components:{},phase:$phase,original_prompt:"ship",session_id:"owner-session",worktree_path:$worktree}' \
+    > "$NO_TARGET_STATE"
+  CLEAN_WAIT_OUTPUT=$(
+    cd "$WORKTREE_MAIN"
+    jq -n --arg transcript "$NO_TARGET_TRANSCRIPT" --arg session "owner-session" \
+      '{transcript_path: $transcript, session_id: $session}' | "$CORE_STOP_HOOK"
+  )
+  if ! printf '%s\n' "$CLEAN_WAIT_OUTPUT" | jq -e '.decision == "block"' >/dev/null 2>&1 ||
+     [ ! -e "$NO_TARGET_STATE" ]; then
+    CLEAN_WAIT_FAILURES=$((CLEAN_WAIT_FAILURES + 1))
+  fi
+done
+if [ "$CLEAN_WAIT_FAILURES" -eq 0 ]; then
+  echo "OK"
+else
+  echo "FAIL"
+  ERRORS=$((ERRORS + 1))
+fi
+
+echo -n "  Stop hook accepts a staged repository target... "
+STAGED_TARGET_ROOT=$(mktemp -d "$HOOK_TMP_BASE/gopher-ai-stop-hook-staged-target.XXXXXX")
+git -C "$STAGED_TARGET_ROOT" init -b main -q
+git -C "$STAGED_TARGET_ROOT" -c user.name='Hook Tests' -c user.email='hooks@example.com' \
+  commit --allow-empty -qm 'test: initialize staged target'
+printf '%s\n' 'staged target' > "$STAGED_TARGET_ROOT/target.txt"
+git -C "$STAGED_TARGET_ROOT" add target.txt
+STAGED_TARGET_STATE="$STAGED_TARGET_ROOT/.local/state/ship.loop.local.json"
+STAGED_TARGET_TRANSCRIPT="$STAGED_TARGET_ROOT/transcript.jsonl"
+mkdir -p "$(dirname "$STAGED_TARGET_STATE")"
+jq -n \
+  --arg worktree "$STAGED_TARGET_ROOT" \
+  '{schema_version:2,owner_workflow:"ship",loop_name:"ship",iteration:1,max_iterations:50,completion_promise:"SHIPPED",terminal_promises:["SHIPPED","INCOMPLETE"],components:{},phase:"pushing",original_prompt:"ship",session_id:"owner-session",worktree_path:$worktree}' \
+  > "$STAGED_TARGET_STATE"
+printf '%s\n' '{"role":"user","message":{"content":[{"type":"tool_result","content":"Loop initialized: ship"}]}}' > "$STAGED_TARGET_TRANSCRIPT"
+STAGED_TARGET_OUTPUT=$(
+  cd "$STAGED_TARGET_ROOT"
+  jq -n --arg transcript "$STAGED_TARGET_TRANSCRIPT" --arg session "owner-session" \
+    '{transcript_path: $transcript, session_id: $session}' | "$CORE_STOP_HOOK"
+)
+if printf '%s\n' "$STAGED_TARGET_OUTPUT" | jq -e '.decision == "block"' >/dev/null 2>&1 &&
+   [ -e "$STAGED_TARGET_STATE" ]; then
+  echo "OK"
+else
+  echo "FAIL"
+  ERRORS=$((ERRORS + 1))
+fi
+
+echo -n "  Stop hook accepts commits ahead of the configured upstream... "
+UNPUSHED_FIXTURE=$(mktemp -d "$HOOK_TMP_BASE/gopher-ai-stop-hook-unpushed.XXXXXX")
+UNPUSHED_REMOTE="$UNPUSHED_FIXTURE/remote.git"
+UNPUSHED_WORKTREE="$UNPUSHED_FIXTURE/worktree"
+git init --bare -q "$UNPUSHED_REMOTE"
+git init -b main -q "$UNPUSHED_WORKTREE"
+git -C "$UNPUSHED_WORKTREE" -c user.name='Hook Tests' -c user.email='hooks@example.com' \
+  commit --allow-empty -qm 'test: initialize upstream target'
+git -C "$UNPUSHED_WORKTREE" remote add origin "$UNPUSHED_REMOTE"
+git -C "$UNPUSHED_WORKTREE" push -qu origin main
+git -C "$UNPUSHED_WORKTREE" -c user.name='Hook Tests' -c user.email='hooks@example.com' \
+  commit --allow-empty -qm 'test: create unpushed target'
+UNPUSHED_STATE="$UNPUSHED_WORKTREE/.local/state/ship.loop.local.json"
+UNPUSHED_TRANSCRIPT="$UNPUSHED_WORKTREE/transcript.jsonl"
+mkdir -p "$(dirname "$UNPUSHED_STATE")"
+jq -n \
+  --arg worktree "$UNPUSHED_WORKTREE" \
+  '{schema_version:2,owner_workflow:"ship",loop_name:"ship",iteration:1,max_iterations:50,completion_promise:"SHIPPED",terminal_promises:["SHIPPED","INCOMPLETE"],components:{},phase:"pushing",original_prompt:"ship",session_id:"owner-session",worktree_path:$worktree}' \
+  > "$UNPUSHED_STATE"
+printf '%s\n' '{"role":"user","message":{"content":[{"type":"tool_result","content":"Loop initialized: ship"}]}}' > "$UNPUSHED_TRANSCRIPT"
+UNPUSHED_OUTPUT=$(
+  cd "$UNPUSHED_WORKTREE"
+  jq -n --arg transcript "$UNPUSHED_TRANSCRIPT" --arg session "owner-session" \
+    '{transcript_path: $transcript, session_id: $session}' | "$CORE_STOP_HOOK"
+)
+if printf '%s\n' "$UNPUSHED_OUTPUT" | jq -e '.decision == "block"' >/dev/null 2>&1 &&
+   [ -e "$UNPUSHED_STATE" ]; then
+  echo "OK"
+else
+  echo "FAIL"
+  ERRORS=$((ERRORS + 1))
+fi
+
+git -C "$WORKTREE_LINKED" -c user.name='Hook Tests' -c user.email='hooks@example.com' \
+  commit --allow-empty -qm 'test: create repository target'
+RETRY_STATE="$WORKTREE_MAIN/.local/state/ship.loop.local.json"
+RETRY_TRANSCRIPT="$WORKTREE_LINKED/retry.jsonl"
+
+echo -n "  Stop hook accepts a non-default branch ahead of the default branch... "
+jq -n \
+  --arg worktree "$WORKTREE_LINKED" \
+  '{schema_version:2,owner_workflow:"ship",loop_name:"ship",iteration:1,max_iterations:50,completion_promise:"SHIPPED",terminal_promises:["SHIPPED","INCOMPLETE"],components:{},phase:"pushing",original_prompt:"ship",session_id:"owner-session",worktree_path:$worktree}' \
+  > "$RETRY_STATE"
+printf '%s\n' '{"role":"user","message":{"content":[{"type":"tool_result","content":"Loop initialized: ship"}]}}' > "$RETRY_TRANSCRIPT"
+NONDEFAULT_TARGET_OUTPUT=$(
+  cd "$WORKTREE_LINKED"
+  jq -n --arg transcript "$RETRY_TRANSCRIPT" --arg session "owner-session" \
+    '{transcript_path: $transcript, session_id: $session}' | "$CORE_STOP_HOOK"
+)
+if printf '%s\n' "$NONDEFAULT_TARGET_OUTPUT" | jq -e '.decision == "block"' >/dev/null 2>&1 &&
+   [ -e "$RETRY_STATE" ]; then
+  echo "OK"
+else
+  echo "FAIL"
+  ERRORS=$((ERRORS + 1))
+fi
+
+echo -n "  Stop hook resets the retry cap after content-only progress... "
+printf '%s\n' 'first revision' > "$WORKTREE_LINKED/progress.txt"
+jq -n \
+  --arg worktree "$WORKTREE_LINKED" \
+  '{schema_version:2,owner_workflow:"ship",loop_name:"ship",iteration:1,max_iterations:50,completion_promise:"SHIPPED",terminal_promises:["SHIPPED","INCOMPLETE"],components:{},phase:"pushing",original_prompt:"ship",session_id:"owner-session",worktree_path:$worktree}' \
+  > "$RETRY_STATE"
+printf '%s\n' '{"role":"user","message":{"content":[{"type":"tool_result","content":"Loop initialized: ship"}]}}' > "$RETRY_TRANSCRIPT"
+for _ in 1 2; do
+  (
+    cd "$WORKTREE_LINKED"
+    jq -n --arg transcript "$RETRY_TRANSCRIPT" --arg session "owner-session" \
+      '{transcript_path: $transcript, session_id: $session}' | "$CORE_STOP_HOOK"
+  ) >/dev/null
+done
+printf '%s\n' 'second revision' > "$WORKTREE_LINKED/progress.txt"
+PROGRESS_OUTPUT=$(
+  cd "$WORKTREE_LINKED"
+  jq -n --arg transcript "$RETRY_TRANSCRIPT" --arg session "owner-session" \
+    '{transcript_path: $transcript, session_id: $session}' | "$CORE_STOP_HOOK"
+)
+if printf '%s\n' "$PROGRESS_OUTPUT" | jq -e '.decision == "block"' >/dev/null 2>&1 &&
+   jq -e '.unchanged_block_count == 1' "$RETRY_STATE" >/dev/null 2>&1; then
+  echo "OK"
+else
+  echo "FAIL"
+  ERRORS=$((ERRORS + 1))
+fi
+
+echo -n "  Stop hook excludes its own state mutations from the retry cap... "
+SELF_STATE_ROOT=$(mktemp -d "$HOOK_TMP_BASE/gopher-ai-stop-hook-self-state.XXXXXX")
+git -C "$SELF_STATE_ROOT" init -b main -q
+git -C "$SELF_STATE_ROOT" -c user.name='Hook Tests' -c user.email='hooks@example.com' \
+  commit --allow-empty -qm 'test: initialize self-state target'
+printf '%s\n' 'staged target' > "$SELF_STATE_ROOT/target.txt"
+git -C "$SELF_STATE_ROOT" add target.txt
+SELF_STATE_FILE="$SELF_STATE_ROOT/.local/state/ship.loop.local.json"
+SELF_STATE_TRANSCRIPT="$SELF_STATE_ROOT/transcript.jsonl"
+mkdir -p "$(dirname "$SELF_STATE_FILE")"
+jq -n \
+  --arg worktree "$SELF_STATE_ROOT" \
+  '{schema_version:2,owner_workflow:"ship",loop_name:"ship",iteration:1,max_iterations:50,completion_promise:"SHIPPED",terminal_promises:["SHIPPED","INCOMPLETE"],components:{},phase:"pushing",original_prompt:"ship",session_id:"owner-session",worktree_path:$worktree}' \
+  > "$SELF_STATE_FILE"
+printf '%s\n' '{"role":"user","message":{"content":[{"type":"tool_result","content":"Loop initialized: ship"}]}}' > "$SELF_STATE_TRANSCRIPT"
+for _ in 1 2; do
+  (
+    cd "$SELF_STATE_ROOT"
+    jq -n --arg transcript "$SELF_STATE_TRANSCRIPT" --arg session "owner-session" \
+      '{transcript_path: $transcript, session_id: $session}' | "$CORE_STOP_HOOK"
+  ) >/dev/null
+done
+if jq -e '.unchanged_block_count == 2' "$SELF_STATE_FILE" >/dev/null 2>&1; then
+  echo "OK"
+else
+  echo "FAIL"
+  ERRORS=$((ERRORS + 1))
+fi
+
+echo -n "  Stop hook resets the retry cap after a phase change... "
+SELF_STATE_TMP="${SELF_STATE_FILE}.tmp"
+jq '.phase = "ci-watch"' "$SELF_STATE_FILE" > "$SELF_STATE_TMP"
+mv "$SELF_STATE_TMP" "$SELF_STATE_FILE"
+SELF_STATE_PHASE_OUTPUT=$(
+  cd "$SELF_STATE_ROOT"
+  jq -n --arg transcript "$SELF_STATE_TRANSCRIPT" --arg session "owner-session" \
+    '{transcript_path: $transcript, session_id: $session}' | "$CORE_STOP_HOOK"
+)
+if printf '%s\n' "$SELF_STATE_PHASE_OUTPUT" | jq -e '.decision == "block"' >/dev/null 2>&1 &&
+   jq -e '.unchanged_block_count == 1' "$SELF_STATE_FILE" >/dev/null 2>&1; then
+  echo "OK"
+else
+  echo "FAIL"
+  ERRORS=$((ERRORS + 1))
+fi
+
+echo -n "  Stop hook caps identical blocks and includes recovery details... "
+jq -n \
+  --arg worktree "$WORKTREE_LINKED" \
+  '{schema_version:2,owner_workflow:"ship",loop_name:"ship",iteration:1,max_iterations:50,completion_promise:"SHIPPED",terminal_promises:["SHIPPED","INCOMPLETE"],components:{},phase:"pushing",original_prompt:"ship",session_id:"owner-session",worktree_path:$worktree}' \
+  > "$RETRY_STATE"
+printf '%s\n' '{"role":"user","message":{"content":[{"type":"tool_result","content":"Loop initialized: ship"}]}}' > "$RETRY_TRANSCRIPT"
+RETRY_FIRST=""
+RETRY_THIRD=""
+RETRY_FOURTH=""
+for RETRY_ATTEMPT in 1 2 3 4; do
+  RETRY_OUTPUT=$(
+    cd "$WORKTREE_LINKED"
+    jq -n --arg transcript "$RETRY_TRANSCRIPT" --arg session "owner-session" \
+      '{transcript_path: $transcript, session_id: $session}' | "$CORE_STOP_HOOK"
+  )
+  case "$RETRY_ATTEMPT" in
+    1) RETRY_FIRST="$RETRY_OUTPUT" ;;
+    3) RETRY_THIRD="$RETRY_OUTPUT" ;;
+    4) RETRY_FOURTH="$RETRY_OUTPUT" ;;
+  esac
+done
+if printf '%s\n' "$RETRY_FIRST" | jq -e --arg state "$RETRY_STATE" '
+     .decision == "block" and
+     (.systemMessage | contains($state)) and
+     (.systemMessage | contains("/go-workflow:cancel-loop"))
+   ' >/dev/null 2>&1 &&
+   printf '%s\n' "$RETRY_THIRD" | jq -e '.decision == "block"' >/dev/null 2>&1 &&
+   [ -z "$RETRY_FOURTH" ] &&
+   [ ! -e "$RETRY_STATE" ]; then
   echo "OK"
 else
   echo "FAIL"

--- a/scripts/test-hooks.sh
+++ b/scripts/test-hooks.sh
@@ -829,6 +829,38 @@ else
   ERRORS=$((ERRORS + 1))
 fi
 
+echo -n "  Stop hook tracks filesystem progress before Git initialization... "
+NONREPOSITORY_ROOT=$(mktemp -d "$HOOK_TMP_BASE/gopher-ai-stop-hook-nonrepository.XXXXXX")
+NONREPOSITORY_STATE="$NONREPOSITORY_ROOT/.local/state/create-go-project.loop.local.json"
+NONREPOSITORY_TRANSCRIPT="$NONREPOSITORY_ROOT/transcript.jsonl"
+mkdir -p "$(dirname "$NONREPOSITORY_STATE")" "$NONREPOSITORY_ROOT/example-project"
+jq -n \
+  --arg worktree "$NONREPOSITORY_ROOT" \
+  '{schema_version:2,owner_workflow:"create-go-project-example",loop_name:"create-go-project-example",iteration:1,max_iterations:50,completion_promise:"COMPLETE",terminal_promises:["COMPLETE","INCOMPLETE"],components:{},phase:"implementing",original_prompt:"create example project",session_id:"owner-session",session_worktree_path:$worktree,worktree_path:$worktree}' \
+  > "$NONREPOSITORY_STATE"
+printf '%s\n' '{"role":"user","message":{"content":[{"type":"tool_result","content":"Loop initialized: create-go-project-example"}]}}' > "$NONREPOSITORY_TRANSCRIPT"
+printf '%s\n' 'first revision' > "$NONREPOSITORY_ROOT/example-project/main.go"
+for _ in 1 2; do
+  (
+    cd "$NONREPOSITORY_ROOT"
+    jq -n --arg transcript "$NONREPOSITORY_TRANSCRIPT" --arg session "owner-session" \
+      '{transcript_path: $transcript, session_id: $session}' | "$CORE_STOP_HOOK"
+  ) >/dev/null
+done
+printf '%s\n' 'second revision' > "$NONREPOSITORY_ROOT/example-project/main.go"
+NONREPOSITORY_OUTPUT=$(
+  cd "$NONREPOSITORY_ROOT"
+  jq -n --arg transcript "$NONREPOSITORY_TRANSCRIPT" --arg session "owner-session" \
+    '{transcript_path: $transcript, session_id: $session}' | "$CORE_STOP_HOOK"
+)
+if printf '%s\n' "$NONREPOSITORY_OUTPUT" | jq -e '.decision == "block"' >/dev/null 2>&1 &&
+   jq -e '.unchanged_block_count == 1' "$NONREPOSITORY_STATE" >/dev/null 2>&1; then
+  echo "OK"
+else
+  echo "FAIL"
+  ERRORS=$((ERRORS + 1))
+fi
+
 echo -n "  Stop hook excludes its own state mutations from the retry cap... "
 SELF_STATE_ROOT=$(mktemp -d "$HOOK_TMP_BASE/gopher-ai-stop-hook-self-state.XXXXXX")
 git -C "$SELF_STATE_ROOT" init -b main -q

--- a/scripts/test-loop-state.sh
+++ b/scripts/test-loop-state.sh
@@ -53,6 +53,7 @@ assert_eq "fresh schema contract" "true" "$(jq -r '
   .owner_workflow == "test-loop" and
   .terminal_promises == ["TEST_DONE", "TEST_FAIL"] and
   .completion_promise == "TEST_DONE" and
+  .session_worktree_path == $expected_worktree and
   .worktree_path == $expected_worktree and
   .components == {}
 ' --arg expected_worktree "$FRESH_DIR" "$FRESH_STATE")"

--- a/scripts/test-loop-state.sh
+++ b/scripts/test-loop-state.sh
@@ -6,7 +6,13 @@ SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
 LOOP_LIB="$ROOT_DIR/shared/lib/loop-state.sh"
 SETUP_LOOP="$ROOT_DIR/shared/scripts/setup-loop.sh"
-FIXTURE_BASE=$(mktemp -d "${TMPDIR:-/tmp}/gopher-ai-loop-state.XXXXXX")
+LOOP_TMP_BASE="${TMPDIR:-${TMP:-${TEMP:-/tmp}}}"
+case "$LOOP_TMP_BASE/" in
+  "$ROOT_DIR/"*)
+    export GIT_CEILING_DIRECTORIES="$LOOP_TMP_BASE${GIT_CEILING_DIRECTORIES:+:$GIT_CEILING_DIRECTORIES}"
+    ;;
+esac
+FIXTURE_BASE=$(mktemp -d "$LOOP_TMP_BASE/gopher-ai-loop-state.XXXXXX")
 
 PASS=0
 FAIL=0
@@ -47,8 +53,9 @@ assert_eq "fresh schema contract" "true" "$(jq -r '
   .owner_workflow == "test-loop" and
   .terminal_promises == ["TEST_DONE", "TEST_FAIL"] and
   .completion_promise == "TEST_DONE" and
+  .worktree_path == $expected_worktree and
   .components == {}
-' "$FRESH_STATE")"
+' --arg expected_worktree "$FRESH_DIR" "$FRESH_STATE")"
 
 REENTRY_BEFORE=$(jq -cS '.iteration = 7 | .phase = "watching" | .custom = "preserved"' "$FRESH_STATE")
 printf '%s\n' "$REENTRY_BEFORE" > "$FRESH_STATE"

--- a/scripts/test-ship-e2e-gate.sh
+++ b/scripts/test-ship-e2e-gate.sh
@@ -370,6 +370,11 @@ rm -rf "$DIRTY_HEAD_SHIFT_TMP"
 
 HEADLESS_TMP=$(mktemp -d "${TMPDIR:-/tmp}/ship-headless-e2e-XXXXXX")
 mkdir -p "$HEADLESS_TMP/.local/state" "$HEADLESS_TMP/hooks" "$HEADLESS_TMP/lib"
+git -C "$HEADLESS_TMP" init -b main -q
+git -C "$HEADLESS_TMP" -c user.name='Ship Tests' -c user.email='ship@example.com' \
+  commit --allow-empty -qm 'test: initialize headless recovery'
+printf '%s\n' 'validated change' > "$HEADLESS_TMP/validated.txt"
+git -C "$HEADLESS_TMP" add validated.txt
 cp "$STOP_HOOK" "$HEADLESS_TMP/hooks/stop-hook.sh"
 cp "$LOOP_LIB" "$HEADLESS_TMP/lib/loop-state.sh"
 cat > "$HEADLESS_TMP/.local/state/ship.loop.local.json" <<'EOF'

--- a/shared/hooks/stop-hook.sh
+++ b/shared/hooks/stop-hook.sh
@@ -242,8 +242,14 @@ repository_state_fingerprint() {
   local upstream
   local upstream_head
   local filesystem_entry
+  local filesystem_root
+  local generated_project
   local relative_entry
   local entry_type
+  local entry_metadata
+  local entry_size
+  local scanned_entries=0
+  local remaining_content_bytes=8388608
   head=$(git -C "$worktree_path" rev-parse HEAD 2>/dev/null || true)
   upstream=$(git -C "$worktree_path" rev-parse --abbrev-ref '@{upstream}' 2>/dev/null || true)
   upstream_head=$(git -C "$worktree_path" rev-parse '@{upstream}' 2>/dev/null || true)
@@ -262,9 +268,30 @@ repository_state_fingerprint() {
       done < <(git -C "$worktree_path" ls-files --others --exclude-standard -z -- \
         . ':(exclude).local/state/**' 2>/dev/null)
     else
+      filesystem_root="$worktree_path"
+      case "${LOOP_NAME:-}" in
+        create-go-project-*)
+          generated_project="${LOOP_NAME#create-go-project-}"
+          case "$generated_project" in
+            ''|*[!A-Za-z0-9_-]*) ;;
+            *)
+              if [ -d "$worktree_path/$generated_project" ] &&
+                 [ ! -L "$worktree_path/$generated_project" ]; then
+                filesystem_root="$worktree_path/$generated_project"
+              fi
+              ;;
+          esac
+          ;;
+      esac
+      printf '%s\n' "$filesystem_root"
       while IFS= read -r -d '' filesystem_entry; do
         [ "$filesystem_entry" != "$TRANSCRIPT_PATH" ] || continue
-        relative_entry="${filesystem_entry#"$worktree_path"/}"
+        scanned_entries=$((scanned_entries + 1))
+        if [ "$scanned_entries" -gt 512 ]; then
+          printf '%s\n' "entry-limit:512"
+          break
+        fi
+        relative_entry="${filesystem_entry#"$filesystem_root"/}"
         if [ -L "$filesystem_entry" ]; then
           entry_type="link"
         elif [ -d "$filesystem_entry" ]; then
@@ -274,12 +301,28 @@ repository_state_fingerprint() {
         fi
         printf '%s\0%s\0' "$entry_type" "$relative_entry"
         if [ "$entry_type" = "file" ]; then
-          cksum < "$filesystem_entry" 2>/dev/null || true
+          entry_metadata=$(stat -f '%z:%m' "$filesystem_entry" 2>/dev/null || \
+            stat -c '%s:%Y' "$filesystem_entry" 2>/dev/null || true)
+          printf '%s\0' "$entry_metadata"
+          entry_size="${entry_metadata%%:*}"
+          case "$entry_size" in
+            ''|*[!0-9]*) entry_size=0 ;;
+          esac
+          if [ "$remaining_content_bytes" -gt 0 ]; then
+            if [ "$entry_size" -le "$remaining_content_bytes" ]; then
+              cksum < "$filesystem_entry" 2>/dev/null || true
+              remaining_content_bytes=$((remaining_content_bytes - entry_size))
+            else
+              head -c "$remaining_content_bytes" "$filesystem_entry" 2>/dev/null | cksum || true
+              remaining_content_bytes=0
+            fi
+          fi
         elif [ "$entry_type" = "link" ]; then
           readlink "$filesystem_entry" 2>/dev/null || true
         fi
-      done < <(find "$worktree_path" \
-        \( -type d -name .git -o -type d -path "$worktree_path/.local/state" \) -prune -o \
+      done < <(find "$filesystem_root" \
+        \( -type d \( -name .git -o -name node_modules -o -name vendor -o -name .cache \) \
+          -o -type d -path "$worktree_path/.local/state" \) -prune -o \
         \( -type d -o -type f -o -type l \) -print0 2>/dev/null)
     fi
   } | cksum | awk '{print $1 ":" $2}'
@@ -520,7 +563,7 @@ if [ "$UNCHANGED_BLOCK_COUNT" -gt "$MAX_UNCHANGED_BLOCKS" ]; then
   cleanup_loop "$STATE_FILE"
   exit 0
 fi
-SYSTEM_MSG="$SYSTEM_MSG Unchanged repository-state block $UNCHANGED_BLOCK_COUNT of $MAX_UNCHANGED_BLOCKS; the loop self-expires before another identical block."
+SYSTEM_MSG="$SYSTEM_MSG Unchanged worktree-state block $UNCHANGED_BLOCK_COUNT of $MAX_UNCHANGED_BLOCKS; the loop self-expires before another identical block."
 
 loop_log "stop-hook: blocking exit, reason='$REASON' unchanged_blocks=$UNCHANGED_BLOCK_COUNT"
 

--- a/shared/hooks/stop-hook.sh
+++ b/shared/hooks/stop-hook.sh
@@ -77,19 +77,19 @@ transcript_owns_loop() {
 session_owns_loop_state() {
   local state_file="$1"
   local stored_session_id
-  local stored_worktree_path
+  local stored_session_worktree_path
   local loop_name
 
   [ -f "$state_file" ] && [ -r "$state_file" ] && jq empty "$state_file" 2>/dev/null || return 1
 
   stored_session_id=$(jq -r '.session_id // empty' "$state_file" 2>/dev/null)
-  stored_worktree_path=$(jq -r '.worktree_path // empty' "$state_file" 2>/dev/null)
+  stored_session_worktree_path=$(jq -r '.session_worktree_path // empty' "$state_file" 2>/dev/null)
   loop_name=$(jq -r '.loop_name // empty' "$state_file" 2>/dev/null)
 
-  if [ -n "$stored_worktree_path" ]; then
-    [ -d "$stored_worktree_path" ] || return 1
-    stored_worktree_path=$(cd "$stored_worktree_path" && pwd -P)
-    [ "$stored_worktree_path" = "$CURRENT_WORKTREE_PATH" ] || return 1
+  if [ -n "$stored_session_worktree_path" ]; then
+    [ -d "$stored_session_worktree_path" ] || return 1
+    stored_session_worktree_path=$(cd "$stored_session_worktree_path" && pwd -P)
+    [ "$stored_session_worktree_path" = "$CURRENT_WORKTREE_PATH" ] || return 1
   fi
 
   if [ -n "$stored_session_id" ]; then
@@ -102,9 +102,15 @@ session_owns_loop_state() {
 
 state_has_stale_worktree() {
   local state_file="$1"
-  local stored_worktree_path
-  stored_worktree_path=$(jq -r '.worktree_path // empty' "$state_file" 2>/dev/null)
-  [ -n "$stored_worktree_path" ] && [ ! -d "$stored_worktree_path" ]
+  local field
+  local stored_path
+  for field in session_worktree_path worktree_path; do
+    stored_path=$(jq -r --arg field "$field" '.[$field] // empty' "$state_file" 2>/dev/null)
+    if [ -n "$stored_path" ] && [ ! -d "$stored_path" ]; then
+      return 0
+    fi
+  done
+  return 1
 }
 
 repository_target_required_for() {
@@ -126,9 +132,12 @@ loop_requires_repository_target() {
 
 repository_has_target() {
   local worktree_path="$1"
+  local base_branch="${2:-}"
   local current_branch
   local upstream
   local default_ref
+  local default_branch
+  local remote
   local candidate
   local ahead
 
@@ -140,25 +149,66 @@ repository_has_target() {
 
   upstream=$(git -C "$worktree_path" rev-parse --abbrev-ref '@{upstream}' 2>/dev/null || true)
   if [ -n "$upstream" ]; then
-    ahead=$(git -C "$worktree_path" rev-list --count "$upstream"..HEAD 2>/dev/null || printf '0')
+    ahead=$(git -C "$worktree_path" rev-list --count "$upstream"..HEAD 2>/dev/null) || return 2
     if [ "$ahead" -gt 0 ]; then
       return 0
     fi
   fi
 
   current_branch=$(git -C "$worktree_path" branch --show-current 2>/dev/null || true)
-  default_ref=$(git -C "$worktree_path" symbolic-ref --quiet --short refs/remotes/origin/HEAD 2>/dev/null || true)
+  default_ref=""
+  default_branch=""
+  if [ -n "$base_branch" ]; then
+    case "$base_branch" in
+      refs/heads/*)
+        default_branch="${base_branch#refs/heads/}"
+        candidate="$base_branch"
+        ;;
+      refs/remotes/*)
+        candidate="$base_branch"
+        default_branch="${base_branch#refs/remotes/}"
+        default_branch="${default_branch#*/}"
+        ;;
+      *)
+        default_branch="$base_branch"
+        candidate="$base_branch"
+        ;;
+    esac
+    if git -C "$worktree_path" rev-parse --verify --quiet "$candidate^{commit}" >/dev/null; then
+      default_ref="$candidate"
+    else
+      for remote in $(git -C "$worktree_path" remote); do
+        candidate="$remote/$base_branch"
+        if git -C "$worktree_path" rev-parse --verify --quiet "$candidate^{commit}" >/dev/null; then
+          default_ref="$candidate"
+          break
+        fi
+      done
+    fi
+  fi
   if [ -z "$default_ref" ]; then
-    for candidate in origin/main origin/master main master; do
-      if git -C "$worktree_path" rev-parse --verify --quiet "$candidate^{commit}" >/dev/null; then
+    for remote in $(git -C "$worktree_path" remote); do
+      candidate=$(git -C "$worktree_path" symbolic-ref --quiet --short "refs/remotes/$remote/HEAD" 2>/dev/null || true)
+      if [ -n "$candidate" ] &&
+         git -C "$worktree_path" rev-parse --verify --quiet "$candidate^{commit}" >/dev/null; then
         default_ref="$candidate"
+        default_branch="${candidate#"$remote"/}"
         break
       fi
     done
   fi
-  if [ -n "$current_branch" ] && [ -n "$default_ref" ] &&
-     [ "$current_branch" != "${default_ref#origin/}" ]; then
-    ahead=$(git -C "$worktree_path" rev-list --count "$default_ref"..HEAD 2>/dev/null || printf '0')
+  if [ -z "$default_ref" ]; then
+    for candidate in origin/main origin/master main master; do
+      if git -C "$worktree_path" rev-parse --verify --quiet "$candidate^{commit}" >/dev/null; then
+        default_ref="$candidate"
+        default_branch="${candidate#origin/}"
+        break
+      fi
+    done
+  fi
+  [ -n "$default_ref" ] || return 2
+  if [ -n "$current_branch" ] && [ "$current_branch" != "$default_branch" ]; then
+    ahead=$(git -C "$worktree_path" rev-list --count "$default_ref"..HEAD 2>/dev/null) || return 2
     if [ "$ahead" -gt 0 ]; then
       return 0
     fi
@@ -172,13 +222,15 @@ state_has_no_repository_target() {
   local owner_workflow
   local phase
   local worktree_path
+  local base_branch
   local target_status=0
   owner_workflow=$(jq -r '.owner_workflow // empty' "$state_file" 2>/dev/null)
   phase=$(jq -r '.phase // empty' "$state_file" 2>/dev/null)
   worktree_path=$(jq -r '.worktree_path // empty' "$state_file" 2>/dev/null)
+  base_branch=$(jq -r '.base_branch // empty' "$state_file" 2>/dev/null)
   repository_target_required_for "$owner_workflow" "$phase" || return 1
   [ -n "$worktree_path" ] && [ -d "$worktree_path" ] || return 1
-  repository_has_target "$worktree_path" || target_status=$?
+  repository_has_target "$worktree_path" "$base_branch" || target_status=$?
   [ "$target_status" -eq 1 ]
 }
 
@@ -289,6 +341,12 @@ if [ -z "$STORED_SESSION_ID" ] && [ -n "$CURRENT_SESSION_ID" ]; then
   set_loop_field "$STATE_FILE" "session_id" "$CURRENT_SESSION_ID" '[]'
   loop_log "stop-hook: claimed loop state '$STATE_FILE' for session '$CURRENT_SESSION_ID'"
 fi
+STORED_SESSION_WORKTREE_PATH=$(jq -r '.session_worktree_path // empty' "$STATE_FILE")
+if [ -z "$STORED_SESSION_WORKTREE_PATH" ]; then
+  set_loop_field "$STATE_FILE" "session_worktree_path" "$CURRENT_WORKTREE_PATH" '[]'
+  STORED_SESSION_WORKTREE_PATH="$CURRENT_WORKTREE_PATH"
+  loop_log "stop-hook: claimed loop state '$STATE_FILE' for session worktree '$CURRENT_WORKTREE_PATH'"
+fi
 STORED_WORKTREE_PATH=$(jq -r '.worktree_path // empty' "$STATE_FILE")
 if [ -z "$STORED_WORKTREE_PATH" ]; then
   set_loop_field "$STATE_FILE" "worktree_path" "$CURRENT_WORKTREE_PATH" '[]'
@@ -330,7 +388,8 @@ fi
 
 TARGET_STATUS=0
 if loop_requires_repository_target; then
-  repository_has_target "$STORED_WORKTREE_PATH" || TARGET_STATUS=$?
+  STORED_BASE_BRANCH=$(jq -r '.base_branch // empty' "$STATE_FILE")
+  repository_has_target "$STORED_WORKTREE_PATH" "$STORED_BASE_BRANCH" || TARGET_STATUS=$?
   if [ "$TARGET_STATUS" -eq 1 ]; then
     loop_log "stop-hook: no repository target remains; cleaning up '$STATE_FILE'"
     cleanup_loop "$STATE_FILE"

--- a/shared/hooks/stop-hook.sh
+++ b/shared/hooks/stop-hook.sh
@@ -301,8 +301,13 @@ repository_state_fingerprint() {
         fi
         printf '%s\0%s\0' "$entry_type" "$relative_entry"
         if [ "$entry_type" = "file" ]; then
-          entry_metadata=$(stat -f '%z:%m' "$filesystem_entry" 2>/dev/null || \
-            stat -c '%s:%Y' "$filesystem_entry" 2>/dev/null || true)
+          if entry_metadata=$(stat -c '%s:%Y' -- "$filesystem_entry" 2>/dev/null); then
+            :
+          elif entry_metadata=$(stat -f '%z:%m' "$filesystem_entry" 2>/dev/null); then
+            :
+          else
+            entry_metadata=""
+          fi
           printf '%s\0' "$entry_metadata"
           entry_size="${entry_metadata%%:*}"
           case "$entry_size" in

--- a/shared/hooks/stop-hook.sh
+++ b/shared/hooks/stop-hook.sh
@@ -241,22 +241,47 @@ repository_state_fingerprint() {
   local head
   local upstream
   local upstream_head
+  local filesystem_entry
+  local relative_entry
+  local entry_type
   head=$(git -C "$worktree_path" rev-parse HEAD 2>/dev/null || true)
   upstream=$(git -C "$worktree_path" rev-parse --abbrev-ref '@{upstream}' 2>/dev/null || true)
   upstream_head=$(git -C "$worktree_path" rev-parse '@{upstream}' 2>/dev/null || true)
   {
     printf '%s\n' "$worktree_path" "$phase" "$reason" "$head" "$upstream" "$upstream_head"
-    git -C "$worktree_path" status --porcelain=v1 --untracked-files=all -- \
-      . ':(exclude).local/state/**' 2>/dev/null || true
-    git -C "$worktree_path" diff --no-ext-diff --binary --cached -- \
-      . ':(exclude).local/state/**' 2>/dev/null || true
-    git -C "$worktree_path" diff --no-ext-diff --binary -- \
-      . ':(exclude).local/state/**' 2>/dev/null || true
-    while IFS= read -r -d '' untracked_file; do
-      printf '%s\0' "$untracked_file"
-      git -C "$worktree_path" hash-object -- "$untracked_file" 2>/dev/null || true
-    done < <(git -C "$worktree_path" ls-files --others --exclude-standard -z -- \
-      . ':(exclude).local/state/**' 2>/dev/null)
+    if git -C "$worktree_path" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+      git -C "$worktree_path" status --porcelain=v1 --untracked-files=all -- \
+        . ':(exclude).local/state/**' 2>/dev/null || true
+      git -C "$worktree_path" diff --no-ext-diff --binary --cached -- \
+        . ':(exclude).local/state/**' 2>/dev/null || true
+      git -C "$worktree_path" diff --no-ext-diff --binary -- \
+        . ':(exclude).local/state/**' 2>/dev/null || true
+      while IFS= read -r -d '' untracked_file; do
+        printf '%s\0' "$untracked_file"
+        git -C "$worktree_path" hash-object -- "$untracked_file" 2>/dev/null || true
+      done < <(git -C "$worktree_path" ls-files --others --exclude-standard -z -- \
+        . ':(exclude).local/state/**' 2>/dev/null)
+    else
+      while IFS= read -r -d '' filesystem_entry; do
+        [ "$filesystem_entry" != "$TRANSCRIPT_PATH" ] || continue
+        relative_entry="${filesystem_entry#"$worktree_path"/}"
+        if [ -L "$filesystem_entry" ]; then
+          entry_type="link"
+        elif [ -d "$filesystem_entry" ]; then
+          entry_type="directory"
+        else
+          entry_type="file"
+        fi
+        printf '%s\0%s\0' "$entry_type" "$relative_entry"
+        if [ "$entry_type" = "file" ]; then
+          cksum < "$filesystem_entry" 2>/dev/null || true
+        elif [ "$entry_type" = "link" ]; then
+          readlink "$filesystem_entry" 2>/dev/null || true
+        fi
+      done < <(find "$worktree_path" \
+        \( -type d -name .git -o -type d -path "$worktree_path/.local/state" \) -prune -o \
+        \( -type d -o -type f -o -type l \) -print0 2>/dev/null)
+    fi
   } | cksum | awk '{print $1 ":" $2}'
 }
 

--- a/shared/hooks/stop-hook.sh
+++ b/shared/hooks/stop-hook.sh
@@ -19,6 +19,7 @@ HOOK_INPUT=$(cat)
 # Extract transcript path from hook input
 TRANSCRIPT_PATH=$(echo "$HOOK_INPUT" | jq -r '.transcript_path // empty' 2>/dev/null)
 CURRENT_SESSION_ID=$(echo "$HOOK_INPUT" | jq -r '.session_id // empty' 2>/dev/null)
+HOOK_CWD=$(echo "$HOOK_INPUT" | jq -r '.cwd // empty' 2>/dev/null)
 if [ -z "$CURRENT_SESSION_ID" ] && [ -n "$TRANSCRIPT_PATH" ]; then
   CURRENT_SESSION_ID=$(basename "$TRANSCRIPT_PATH" .jsonl 2>/dev/null || true)
 fi
@@ -33,14 +34,33 @@ fi
 
 source "$LIB_PATH"
 
-loop_log "stop-hook: entered, transcript=$TRANSCRIPT_PATH"
+resolve_current_worktree() {
+  local candidate="$HOOK_CWD"
+  local root
+  if [ -z "$candidate" ] || [ ! -d "$candidate" ]; then
+    candidate=$(pwd -P)
+  fi
+  root=$(git -C "$candidate" rev-parse --show-toplevel 2>/dev/null || true)
+  if [ -n "$root" ] && [ -d "$root" ]; then
+    root=$(cd "$root" && pwd -P)
+  else
+    root=$(cd "$candidate" && pwd -P)
+  fi
+  printf '%s\n' "$root"
+}
+
+CURRENT_WORKTREE_PATH=$(resolve_current_worktree)
+
+loop_log "stop-hook: entered, transcript=$TRANSCRIPT_PATH worktree=$CURRENT_WORKTREE_PATH"
 
 block_stop() {
   local reason="$1"
   local message="$2"
+  local state_context="${3:-${STATE_FILE:-unknown}}"
   if ! printf '%s' "$reason" | grep '[^[:space:]]' >/dev/null; then
     reason="Loop execution is blocked by invalid state."
   fi
+  message="$message State file(s): $state_context. Cancel with /go-workflow:cancel-loop."
   jq -n --arg reason "$reason" --arg msg "$message" \
     '{"decision": "block", "reason": $reason, "systemMessage": $msg}'
 }
@@ -57,19 +77,135 @@ transcript_owns_loop() {
 session_owns_loop_state() {
   local state_file="$1"
   local stored_session_id
+  local stored_worktree_path
   local loop_name
 
   [ -f "$state_file" ] && [ -r "$state_file" ] && jq empty "$state_file" 2>/dev/null || return 1
 
   stored_session_id=$(jq -r '.session_id // empty' "$state_file" 2>/dev/null)
+  stored_worktree_path=$(jq -r '.worktree_path // empty' "$state_file" 2>/dev/null)
   loop_name=$(jq -r '.loop_name // empty' "$state_file" 2>/dev/null)
 
-  if [ -n "$stored_session_id" ] && [ -n "$CURRENT_SESSION_ID" ]; then
-    [ "$stored_session_id" = "$CURRENT_SESSION_ID" ]
+  if [ -n "$stored_worktree_path" ]; then
+    [ -d "$stored_worktree_path" ] || return 1
+    stored_worktree_path=$(cd "$stored_worktree_path" && pwd -P)
+    [ "$stored_worktree_path" = "$CURRENT_WORKTREE_PATH" ] || return 1
+  fi
+
+  if [ -n "$stored_session_id" ]; then
+    [ -n "$CURRENT_SESSION_ID" ] && [ "$stored_session_id" = "$CURRENT_SESSION_ID" ]
     return
   fi
 
   transcript_owns_loop "$loop_name"
+}
+
+state_has_stale_worktree() {
+  local state_file="$1"
+  local stored_worktree_path
+  stored_worktree_path=$(jq -r '.worktree_path // empty' "$state_file" 2>/dev/null)
+  [ -n "$stored_worktree_path" ] && [ ! -d "$stored_worktree_path" ]
+}
+
+repository_target_required_for() {
+  local owner_workflow="$1"
+  local phase="$2"
+  case "$owner_workflow:$phase" in
+    ship:reviewing|ship:pushing)
+      return 0
+      ;;
+    *)
+      return 1
+      ;;
+  esac
+}
+
+loop_requires_repository_target() {
+  repository_target_required_for "$OWNER_WORKFLOW" "$PHASE"
+}
+
+repository_has_target() {
+  local worktree_path="$1"
+  local current_branch
+  local upstream
+  local default_ref
+  local candidate
+  local ahead
+
+  git -C "$worktree_path" rev-parse --is-inside-work-tree >/dev/null 2>&1 || return 2
+
+  if ! git -C "$worktree_path" diff --cached --quiet --; then
+    return 0
+  fi
+
+  upstream=$(git -C "$worktree_path" rev-parse --abbrev-ref '@{upstream}' 2>/dev/null || true)
+  if [ -n "$upstream" ]; then
+    ahead=$(git -C "$worktree_path" rev-list --count "$upstream"..HEAD 2>/dev/null || printf '0')
+    if [ "$ahead" -gt 0 ]; then
+      return 0
+    fi
+  fi
+
+  current_branch=$(git -C "$worktree_path" branch --show-current 2>/dev/null || true)
+  default_ref=$(git -C "$worktree_path" symbolic-ref --quiet --short refs/remotes/origin/HEAD 2>/dev/null || true)
+  if [ -z "$default_ref" ]; then
+    for candidate in origin/main origin/master main master; do
+      if git -C "$worktree_path" rev-parse --verify --quiet "$candidate^{commit}" >/dev/null; then
+        default_ref="$candidate"
+        break
+      fi
+    done
+  fi
+  if [ -n "$current_branch" ] && [ -n "$default_ref" ] &&
+     [ "$current_branch" != "${default_ref#origin/}" ]; then
+    ahead=$(git -C "$worktree_path" rev-list --count "$default_ref"..HEAD 2>/dev/null || printf '0')
+    if [ "$ahead" -gt 0 ]; then
+      return 0
+    fi
+  fi
+
+  return 1
+}
+
+state_has_no_repository_target() {
+  local state_file="$1"
+  local owner_workflow
+  local phase
+  local worktree_path
+  local target_status=0
+  owner_workflow=$(jq -r '.owner_workflow // empty' "$state_file" 2>/dev/null)
+  phase=$(jq -r '.phase // empty' "$state_file" 2>/dev/null)
+  worktree_path=$(jq -r '.worktree_path // empty' "$state_file" 2>/dev/null)
+  repository_target_required_for "$owner_workflow" "$phase" || return 1
+  [ -n "$worktree_path" ] && [ -d "$worktree_path" ] || return 1
+  repository_has_target "$worktree_path" || target_status=$?
+  [ "$target_status" -eq 1 ]
+}
+
+repository_state_fingerprint() {
+  local worktree_path="$1"
+  local phase="$2"
+  local reason="$3"
+  local head
+  local upstream
+  local upstream_head
+  head=$(git -C "$worktree_path" rev-parse HEAD 2>/dev/null || true)
+  upstream=$(git -C "$worktree_path" rev-parse --abbrev-ref '@{upstream}' 2>/dev/null || true)
+  upstream_head=$(git -C "$worktree_path" rev-parse '@{upstream}' 2>/dev/null || true)
+  {
+    printf '%s\n' "$worktree_path" "$phase" "$reason" "$head" "$upstream" "$upstream_head"
+    git -C "$worktree_path" status --porcelain=v1 --untracked-files=all -- \
+      . ':(exclude).local/state/**' 2>/dev/null || true
+    git -C "$worktree_path" diff --no-ext-diff --binary --cached -- \
+      . ':(exclude).local/state/**' 2>/dev/null || true
+    git -C "$worktree_path" diff --no-ext-diff --binary -- \
+      . ':(exclude).local/state/**' 2>/dev/null || true
+    while IFS= read -r -d '' untracked_file; do
+      printf '%s\0' "$untracked_file"
+      git -C "$worktree_path" hash-object -- "$untracked_file" 2>/dev/null || true
+    done < <(git -C "$worktree_path" ls-files --others --exclude-standard -z -- \
+      . ':(exclude).local/state/**' 2>/dev/null)
+  } | cksum | awk '{print $1 ":" $2}'
 }
 
 # Find any active loop state file
@@ -78,7 +214,17 @@ STATE_FILES=$(find_active_loops)
 OWNED_STATE_FILES=""
 while IFS= read -r CANDIDATE_STATE_FILE; do
   [ -n "$CANDIDATE_STATE_FILE" ] || continue
+  if state_has_stale_worktree "$CANDIDATE_STATE_FILE"; then
+    loop_log "stop-hook: pruning stale loop state '$CANDIDATE_STATE_FILE'"
+    cleanup_loop "$CANDIDATE_STATE_FILE"
+    continue
+  fi
   if session_owns_loop_state "$CANDIDATE_STATE_FILE"; then
+    if state_has_no_repository_target "$CANDIDATE_STATE_FILE"; then
+      loop_log "stop-hook: pruning targetless loop state '$CANDIDATE_STATE_FILE'"
+      cleanup_loop "$CANDIDATE_STATE_FILE"
+      continue
+    fi
     if [ -z "$OWNED_STATE_FILES" ]; then
       OWNED_STATE_FILES="$CANDIDATE_STATE_FILE"
     else
@@ -101,7 +247,8 @@ if [ "$STATE_COUNT" -ne 1 ]; then
   MULTIPLE_REASON=$(printf 'Multiple active loop states were found; ownership is ambiguous:\n%s' "$STATE_FILES")
   loop_log "stop-hook: refusing ambiguous active loops: $STATE_FILES"
   block_stop "$MULTIPLE_REASON" \
-    "$MULTIPLE_REASON Cancel the orphaned loop states or restore one caller-owned state before continuing."
+    "$MULTIPLE_REASON Cancel the orphaned loop states or restore one caller-owned state before continuing." \
+    "$STATE_FILES"
   exit 0
 fi
 
@@ -142,6 +289,12 @@ if [ -z "$STORED_SESSION_ID" ] && [ -n "$CURRENT_SESSION_ID" ]; then
   set_loop_field "$STATE_FILE" "session_id" "$CURRENT_SESSION_ID" '[]'
   loop_log "stop-hook: claimed loop state '$STATE_FILE' for session '$CURRENT_SESSION_ID'"
 fi
+STORED_WORKTREE_PATH=$(jq -r '.worktree_path // empty' "$STATE_FILE")
+if [ -z "$STORED_WORKTREE_PATH" ]; then
+  set_loop_field "$STATE_FILE" "worktree_path" "$CURRENT_WORKTREE_PATH" '[]'
+  STORED_WORKTREE_PATH="$CURRENT_WORKTREE_PATH"
+  loop_log "stop-hook: claimed loop state '$STATE_FILE' for worktree '$CURRENT_WORKTREE_PATH'"
+fi
 
 # Validate iteration is a number
 if ! [[ "$ITERATION" =~ ^[0-9]+$ ]]; then
@@ -170,6 +323,16 @@ if [ -n "$COMPLETION_PROMISE" ] && [ -n "$TRANSCRIPT_PATH" ] && [ -f "$TRANSCRIP
   loop_log "stop-hook: checking completion promise '$COMPLETION_PROMISE'"
   if check_completion_promise "$COMPLETION_PROMISE" "$TRANSCRIPT_PATH"; then
     loop_log "stop-hook: completion promise found, cleaning up"
+    cleanup_loop "$STATE_FILE"
+    exit 0
+  fi
+fi
+
+TARGET_STATUS=0
+if loop_requires_repository_target; then
+  repository_has_target "$STORED_WORKTREE_PATH" || TARGET_STATUS=$?
+  if [ "$TARGET_STATUS" -eq 1 ]; then
+    loop_log "stop-hook: no repository target remains; cleaning up '$STATE_FILE'"
     cleanup_loop "$STATE_FILE"
     exit 0
   fi
@@ -265,8 +428,16 @@ if ! printf '%s' "$REASON" | grep '[^[:space:]]' >/dev/null; then
   REASON="Continue working on the task."
 fi
 
-loop_log "stop-hook: blocking exit, reason='$REASON'"
+MAX_UNCHANGED_BLOCKS=3
+BLOCK_FINGERPRINT=$(repository_state_fingerprint "$STORED_WORKTREE_PATH" "$PHASE" "$REASON")
+UNCHANGED_BLOCK_COUNT=$(record_loop_block_attempt "$STATE_FILE" "$BLOCK_FINGERPRINT")
+if [ "$UNCHANGED_BLOCK_COUNT" -gt "$MAX_UNCHANGED_BLOCKS" ]; then
+  loop_log "stop-hook: unchanged block cap reached ($UNCHANGED_BLOCK_COUNT > $MAX_UNCHANGED_BLOCKS); cleaning up '$STATE_FILE'"
+  cleanup_loop "$STATE_FILE"
+  exit 0
+fi
+SYSTEM_MSG="$SYSTEM_MSG Unchanged repository-state block $UNCHANGED_BLOCK_COUNT of $MAX_UNCHANGED_BLOCKS; the loop self-expires before another identical block."
 
-# Block exit and re-feed prompt
-jq -n --arg reason "$REASON" --arg msg "$SYSTEM_MSG" \
-  '{"decision": "block", "reason": $reason, "systemMessage": $msg}'
+loop_log "stop-hook: blocking exit, reason='$REASON' unchanged_blocks=$UNCHANGED_BLOCK_COUNT"
+
+block_stop "$REASON" "$SYSTEM_MSG" "$STATE_FILE"

--- a/shared/lib/loop-state.sh
+++ b/shared/lib/loop-state.sh
@@ -18,6 +18,17 @@ resolve_loop_owner_root() {
   printf '%s\n' "$root"
 }
 
+resolve_loop_worktree_root() {
+  local root
+  root=$(git rev-parse --show-toplevel 2>/dev/null || true)
+  if [ -z "$root" ]; then
+    root=$(pwd -P)
+  elif [ -d "$root" ]; then
+    root=$(cd "$root" && pwd -P)
+  fi
+  printf '%s\n' "$root"
+}
+
 loop_state_directory() {
   printf '%s/.local/state\n' "$(resolve_loop_owner_root)"
 }
@@ -246,6 +257,22 @@ increment_iteration() {
   ensure_loop_state_schema "$state_file" || return 1
   jq '.iteration = ((.iteration // 0) + 1)' "$state_file" > "$tmp_file" && mv "$tmp_file" "$state_file"
   loop_log "increment_iteration: file=$state_file"
+}
+
+record_loop_block_attempt() {
+  local state_file="$1"
+  local fingerprint="$2"
+  local tmp_file="${state_file}.tmp.$$"
+  ensure_loop_state_schema "$state_file" || return 1
+  jq --arg fingerprint "$fingerprint" '
+    if (.last_block_fingerprint // "") == $fingerprint then
+      .unchanged_block_count = ((.unchanged_block_count // 0) + 1)
+    else
+      .last_block_fingerprint = $fingerprint |
+      .unchanged_block_count = 1
+    end
+  ' "$state_file" > "$tmp_file" && mv "$tmp_file" "$state_file"
+  jq -r '.unchanged_block_count' "$state_file"
 }
 
 set_loop_phase() {

--- a/shared/scripts/setup-loop.sh
+++ b/shared/scripts/setup-loop.sh
@@ -98,6 +98,7 @@ if [ "$ACTIVE_COUNT" -ne 0 ]; then
 fi
 
 SESSION_ID="${CLAUDE_SESSION_ID:-}"
+WORKTREE_PATH=$(resolve_loop_worktree_root)
 
 MAX_ITER_JSON="null"
 if [ -n "$MAX_ITERATIONS" ]; then
@@ -131,6 +132,7 @@ jq -n \
   --arg phase "$INITIAL_PHASE" \
   --arg started_at "$(date -u +"%Y-%m-%dT%H:%M:%SZ")" \
   --arg session_id "$SESSION_ID" \
+  --arg worktree_path "$WORKTREE_PATH" \
   --argjson phase_messages "$PHASE_MSGS_JSON" \
   '{
     schema_version: $schema_version,
@@ -144,6 +146,7 @@ jq -n \
     bot_review_baseline: "",
     started_at: $started_at,
     session_id: $session_id,
+    worktree_path: $worktree_path,
     awaiting_driver_input: false,
     driver_input_reason: "",
     phase_messages: $phase_messages,

--- a/shared/scripts/setup-loop.sh
+++ b/shared/scripts/setup-loop.sh
@@ -99,6 +99,7 @@ fi
 
 SESSION_ID="${CLAUDE_SESSION_ID:-}"
 WORKTREE_PATH=$(resolve_loop_worktree_root)
+SESSION_WORKTREE_PATH="$WORKTREE_PATH"
 
 MAX_ITER_JSON="null"
 if [ -n "$MAX_ITERATIONS" ]; then
@@ -132,6 +133,7 @@ jq -n \
   --arg phase "$INITIAL_PHASE" \
   --arg started_at "$(date -u +"%Y-%m-%dT%H:%M:%SZ")" \
   --arg session_id "$SESSION_ID" \
+  --arg session_worktree_path "$SESSION_WORKTREE_PATH" \
   --arg worktree_path "$WORKTREE_PATH" \
   --argjson phase_messages "$PHASE_MSGS_JSON" \
   '{
@@ -146,6 +148,7 @@ jq -n \
     bot_review_baseline: "",
     started_at: $started_at,
     session_id: $session_id,
+    session_worktree_path: $session_worktree_path,
     worktree_path: $worktree_path,
     awaiting_driver_input: false,
     driver_input_reason: "",


### PR DESCRIPTION
## Summary

- scope loop recovery to its owning session and worktree, pruning demonstrably stale state without replaying foreign work
- clear targetless commit/push recovery states and expire repeated unchanged blocks after a bounded retry count
- include the state path and cancellation command in every block response, with regression coverage for recovery targets, wait phases, progress resets, and Detent temp isolation

Fixes #320

## Test Plan

- `./scripts/test-loop-state.sh && ./scripts/test-hooks.sh && ./scripts/check-shared-sync.sh`
- authoritative `gate.run` from `detent.yaml`
- `git diff --check`
