### PR TITLE
fix(codex): adapt PostToolUse hook schema

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -87,10 +87,12 @@ The `shared/` directory contains code used by multiple plugins:
   - Checks for required env vars (GITHUB_TOKEN, OPENAI_API_KEY) contextually
   - Blocks execution if required tools are missing (golangci-lint, templ, gh, node)
   - Warns on uncommitted changes before tests; blocks releases with dirty git state
-- **PostToolUse hook** (`post-tool-use.sh`): Error detection and auto-retry after tool execution:
+- **PostToolUse hook** (`post-tool-use.sh`): Error detection after tool execution:
   - Detects Go compilation errors, lint failures, permission denied
-  - Auto-retries network timeouts (up to 3 retries with linear backoff)
-  - Auto-retries rate limits (up to 3 retries with exponential backoff: 30s, 60s, 120s)
+  - Codex observes local Bash only; hosted WebFetch and WebSearch bypass this local hook in Codex but remain matched for Claude
+  - Codex transient failures receive model-visible safe retry guidance instead of automatic retries
+  - Claude auto-retries network timeouts (up to 3 retries with linear backoff)
+  - Claude auto-retries rate limits (up to 3 retries with exponential backoff: 30s, 60s, 120s)
   - Summarizes long output (>200 lines)
 **When editing `shared/`**: The pre-commit hook automatically syncs changes to plugins. If you need to sync manually:
 

--- a/plugins/go-workflow/hooks/post-tool-use.sh
+++ b/plugins/go-workflow/hooks/post-tool-use.sh
@@ -5,8 +5,8 @@ HOOK_INPUT=$(cat)
 
 if ! PLATFORM=$(printf '%s\n' "$HOOK_INPUT" | jq -r '
   if type != "object" then "unknown"
-  elif has("tool_response") then "codex"
-  elif has("tool_output") then "claude"
+  elif has("turn_id") and has("tool_response") then "codex"
+  elif has("tool_response") or has("tool_output") then "claude"
   else "unknown"
   end
 ' 2>/dev/null); then
@@ -24,14 +24,8 @@ if ! TOOL_NAME=$(printf '%s\n' "$HOOK_INPUT" | jq -r '
   exit 0
 fi
 
-if [ "$PLATFORM" = "codex" ]; then
-  OUTPUT_FIELD="tool_response"
-else
-  OUTPUT_FIELD="tool_output"
-fi
-
-if ! TOOL_OUTPUT=$(printf '%s\n' "$HOOK_INPUT" | jq -r --arg field "$OUTPUT_FIELD" '
-  .[$field] |
+if ! TOOL_OUTPUT=$(printf '%s\n' "$HOOK_INPUT" | jq -r --arg platform "$PLATFORM" '
+  (if $platform == "codex" or has("tool_response") then .tool_response else .tool_output end) |
   if . == null then ""
   elif type == "string" then .
   else [.. | scalars | tostring] | join("\n")

--- a/plugins/go-workflow/hooks/post-tool-use.sh
+++ b/plugins/go-workflow/hooks/post-tool-use.sh
@@ -54,23 +54,29 @@ detect_permission_error() {
   printf '%s\n' "$TOOL_OUTPUT" | grep -qiE 'permission denied|403 Forbidden|EACCES|not authorized'
 }
 
-codex_command_failed() {
-  printf '%s\n' "$HOOK_INPUT" | jq -e '
+codex_command_status() {
+  printf '%s\n' "$HOOK_INPUT" | jq -r '
     .tool_response |
     if type == "object" then
       if (.exit_code? // .exitCode?) != null then
-        (((.exit_code? // .exitCode?) | tonumber? // 0) != 0)
-      elif has("success") then
-        .success == false
+        if (((.exit_code? // .exitCode?) | tonumber? // 0) != 0) then "failed" else "succeeded" end
+      elif has("success") and (.success | type == "boolean") then
+        if .success then "succeeded" else "failed" end
       else
-        false
+        "unknown"
       end
     elif type == "string" then
-      test("(^|\\n)[[:space:]]*(Process|Command) exited with code [1-9][0-9]*[[:space:]]*(\\n|$)"; "i")
+      if test("(^|\\n)[[:space:]]*(Process|Command) exited with code [1-9][0-9]*[[:space:]]*(\\n|$)"; "i") then
+        "failed"
+      elif test("(^|\\n)[[:space:]]*(Process|Command) exited with code 0[[:space:]]*(\\n|$)"; "i") then
+        "succeeded"
+      else
+        "unknown"
+      end
     else
-      false
+      "unknown"
     end
-  ' >/dev/null 2>&1
+  ' 2>/dev/null
 }
 
 emit_codex_block() {
@@ -99,39 +105,58 @@ emit_codex_context() {
     }'
 }
 
-if [ "$PLATFORM" = "codex" ]; then
-  CODEX_COMMAND_FAILED=false
-  if codex_command_failed; then
-    CODEX_COMMAND_FAILED=true
+emit_codex_diagnostic() {
+  local failed_reason="$1"
+  local unknown_reason="$2"
+  local guidance="$3"
+  if [ "$CODEX_COMMAND_STATUS" = failed ]; then
+    emit_codex_block "$failed_reason" "$guidance"
+    return
   fi
+  local output_excerpt="${TOOL_OUTPUT:0:4000}"
+  local context
+  context=$(printf '%s\n\n%s\n\nCommand output excerpt:\n%s' \
+    "$unknown_reason" \
+    "Treat this as context only. Confirm that the command failed before retrying it or changing code." \
+    "$output_excerpt")
+  emit_codex_context "$context"
+}
 
-  if [ "$CODEX_COMMAND_FAILED" = true ] && detect_network_timeout; then
-    emit_codex_block \
+if [ "$PLATFORM" = "codex" ]; then
+  CODEX_COMMAND_STATUS=$(codex_command_status) || CODEX_COMMAND_STATUS=unknown
+
+  if [ "$CODEX_COMMAND_STATUS" != succeeded ] && detect_network_timeout; then
+    emit_codex_diagnostic \
       "Network timeout detected after the Bash command ran." \
+      "The Bash output matches a network-timeout diagnostic, but command completion status is unavailable." \
       "Do not retry automatically. Retry only after assessing whether repeating the command is safe and idempotent and whether the prior attempt may have produced side effects."
     exit 0
   fi
-  if [ "$CODEX_COMMAND_FAILED" = true ] && detect_rate_limit; then
-    emit_codex_block \
+  if [ "$CODEX_COMMAND_STATUS" != succeeded ] && detect_rate_limit; then
+    emit_codex_diagnostic \
       "Rate limit detected after the Bash command ran." \
+      "The Bash output matches a rate-limit diagnostic, but command completion status is unavailable." \
       "Do not retry automatically. Retry only after assessing whether repeating the command is safe and idempotent and whether the prior attempt may have produced side effects."
     exit 0
   fi
-  if [ "$CODEX_COMMAND_FAILED" = true ] && detect_compilation_error; then
-    emit_codex_block \
+  if [ "$CODEX_COMMAND_STATUS" != succeeded ] && detect_compilation_error; then
+    emit_codex_diagnostic \
       "Go compilation error detected." \
+      "The Bash output matches a Go compilation diagnostic, but command completion status is unavailable." \
       "Fix the reported compilation errors before proceeding."
     exit 0
   fi
-  if [ "$CODEX_COMMAND_FAILED" = true ] && detect_lint_error; then
-    emit_codex_block \
+  if [ "$CODEX_COMMAND_STATUS" != succeeded ] && detect_lint_error; then
+    emit_codex_diagnostic \
       "Lint failures detected." \
+      "The Bash output matches a lint-failure diagnostic, but command completion status is unavailable." \
       "Review and fix the reported lint failures before committing."
     exit 0
   fi
-  if [ "$CODEX_COMMAND_FAILED" = true ] && detect_permission_error; then
-    emit_codex_block \
+  if [ "$CODEX_COMMAND_STATUS" != succeeded ] && detect_permission_error; then
+    emit_codex_diagnostic \
       "Permission denied by the Bash command." \
+      "The Bash output matches a permission-denied diagnostic, but command completion status is unavailable." \
       "Check credentials and access rights before proceeding."
     exit 0
   fi

--- a/plugins/go-workflow/hooks/post-tool-use.sh
+++ b/plugins/go-workflow/hooks/post-tool-use.sh
@@ -1,29 +1,155 @@
 #!/bin/bash
-# PostToolUse error detection and auto-retry hook for go-workflow
 set -euo pipefail
+
 HOOK_INPUT=$(cat)
-TOOL_NAME=$(echo "$HOOK_INPUT" | jq -r '.tool_name // empty' 2>/dev/null)
-TOOL_OUTPUT=$(echo "$HOOK_INPUT" | jq -r '.tool_output // empty' 2>/dev/null)
-RETRY_STATE="${TMPDIR:-/tmp}/gopher-ai-retry-${TOOL_NAME}"
+
+if ! PLATFORM=$(printf '%s\n' "$HOOK_INPUT" | jq -r '
+  if type != "object" then "unknown"
+  elif has("tool_response") then "codex"
+  elif has("tool_output") then "claude"
+  else "unknown"
+  end
+' 2>/dev/null); then
+  exit 0
+fi
+
+if [ "$PLATFORM" = "unknown" ]; then
+  exit 0
+fi
+
+if ! TOOL_NAME=$(printf '%s\n' "$HOOK_INPUT" | jq -r '
+  .tool_name // "" |
+  if type == "string" then . else tostring end
+' 2>/dev/null); then
+  exit 0
+fi
+
+if [ "$PLATFORM" = "codex" ]; then
+  OUTPUT_FIELD="tool_response"
+else
+  OUTPUT_FIELD="tool_output"
+fi
+
+if ! TOOL_OUTPUT=$(printf '%s\n' "$HOOK_INPUT" | jq -r --arg field "$OUTPUT_FIELD" '
+  .[$field] |
+  if . == null then ""
+  elif type == "string" then .
+  else [.. | scalars | tostring] | join("\n")
+  end
+' 2>/dev/null); then
+  exit 0
+fi
 
 detect_network_timeout() {
-  echo "$TOOL_OUTPUT" | grep -qiE 'connection timed out|network.*(unreachable|timeout)|dial tcp.*timeout|context deadline exceeded|ETIMEDOUT'
+  printf '%s\n' "$TOOL_OUTPUT" | grep -qiE 'connection timed out|network.*(unreachable|timeout)|dial tcp.*timeout|context deadline exceeded|ETIMEDOUT|i/o timeout'
 }
+
 detect_rate_limit() {
-  echo "$TOOL_OUTPUT" | grep -qiE 'rate limit|429|too many requests|API rate limit exceeded|secondary rate limit'
+  printf '%s\n' "$TOOL_OUTPUT" | grep -qiE 'rate limit|429|too many requests|API rate limit exceeded|secondary rate limit'
 }
-get_retry_count() { local f="${RETRY_STATE}-$1"; [ -f "$f" ] && cat "$f" || echo "0"; }
-increment_retry() { local f="${RETRY_STATE}-$1"; echo $(( $(get_retry_count "$1") + 1 )) > "$f"; }
-cleanup_retry() { rm -f "${RETRY_STATE}-$1" 2>/dev/null; }
+
+detect_compilation_error() {
+  printf '%s\n' "$TOOL_OUTPUT" | grep -qE '^.+\.go:[0-9]+:[0-9]+: '
+}
+
+detect_lint_error() {
+  printf '%s\n' "$TOOL_OUTPUT" | grep -qiE 'golangci-lint.*error|staticcheck.*error'
+}
+
+detect_permission_error() {
+  printf '%s\n' "$TOOL_OUTPUT" | grep -qiE 'permission denied|403 Forbidden|EACCES|not authorized'
+}
+
+emit_codex_block() {
+  local reason="$1"
+  local guidance="$2"
+  local output_excerpt="${TOOL_OUTPUT:0:4000}"
+  local feedback
+  feedback=$(printf '%s\n\n%s\n\nCommand output excerpt:\n%s' "$reason" "$guidance" "$output_excerpt")
+  jq -cn \
+    --arg reason "$feedback" \
+    '{
+      decision: "block",
+      reason: $reason
+    }'
+}
+
+emit_codex_context() {
+  local context="$1"
+  jq -cn \
+    --arg context "$context" \
+    '{
+      hookSpecificOutput: {
+        hookEventName: "PostToolUse",
+        additionalContext: $context
+      }
+    }'
+}
+
+if [ "$PLATFORM" = "codex" ]; then
+  if detect_network_timeout; then
+    emit_codex_block \
+      "Network timeout detected after the Bash command ran." \
+      "Do not retry automatically. Retry only after assessing whether repeating the command is safe and idempotent and whether the prior attempt may have produced side effects."
+    exit 0
+  fi
+  if detect_rate_limit; then
+    emit_codex_block \
+      "Rate limit detected after the Bash command ran." \
+      "Do not retry automatically. Retry only after assessing whether repeating the command is safe and idempotent and whether the prior attempt may have produced side effects."
+    exit 0
+  fi
+  if detect_compilation_error; then
+    emit_codex_block \
+      "Go compilation error detected." \
+      "Fix the reported compilation errors before proceeding."
+    exit 0
+  fi
+  if detect_lint_error; then
+    emit_codex_block \
+      "Lint failures detected." \
+      "Review and fix the reported lint failures before committing."
+    exit 0
+  fi
+  if detect_permission_error; then
+    emit_codex_block \
+      "Permission denied by the Bash command." \
+      "Check credentials and access rights before proceeding."
+    exit 0
+  fi
+
+  output_lines=$(printf '%s\n' "$TOOL_OUTPUT" | wc -l)
+  if [ "$output_lines" -gt 200 ]; then
+    emit_codex_context "The Bash command produced ${output_lines} lines of output. Summarize the relevant result before proceeding."
+  fi
+  exit 0
+fi
+
+RETRY_STATE="${TMPDIR:-/tmp}/gopher-ai-retry-${TOOL_NAME}"
+
+get_retry_count() {
+  local retry_file="${RETRY_STATE}-$1"
+  [ -f "$retry_file" ] && cat "$retry_file" || echo "0"
+}
+
+increment_retry() {
+  local retry_file="${RETRY_STATE}-$1"
+  printf '%s\n' "$(( $(get_retry_count "$1") + 1 ))" > "$retry_file"
+}
+
+cleanup_retry() {
+  rm -f "${RETRY_STATE}-$1" 2>/dev/null
+}
 
 handle_network_timeout() {
-  local rc; rc=$(get_retry_count "network")
-  if [ "$rc" -lt 3 ]; then
+  local retry_count
+  retry_count=$(get_retry_count "network")
+  if [ "$retry_count" -lt 3 ]; then
     increment_retry "network"
-    local wait=$(( (rc + 1) * 5 ))
-    echo "Network timeout (attempt $((rc+1))/3). Retrying in ${wait}s..." >&2
-    sleep "$wait"
-    printf '{"retry":true,"reason":"Network timeout - retry %d/3"}\n' "$((rc+1))"
+    local wait_seconds=$(( (retry_count + 1) * 5 ))
+    echo "Network timeout (attempt $((retry_count+1))/3). Retrying in ${wait_seconds}s..." >&2
+    sleep "$wait_seconds"
+    printf '{"retry":true,"reason":"Network timeout - retry %d/3"}\n' "$((retry_count+1))"
     exit 0
   fi
   cleanup_retry "network"
@@ -31,36 +157,34 @@ handle_network_timeout() {
 }
 
 handle_rate_limit() {
-  local rc; rc=$(get_retry_count "ratelimit")
-  if [ "$rc" -lt 3 ]; then
+  local retry_count
+  retry_count=$(get_retry_count "ratelimit")
+  if [ "$retry_count" -lt 3 ]; then
     increment_retry "ratelimit"
-    local wait=$(( 30 * (2 ** rc) ))
-    echo "Rate limit hit (attempt $((rc+1))/3). Waiting ${wait}s..." >&2
-    sleep "$wait"
-    printf '{"retry":true,"reason":"Rate limit - retry %d/3 after %ds"}\n' "$((rc+1))" "$wait"
+    local wait_seconds=$(( 30 * (2 ** retry_count) ))
+    echo "Rate limit hit (attempt $((retry_count+1))/3). Waiting ${wait_seconds}s..." >&2
+    sleep "$wait_seconds"
+    printf '{"retry":true,"reason":"Rate limit - retry %d/3 after %ds"}\n' "$((retry_count+1))" "$wait_seconds"
     exit 0
   fi
   cleanup_retry "ratelimit"
   echo "Rate limit persists after 3 retries. Check API quota." >&2
 }
 
-# Transient failures (may retry)
 if detect_network_timeout; then handle_network_timeout; exit 0; fi
 if detect_rate_limit; then handle_rate_limit; exit 0; fi
 
-# Non-transient errors (inform only)
-if echo "$TOOL_OUTPUT" | grep -qE '^.+\.go:[0-9]+:[0-9]+: '; then
+if detect_compilation_error; then
   echo "Go compilation error detected. Fix the reported errors before proceeding." >&2
 fi
-if echo "$TOOL_OUTPUT" | grep -qiE 'golangci-lint.*error|staticcheck.*error'; then
+if detect_lint_error; then
   echo "Lint failures detected. Review and fix before committing." >&2
 fi
-if echo "$TOOL_OUTPUT" | grep -qiE 'permission denied|403 Forbidden|EACCES|not authorized'; then
+if detect_permission_error; then
   echo "Permission denied. Check credentials and access rights." >&2
 fi
 
-# Output optimization
-output_lines=$(echo "$TOOL_OUTPUT" | wc -l)
+output_lines=$(printf '%s\n' "$TOOL_OUTPUT" | wc -l)
 if [ "$output_lines" -gt 200 ]; then
   echo "Note: Tool output was ${output_lines} lines." >&2
 fi

--- a/plugins/go-workflow/hooks/post-tool-use.sh
+++ b/plugins/go-workflow/hooks/post-tool-use.sh
@@ -54,6 +54,25 @@ detect_permission_error() {
   printf '%s\n' "$TOOL_OUTPUT" | grep -qiE 'permission denied|403 Forbidden|EACCES|not authorized'
 }
 
+codex_command_failed() {
+  printf '%s\n' "$HOOK_INPUT" | jq -e '
+    .tool_response |
+    if type == "object" then
+      if (.exit_code? // .exitCode?) != null then
+        (((.exit_code? // .exitCode?) | tonumber? // 0) != 0)
+      elif has("success") then
+        .success == false
+      else
+        false
+      end
+    elif type == "string" then
+      test("(^|\\n)[[:space:]]*(Process|Command) exited with code [1-9][0-9]*[[:space:]]*(\\n|$)"; "i")
+    else
+      false
+    end
+  ' >/dev/null 2>&1
+}
+
 emit_codex_block() {
   local reason="$1"
   local guidance="$2"
@@ -81,31 +100,36 @@ emit_codex_context() {
 }
 
 if [ "$PLATFORM" = "codex" ]; then
-  if detect_network_timeout; then
+  CODEX_COMMAND_FAILED=false
+  if codex_command_failed; then
+    CODEX_COMMAND_FAILED=true
+  fi
+
+  if [ "$CODEX_COMMAND_FAILED" = true ] && detect_network_timeout; then
     emit_codex_block \
       "Network timeout detected after the Bash command ran." \
       "Do not retry automatically. Retry only after assessing whether repeating the command is safe and idempotent and whether the prior attempt may have produced side effects."
     exit 0
   fi
-  if detect_rate_limit; then
+  if [ "$CODEX_COMMAND_FAILED" = true ] && detect_rate_limit; then
     emit_codex_block \
       "Rate limit detected after the Bash command ran." \
       "Do not retry automatically. Retry only after assessing whether repeating the command is safe and idempotent and whether the prior attempt may have produced side effects."
     exit 0
   fi
-  if detect_compilation_error; then
+  if [ "$CODEX_COMMAND_FAILED" = true ] && detect_compilation_error; then
     emit_codex_block \
       "Go compilation error detected." \
       "Fix the reported compilation errors before proceeding."
     exit 0
   fi
-  if detect_lint_error; then
+  if [ "$CODEX_COMMAND_FAILED" = true ] && detect_lint_error; then
     emit_codex_block \
       "Lint failures detected." \
       "Review and fix the reported lint failures before committing."
     exit 0
   fi
-  if detect_permission_error; then
+  if [ "$CODEX_COMMAND_FAILED" = true ] && detect_permission_error; then
     emit_codex_block \
       "Permission denied by the Bash command." \
       "Check credentials and access rights before proceeding."

--- a/scripts/test-codex-plugin-lifecycle-server.py
+++ b/scripts/test-codex-plugin-lifecycle-server.py
@@ -8,6 +8,110 @@ from http.server import SimpleHTTPRequestHandler, ThreadingHTTPServer
 from pathlib import Path
 
 
+PROBE_SENTINEL = "lifecycle-post-tool-use-probe"
+PROBE_CALL_ID = "post-tool-use-probe"
+PROBE_COMMAND = "printf '%s\\n' 'probe.go:1:1: undefined: lifecycleProbe' >&2; exit 1"
+
+
+def nested_objects(value):
+    if isinstance(value, dict):
+        yield value
+        for child in value.values():
+            yield from nested_objects(child)
+    elif isinstance(value, list):
+        for child in value:
+            yield from nested_objects(child)
+
+
+def has_probe_output(request_body):
+    return any(
+        item.get("type") in ("function_call_output", "custom_tool_call_output")
+        and item.get("call_id") == PROBE_CALL_ID
+        for item in nested_objects(request_body)
+    )
+
+
+def probe_call(request_body):
+    tools = {
+        item.get("name"): item
+        for item in nested_objects(request_body)
+        if isinstance(item.get("name"), str)
+        and isinstance(item.get("parameters"), dict)
+    }
+    for name in ("shell_command", "exec_command"):
+        if name not in tools:
+            continue
+        properties = tools[name].get("parameters", {}).get("properties", {})
+        command_argument = next(
+            (candidate for candidate in ("command", "cmd") if candidate in properties),
+            None,
+        )
+        if command_argument is not None:
+            return {
+                "type": "function_call",
+                "call_id": PROBE_CALL_ID,
+                "name": name,
+                "arguments": json.dumps(
+                    {command_argument: PROBE_COMMAND}, separators=(",", ":")
+                ),
+            }
+    custom_exec = next(
+        (
+            item
+            for item in nested_objects(request_body)
+            if item.get("type") == "custom" and item.get("name") == "exec"
+        ),
+        None,
+    )
+    if custom_exec is not None:
+        command = json.dumps(PROBE_COMMAND)
+        code = (
+            "try {\n"
+            f"  const result = await tools.exec_command({{cmd: {command}}});\n"
+            "  text(result.output);\n"
+            "} catch (error) {\n"
+            "  text(String(error));\n"
+            "}"
+        )
+        return {
+            "type": "custom_tool_call",
+            "call_id": PROBE_CALL_ID,
+            "name": "exec",
+            "input": code,
+        }
+    raise ValueError("no supported shell tool was advertised")
+
+
+def response_events(response_id, output_item):
+    events = [
+        {
+            "type": "response.created",
+            "response": {"id": response_id},
+        },
+        {
+            "type": "response.output_item.done",
+            "item": output_item,
+        },
+        {
+            "type": "response.completed",
+            "response": {
+                "id": response_id,
+                "usage": {
+                    "input_tokens": 0,
+                    "input_tokens_details": None,
+                    "output_tokens": 0,
+                    "output_tokens_details": None,
+                    "total_tokens": 0,
+                },
+            },
+        },
+    ]
+    return "".join(
+        f"event: {event['type']}\ndata: {json.dumps(event, separators=(',', ':'))}\n\n"
+        for event in events
+    ).encode("utf-8")
+
+
 class LifecycleHandler(SimpleHTTPRequestHandler):
     request_count = 0
     request_lock = threading.Lock()
@@ -19,12 +123,15 @@ class LifecycleHandler(SimpleHTTPRequestHandler):
             return
 
         content_length = int(self.headers.get("Content-Length", "0"))
-        self.rfile.read(content_length)
+        request_body = json.loads(self.rfile.read(content_length))
 
         with self.request_lock:
             type(self).request_count += 1
             request_number = type(self).request_count
 
+        self.state_dir.joinpath(f"{request_number}.request.json").write_text(
+            json.dumps(request_body, indent=2, sort_keys=True) + "\n", encoding="utf-8"
+        )
         self.state_dir.joinpath(f"{request_number}.requested").write_text(
             self.path, encoding="utf-8"
         )
@@ -38,40 +145,28 @@ class LifecycleHandler(SimpleHTTPRequestHandler):
             return
 
         response_id = f"response_{request_number}"
-        events = [
-            {
-                "type": "response.created",
-                "response": {"id": response_id},
-            },
-            {
-                "type": "response.output_item.done",
-                "item": {
-                    "type": "message",
-                    "role": "assistant",
-                    "id": response_id,
-                    "content": [
-                        {"type": "output_text", "text": "lifecycle-ok"}
-                    ],
-                },
-            },
-            {
-                "type": "response.completed",
-                "response": {
-                    "id": response_id,
-                    "usage": {
-                        "input_tokens": 0,
-                        "input_tokens_details": None,
-                        "output_tokens": 0,
-                        "output_tokens_details": None,
-                        "total_tokens": 0,
-                    },
-                },
-            },
-        ]
-        body = "".join(
-            f"event: {event['type']}\ndata: {json.dumps(event, separators=(',', ':'))}\n\n"
-            for event in events
-        ).encode("utf-8")
+        request_text = json.dumps(request_body, separators=(",", ":"))
+        if has_probe_output(request_body):
+            output_item = {
+                "type": "message",
+                "role": "assistant",
+                "id": response_id,
+                "content": [{"type": "output_text", "text": "lifecycle-hook-ok"}],
+            }
+        elif PROBE_SENTINEL in request_text:
+            try:
+                output_item = probe_call(request_body)
+            except ValueError as error:
+                self.send_error(400, str(error))
+                return
+        else:
+            output_item = {
+                "type": "message",
+                "role": "assistant",
+                "id": response_id,
+                "content": [{"type": "output_text", "text": "lifecycle-ok"}],
+            }
+        body = response_events(response_id, output_item)
 
         self.send_response(200)
         self.send_header("Content-Type", "text/event-stream")

--- a/scripts/test-codex-plugin-lifecycle.sh
+++ b/scripts/test-codex-plugin-lifecycle.sh
@@ -235,13 +235,14 @@ start_session() {
     local prompt="${3:-Reply with exactly lifecycle-ok and do not use tools.}"
     local hook_input="${4:-}"
     local hook_output="${5:-}"
+    local sandbox_mode="${6:-read-only}"
     CODEX_LIFECYCLE_HOOK_INPUT="$hook_input" \
     CODEX_LIFECYCLE_HOOK_OUTPUT="$hook_output" \
     run_codex exec \
         --cd "$workspace" \
         --skip-git-repo-check \
         --dangerously-bypass-hook-trust \
-        --sandbox read-only \
+        --sandbox "$sandbox_mode" \
         --json \
         -c 'model_provider="lifecycle"' \
         -c "model_providers.lifecycle={ name = \"Lifecycle\", base_url = \"$RESPONSES_BASE_URL\", env_key = \"OPENAI_API_KEY\", wire_api = \"responses\", supports_websockets = false }" \
@@ -349,7 +350,7 @@ wait_for_session_request "$SERVER_STATE/2.requested" "$SECOND_SESSION_PID" "post
 finish_session "$SECOND_SESSION_PID" second
 assert_session second "$SECOND_WORKSPACE" "$SECOND_VERSION"
 
-start_session probe "$THIRD_WORKSPACE" "$PROBE_PROMPT" "$HOOK_INPUT_CAPTURE" "$HOOK_OUTPUT_CAPTURE"
+start_session probe "$THIRD_WORKSPACE" "$PROBE_PROMPT" "$HOOK_INPUT_CAPTURE" "$HOOK_OUTPUT_CAPTURE" danger-full-access
 PROBE_SESSION_PID=$SESSION_PID
 wait_for_session_request "$SERVER_STATE/3.requested" "$PROBE_SESSION_PID" "probe Responses request"
 : > "$SERVER_STATE/3.release"

--- a/scripts/test-codex-plugin-lifecycle.sh
+++ b/scripts/test-codex-plugin-lifecycle.sh
@@ -360,6 +360,7 @@ wait_for_session_request "$SERVER_STATE/4.requested" "$PROBE_SESSION_PID" "probe
 
 jq -e --arg command "$PROBE_COMMAND" '
     .hook_event_name == "PostToolUse" and
+    (.turn_id | type == "string" and length > 0) and
     .tool_name == "Bash" and
     (.tool_use_id | type == "string" and length > 0) and
     .tool_input.command == $command and

--- a/scripts/test-codex-plugin-lifecycle.sh
+++ b/scripts/test-codex-plugin-lifecycle.sh
@@ -14,9 +14,14 @@ TEST_HOME="$TEST_ROOT/home"
 CODEX_HOME="$TEST_HOME/.codex"
 FIRST_WORKSPACE="$TEST_ROOT/first-workspace"
 SECOND_WORKSPACE="$TEST_ROOT/second-workspace"
+THIRD_WORKSPACE="$TEST_ROOT/third-workspace"
 LOG_DIR="$TEST_ROOT/logs"
 PORT_FILE="$TEST_ROOT/server.port"
 ACTIVE_PIDS=""
+PROBE_COMMAND="printf '%s\n' 'probe.go:1:1: undefined: lifecycleProbe' >&2; exit 1"
+PROBE_PROMPT="Run the lifecycle-post-tool-use-probe sentinel with the shell tool."
+HOOK_INPUT_CAPTURE="$LOG_DIR/post-tool-use.input.json"
+HOOK_OUTPUT_CAPTURE="$LOG_DIR/post-tool-use.output.json"
 
 fail() {
     printf 'FAIL: %s\n' "$*" >&2
@@ -41,7 +46,7 @@ dump_diagnostics() {
         done
     fi
     local workspace
-    for workspace in "$FIRST_WORKSPACE" "$SECOND_WORKSPACE"; do
+    for workspace in "$FIRST_WORKSPACE" "$SECOND_WORKSPACE" "$THIRD_WORKSPACE"; do
         if [[ -f "$workspace/.local/state/loop-debug.log" ]]; then
             printf '\n--- %s stop-hook log ---\n' "$(basename "$workspace")" >&2
             sed -n '1,120p' "$workspace/.local/state/loop-debug.log" >&2
@@ -81,6 +86,7 @@ mkdir -p \
     "$CODEX_HOME" \
     "$FIRST_WORKSPACE" \
     "$SECOND_WORKSPACE" \
+    "$THIRD_WORKSPACE" \
     "$LOG_DIR"
 
 for plugin_dir in "$ROOT_DIR"/plugins/*; do
@@ -89,6 +95,29 @@ for plugin_dir in "$ROOT_DIR"/plugins/*; do
 done
 cp "$ROOT_DIR/.agents/plugins/marketplace.json" \
     "$FIXTURE_WORK/.agents/plugins/marketplace.json"
+
+POST_TOOL_USE_CAPTURE="$FIXTURE_WORK/plugins/go-workflow/hooks/post-tool-use-capture.sh"
+cat > "$POST_TOOL_USE_CAPTURE" <<'EOF'
+#!/bin/bash
+set -euo pipefail
+
+HOOK_ROOT="$(cd "$(dirname "$0")" && pwd)"
+INPUT_PATH="${CODEX_LIFECYCLE_HOOK_INPUT:?}"
+OUTPUT_PATH="${CODEX_LIFECYCLE_HOOK_OUTPUT:?}"
+cat > "$INPUT_PATH"
+set +e
+"$HOOK_ROOT/post-tool-use.sh" < "$INPUT_PATH" > "$OUTPUT_PATH"
+status=$?
+set -e
+cat "$OUTPUT_PATH"
+exit "$status"
+EOF
+chmod +x "$POST_TOOL_USE_CAPTURE"
+jq '(.hooks.PostToolUse[0].hooks[0].command) = "${CLAUDE_PLUGIN_ROOT}/hooks/post-tool-use-capture.sh"' \
+    "$FIXTURE_WORK/plugins/go-workflow/hooks/hooks.json" \
+    > "$FIXTURE_WORK/plugins/go-workflow/hooks/hooks.json.tmp"
+mv "$FIXTURE_WORK/plugins/go-workflow/hooks/hooks.json.tmp" \
+    "$FIXTURE_WORK/plugins/go-workflow/hooks/hooks.json"
 
 set_fixture_version() {
     local version="$1"
@@ -169,6 +198,8 @@ run_codex() {
         HOME="$TEST_HOME" \
         CODEX_HOME="$CODEX_HOME" \
         OPENAI_API_KEY=dummy \
+        CODEX_LIFECYCLE_HOOK_INPUT="${CODEX_LIFECYCLE_HOOK_INPUT:-}" \
+        CODEX_LIFECYCLE_HOOK_OUTPUT="${CODEX_LIFECYCLE_HOOK_OUTPUT:-}" \
         codex "$@"
 }
 
@@ -201,6 +232,11 @@ printf 'first=%s\n' "$FIRST_ROOT" > "$LOG_DIR/roots.log"
 start_session() {
     local label="$1"
     local workspace="$2"
+    local prompt="${3:-Reply with exactly lifecycle-ok and do not use tools.}"
+    local hook_input="${4:-}"
+    local hook_output="${5:-}"
+    CODEX_LIFECYCLE_HOOK_INPUT="$hook_input" \
+    CODEX_LIFECYCLE_HOOK_OUTPUT="$hook_output" \
     run_codex exec \
         --cd "$workspace" \
         --skip-git-repo-check \
@@ -209,7 +245,7 @@ start_session() {
         --json \
         -c 'model_provider="lifecycle"' \
         -c "model_providers.lifecycle={ name = \"Lifecycle\", base_url = \"$RESPONSES_BASE_URL\", env_key = \"OPENAI_API_KEY\", wire_api = \"responses\", supports_websockets = false }" \
-        "Reply with exactly lifecycle-ok and do not use tools." \
+        "$prompt" \
         </dev/null \
         > "$LOG_DIR/$label.stdout" 2> "$LOG_DIR/$label.stderr" &
     SESSION_PID=$!
@@ -244,10 +280,11 @@ assert_session() {
     local label="$1"
     local workspace="$2"
     local version="$3"
+    local expected_reply="${4:-lifecycle-ok}"
     local combined="$LOG_DIR/$label.combined"
     sed -n '1,240p' "$LOG_DIR/$label.stdout" > "$combined"
     sed -n '1,240p' "$LOG_DIR/$label.stderr" >> "$combined"
-    grep -q 'lifecycle-ok' "$combined" || fail "$label session did not complete the minimal turn"
+    grep -Fq "$expected_reply" "$combined" || fail "$label session did not complete the expected turn"
     if grep -Eiq '(SessionStart|Stop) hook \(failed\)|hook exited with code [1-9][0-9]*|hook.*(not found|No such file)|exit(ed)? (with )?(code )?127' "$combined"; then
         fail "$label session reported a hook failure"
     fi
@@ -311,5 +348,50 @@ wait_for_session_request "$SERVER_STATE/2.requested" "$SECOND_SESSION_PID" "post
 : > "$SERVER_STATE/2.release"
 finish_session "$SECOND_SESSION_PID" second
 assert_session second "$SECOND_WORKSPACE" "$SECOND_VERSION"
+
+start_session probe "$THIRD_WORKSPACE" "$PROBE_PROMPT" "$HOOK_INPUT_CAPTURE" "$HOOK_OUTPUT_CAPTURE"
+PROBE_SESSION_PID=$SESSION_PID
+wait_for_session_request "$SERVER_STATE/3.requested" "$PROBE_SESSION_PID" "probe Responses request"
+: > "$SERVER_STATE/3.release"
+wait_for_session_request "$HOOK_INPUT_CAPTURE" "$PROBE_SESSION_PID" "PostToolUse input capture"
+wait_for_session_request "$HOOK_OUTPUT_CAPTURE" "$PROBE_SESSION_PID" "PostToolUse output capture"
+wait_for_session_request "$SERVER_STATE/4.requested" "$PROBE_SESSION_PID" "probe function output request"
+
+jq -e --arg command "$PROBE_COMMAND" '
+    .hook_event_name == "PostToolUse" and
+    .tool_name == "Bash" and
+    (.tool_use_id | type == "string" and length > 0) and
+    .tool_input.command == $command and
+    (.tool_response | type == "string" and contains("lifecycleProbe")) and
+    (has("tool_output") | not)
+' "$HOOK_INPUT_CAPTURE" >/dev/null \
+    || fail "PostToolUse input did not match the Codex hook payload"
+
+jq -e '
+    type == "object" and
+    .decision == "block" and
+    ((.reason // "") | test("[^[:space:]]")) and
+    (.reason | test("compilation"; "i")) and
+    (.reason | contains("probe.go:1:1: undefined: lifecycleProbe")) and
+    (has("retry") | not) and
+    ((keys - ["continue", "decision", "hookSpecificOutput", "reason", "stopReason", "systemMessage"]) | length == 0) and
+    (((.hookSpecificOutput // {}) | keys - ["additionalContext", "hookEventName"]) | length == 0)
+' "$HOOK_OUTPUT_CAPTURE" >/dev/null \
+    || fail "PostToolUse output was not supported Codex blocking JSON"
+
+jq -e '
+    ([.. | objects | select(
+        (.type? == "function_call_output" or .type? == "custom_tool_call_output") and
+        .call_id? == "post-tool-use-probe" and
+        ((.output? // "") | tostring | test("compilation"; "i")) and
+        ((.output? // "") | tostring | contains("probe.go:1:1: undefined: lifecycleProbe"))
+    )] | length == 1) and
+    ([.. | strings] | join("\n") | test("compilation"; "i"))
+' "$SERVER_STATE/4.request.json" >/dev/null \
+    || fail "follow-up request did not contain the tool result and hook steering"
+
+: > "$SERVER_STATE/4.release"
+finish_session "$PROBE_SESSION_PID" probe
+assert_session probe "$THIRD_WORKSPACE" "$SECOND_VERSION" "lifecycle-hook-ok"
 
 printf 'Codex %s plugin lifecycle smoke test passed.\n' "$ACTUAL_CODEX_VERSION"

--- a/scripts/test-codex-plugin-lifecycle.sh
+++ b/scripts/test-codex-plugin-lifecycle.sh
@@ -386,10 +386,12 @@ jq -e '
     ([.. | objects | select(
         (.type? == "function_call_output" or .type? == "custom_tool_call_output") and
         .call_id? == "post-tool-use-probe" and
-        ((.output? // "") | tostring | test("compilation"; "i")) and
         ((.output? // "") | tostring | contains("probe.go:1:1: undefined: lifecycleProbe"))
     )] | length == 1) and
-    ([.. | strings] | join("\n") | test("compilation"; "i"))
+    ([.. | strings] | join("\n") |
+        test("compilation"; "i") and
+        test("status.*unavailable"; "i") and
+        contains("probe.go:1:1: undefined: lifecycleProbe"))
 ' "$SERVER_STATE/4.request.json" >/dev/null \
     || fail "follow-up request did not contain the tool result and hook steering"
 

--- a/scripts/test-codex-plugin-lifecycle.sh
+++ b/scripts/test-codex-plugin-lifecycle.sh
@@ -364,7 +364,7 @@ jq -e --arg command "$PROBE_COMMAND" '
     .tool_name == "Bash" and
     (.tool_use_id | type == "string" and length > 0) and
     .tool_input.command == $command and
-    (.tool_response | type == "string" and contains("lifecycleProbe")) and
+    (.tool_response | type == "string" and contains("lifecycleProbe") and test("exited with code 1"; "i")) and
     (has("tool_output") | not)
 ' "$HOOK_INPUT_CAPTURE" >/dev/null \
     || fail "PostToolUse input did not match the Codex hook payload"

--- a/scripts/test-codex-plugin-lifecycle.sh
+++ b/scripts/test-codex-plugin-lifecycle.sh
@@ -364,22 +364,23 @@ jq -e --arg command "$PROBE_COMMAND" '
     .tool_name == "Bash" and
     (.tool_use_id | type == "string" and length > 0) and
     .tool_input.command == $command and
-    (.tool_response | type == "string" and contains("lifecycleProbe") and test("exited with code 1"; "i")) and
+    (.tool_response | type == "string" and contains("lifecycleProbe")) and
     (has("tool_output") | not)
 ' "$HOOK_INPUT_CAPTURE" >/dev/null \
     || fail "PostToolUse input did not match the Codex hook payload"
 
 jq -e '
     type == "object" and
-    .decision == "block" and
-    ((.reason // "") | test("[^[:space:]]")) and
-    (.reason | test("compilation"; "i")) and
-    (.reason | contains("probe.go:1:1: undefined: lifecycleProbe")) and
+    (has("decision") | not) and
     (has("retry") | not) and
     ((keys - ["continue", "decision", "hookSpecificOutput", "reason", "stopReason", "systemMessage"]) | length == 0) and
-    (((.hookSpecificOutput // {}) | keys - ["additionalContext", "hookEventName"]) | length == 0)
+    (((.hookSpecificOutput // {}) | keys - ["additionalContext", "hookEventName"]) | length == 0) and
+    .hookSpecificOutput.hookEventName == "PostToolUse" and
+    (.hookSpecificOutput.additionalContext | test("compilation"; "i")) and
+    (.hookSpecificOutput.additionalContext | test("status.*unavailable"; "i")) and
+    (.hookSpecificOutput.additionalContext | contains("probe.go:1:1: undefined: lifecycleProbe"))
 ' "$HOOK_OUTPUT_CAPTURE" >/dev/null \
-    || fail "PostToolUse output was not supported Codex blocking JSON"
+    || fail "PostToolUse output was not supported Codex diagnostic context"
 
 jq -e '
     ([.. | objects | select(

--- a/scripts/test-hooks.sh
+++ b/scripts/test-hooks.sh
@@ -93,22 +93,24 @@ fi
 POST_TOOL_USE_ROOT=$(mktemp -d "$HOOK_TMP_BASE/gopher-ai-post-tool-use.XXXXXX")
 POST_TOOL_USE_HOOK="$ROOT_DIR/plugins/go-workflow/hooks/post-tool-use.sh"
 
-printf '%s\n' '{"tool_name":"Bash","tool_response":"main.go:12:3: undefined: missingName"}' \
+printf '%s\n' '{"turn_id":"turn-codex","tool_name":"Bash","tool_response":"main.go:12:3: undefined: missingName"}' \
   > "$POST_TOOL_USE_ROOT/codex-compilation.json"
-printf '%s\n' '{"tool_name":"Bash","tool_response":{"stdout":"","stderr":"dial tcp 192.0.2.1:443: i/o timeout","exit_code":1}}' \
+printf '%s\n' '{"turn_id":"turn-codex","tool_name":"Bash","tool_response":{"stdout":"","stderr":"dial tcp 192.0.2.1:443: i/o timeout","exit_code":1}}' \
   > "$POST_TOOL_USE_ROOT/codex-timeout.json"
-printf '%s\n' '{"tool_name":"Bash","tool_response":{"stdout":"golangci-lint returned an error","exit_code":1}}' \
+printf '%s\n' '{"turn_id":"turn-codex","tool_name":"Bash","tool_response":{"stdout":"golangci-lint returned an error","exit_code":1}}' \
   > "$POST_TOOL_USE_ROOT/codex-lint.json"
-printf '%s\n' '{"tool_name":"Bash","tool_response":"open protected.txt: permission denied"}' \
+printf '%s\n' '{"turn_id":"turn-codex","tool_name":"Bash","tool_response":"open protected.txt: permission denied"}' \
   > "$POST_TOOL_USE_ROOT/codex-permission.json"
-printf '%s\n' '{"tool_name":"Bash","tool_response":{"stdout":"build completed","exit_code":0}}' \
+printf '%s\n' '{"turn_id":"turn-codex","tool_name":"Bash","tool_response":{"stdout":"build completed","exit_code":0}}' \
   > "$POST_TOOL_USE_ROOT/codex-normal.json"
 jq -n --arg output "$(awk 'BEGIN { for (line = 1; line <= 201; line++) print "line " line }')" \
-  '{tool_name: "Bash", tool_response: $output}' \
+  '{turn_id: "turn-codex", tool_name: "Bash", tool_response: $output}' \
   > "$POST_TOOL_USE_ROOT/codex-long-output.json"
-printf '%s\n' '{"tool_name":"Bash","tool_output":{"stdout":"main.go:9:2: undefined: value","stderr":"","exit_code":1}}' \
+printf '%s\n' '{"session_id":"session-claude","tool_name":"Bash","tool_response":{"stdout":"main.go:9:2: undefined: value","stderr":"","exit_code":1}}' \
   > "$POST_TOOL_USE_ROOT/claude-compilation.json"
-printf '%s\n' '{"tool_name":"Bash","tool_output":"API rate limit exceeded"}' \
+printf '%s\n' '{"session_id":"session-claude","tool_name":"Bash","tool_output":{"stdout":"main.go:10:2: undefined: legacyValue","stderr":"","exit_code":1}}' \
+  > "$POST_TOOL_USE_ROOT/claude-legacy-compilation.json"
+printf '%s\n' '{"session_id":"session-claude","tool_name":"Bash","tool_response":"API rate limit exceeded"}' \
   > "$POST_TOOL_USE_ROOT/claude-rate-limit.json"
 printf '%s\n' '{"tool_name":"Bash"}' > "$POST_TOOL_USE_ROOT/missing-output.json"
 printf '%s\n' '{not-json' > "$POST_TOOL_USE_ROOT/malformed.json"
@@ -262,13 +264,26 @@ else
   ERRORS=$((ERRORS + 1))
 fi
 
-echo -n "  Claude PostToolUse reads structured tool_output failures... "
+echo -n "  Claude PostToolUse reads current structured tool_response failures... "
 CLAUDE_COMPILE_OUTPUT=$(run_post_tool_use_fixture \
   "$POST_TOOL_USE_ROOT/claude-compilation.json" \
   "$POST_TOOL_USE_ROOT/claude-compilation.stderr")
 CLAUDE_COMPILE_ERROR=$(< "$POST_TOOL_USE_ROOT/claude-compilation.stderr")
 if [ -z "$CLAUDE_COMPILE_OUTPUT" ] &&
    [[ "$CLAUDE_COMPILE_ERROR" == *"Go compilation error detected"* ]]; then
+  echo "OK"
+else
+  echo "FAIL"
+  ERRORS=$((ERRORS + 1))
+fi
+
+echo -n "  Claude PostToolUse keeps legacy tool_output compatibility... "
+CLAUDE_LEGACY_COMPILE_OUTPUT=$(run_post_tool_use_fixture \
+  "$POST_TOOL_USE_ROOT/claude-legacy-compilation.json" \
+  "$POST_TOOL_USE_ROOT/claude-legacy-compilation.stderr")
+CLAUDE_LEGACY_COMPILE_ERROR=$(< "$POST_TOOL_USE_ROOT/claude-legacy-compilation.stderr")
+if [ -z "$CLAUDE_LEGACY_COMPILE_OUTPUT" ] &&
+   [[ "$CLAUDE_LEGACY_COMPILE_ERROR" == *"Go compilation error detected"* ]]; then
   echo "OK"
 else
   echo "FAIL"

--- a/scripts/test-hooks.sh
+++ b/scripts/test-hooks.sh
@@ -93,13 +93,13 @@ fi
 POST_TOOL_USE_ROOT=$(mktemp -d "$HOOK_TMP_BASE/gopher-ai-post-tool-use.XXXXXX")
 POST_TOOL_USE_HOOK="$ROOT_DIR/plugins/go-workflow/hooks/post-tool-use.sh"
 
-printf '%s\n' '{"turn_id":"turn-codex","tool_name":"Bash","tool_response":"Process exited with code 1\nFinal output:\nmain.go:12:3: undefined: missingName"}' \
+printf '%s\n' '{"turn_id":"turn-codex","tool_name":"Bash","tool_response":"main.go:12:3: undefined: missingName\n"}' \
   > "$POST_TOOL_USE_ROOT/codex-compilation.json"
 printf '%s\n' '{"turn_id":"turn-codex","tool_name":"Bash","tool_response":{"stdout":"","stderr":"dial tcp 192.0.2.1:443: i/o timeout","exit_code":1}}' \
   > "$POST_TOOL_USE_ROOT/codex-timeout.json"
 printf '%s\n' '{"turn_id":"turn-codex","tool_name":"Bash","tool_response":{"stdout":"golangci-lint returned an error","exit_code":1}}' \
   > "$POST_TOOL_USE_ROOT/codex-lint.json"
-printf '%s\n' '{"turn_id":"turn-codex","tool_name":"Bash","tool_response":"Process exited with code 1\nFinal output:\nopen protected.txt: permission denied"}' \
+printf '%s\n' '{"turn_id":"turn-codex","tool_name":"Bash","tool_response":{"stdout":"","stderr":"open protected.txt: permission denied","exit_code":1}}' \
   > "$POST_TOOL_USE_ROOT/codex-permission.json"
 printf '%s\n' '{"turn_id":"turn-codex","tool_name":"Bash","tool_response":{"stdout":"build completed","exit_code":0}}' \
   > "$POST_TOOL_USE_ROOT/codex-normal.json"
@@ -152,15 +152,16 @@ is_supported_codex_post_tool_use_response() {
   ' >/dev/null 2>&1
 }
 
-echo -n "  Codex PostToolUse reads string tool_response compilation failures... "
+echo -n "  Codex PostToolUse preserves status-unknown string diagnostics as context... "
 CODEX_COMPILE_OUTPUT=$(run_post_tool_use_fixture \
   "$POST_TOOL_USE_ROOT/codex-compilation.json" \
   "$POST_TOOL_USE_ROOT/codex-compilation.stderr")
 if printf '%s\n' "$CODEX_COMPILE_OUTPUT" | is_supported_codex_post_tool_use_response &&
    printf '%s\n' "$CODEX_COMPILE_OUTPUT" | jq -e '
-     .decision == "block" and
-     (.reason | test("compilation"; "i")) and
-     (.reason | contains("main.go:12:3: undefined: missingName"))
+     (has("decision") | not) and
+     (.hookSpecificOutput.additionalContext | test("compilation"; "i")) and
+     (.hookSpecificOutput.additionalContext | test("status.*unavailable"; "i")) and
+     (.hookSpecificOutput.additionalContext | contains("main.go:12:3: undefined: missingName"))
    ' >/dev/null 2>&1; then
   echo "OK"
 else

--- a/scripts/test-hooks.sh
+++ b/scripts/test-hooks.sh
@@ -266,8 +266,9 @@ echo -n "  Claude PostToolUse reads structured tool_output failures... "
 CLAUDE_COMPILE_OUTPUT=$(run_post_tool_use_fixture \
   "$POST_TOOL_USE_ROOT/claude-compilation.json" \
   "$POST_TOOL_USE_ROOT/claude-compilation.stderr")
+CLAUDE_COMPILE_ERROR=$(< "$POST_TOOL_USE_ROOT/claude-compilation.stderr")
 if [ -z "$CLAUDE_COMPILE_OUTPUT" ] &&
-   rg -q "Go compilation error detected" "$POST_TOOL_USE_ROOT/claude-compilation.stderr"; then
+   [[ "$CLAUDE_COMPILE_ERROR" == *"Go compilation error detected"* ]]; then
   echo "OK"
 else
   echo "FAIL"

--- a/scripts/test-hooks.sh
+++ b/scripts/test-hooks.sh
@@ -93,16 +93,20 @@ fi
 POST_TOOL_USE_ROOT=$(mktemp -d "$HOOK_TMP_BASE/gopher-ai-post-tool-use.XXXXXX")
 POST_TOOL_USE_HOOK="$ROOT_DIR/plugins/go-workflow/hooks/post-tool-use.sh"
 
-printf '%s\n' '{"turn_id":"turn-codex","tool_name":"Bash","tool_response":"main.go:12:3: undefined: missingName"}' \
+printf '%s\n' '{"turn_id":"turn-codex","tool_name":"Bash","tool_response":"Process exited with code 1\nFinal output:\nmain.go:12:3: undefined: missingName"}' \
   > "$POST_TOOL_USE_ROOT/codex-compilation.json"
 printf '%s\n' '{"turn_id":"turn-codex","tool_name":"Bash","tool_response":{"stdout":"","stderr":"dial tcp 192.0.2.1:443: i/o timeout","exit_code":1}}' \
   > "$POST_TOOL_USE_ROOT/codex-timeout.json"
 printf '%s\n' '{"turn_id":"turn-codex","tool_name":"Bash","tool_response":{"stdout":"golangci-lint returned an error","exit_code":1}}' \
   > "$POST_TOOL_USE_ROOT/codex-lint.json"
-printf '%s\n' '{"turn_id":"turn-codex","tool_name":"Bash","tool_response":"open protected.txt: permission denied"}' \
+printf '%s\n' '{"turn_id":"turn-codex","tool_name":"Bash","tool_response":"Process exited with code 1\nFinal output:\nopen protected.txt: permission denied"}' \
   > "$POST_TOOL_USE_ROOT/codex-permission.json"
 printf '%s\n' '{"turn_id":"turn-codex","tool_name":"Bash","tool_response":{"stdout":"build completed","exit_code":0}}' \
   > "$POST_TOOL_USE_ROOT/codex-normal.json"
+printf '%s\n' '{"turn_id":"turn-codex","tool_name":"Bash","tool_response":{"stdout":"main.go:12:3: undefined: archivedDiagnostic","exit_code":0}}' \
+  > "$POST_TOOL_USE_ROOT/codex-success-diagnostic.json"
+printf '%s\n' '{"turn_id":"turn-codex","tool_name":"Bash","tool_response":"Process exited with code 0\nFinal output:\ncontext deadline exceeded with status 429"}' \
+  > "$POST_TOOL_USE_ROOT/codex-success-transient.json"
 jq -n --arg output "$(awk 'BEGIN { for (line = 1; line <= 201; line++) print "line " line }')" \
   '{turn_id: "turn-codex", tool_name: "Bash", tool_response: $output}' \
   > "$POST_TOOL_USE_ROOT/codex-long-output.json"
@@ -229,6 +233,23 @@ CODEX_NORMAL_OUTPUT=$(run_post_tool_use_fixture \
   "$POST_TOOL_USE_ROOT/codex-normal.stderr")
 if [ -z "$CODEX_NORMAL_OUTPUT" ] &&
    [ ! -s "$POST_TOOL_USE_ROOT/codex-normal.stderr" ]; then
+  echo "OK"
+else
+  echo "FAIL"
+  ERRORS=$((ERRORS + 1))
+fi
+
+echo -n "  Codex PostToolUse ignores failure text from successful commands... "
+CODEX_SUCCESS_DIAGNOSTIC_OUTPUT=$(run_post_tool_use_fixture \
+  "$POST_TOOL_USE_ROOT/codex-success-diagnostic.json" \
+  "$POST_TOOL_USE_ROOT/codex-success-diagnostic.stderr")
+CODEX_SUCCESS_TRANSIENT_OUTPUT=$(run_post_tool_use_fixture \
+  "$POST_TOOL_USE_ROOT/codex-success-transient.json" \
+  "$POST_TOOL_USE_ROOT/codex-success-transient.stderr")
+if [ -z "$CODEX_SUCCESS_DIAGNOSTIC_OUTPUT" ] &&
+   [ -z "$CODEX_SUCCESS_TRANSIENT_OUTPUT" ] &&
+   [ ! -s "$POST_TOOL_USE_ROOT/codex-success-diagnostic.stderr" ] &&
+   [ ! -s "$POST_TOOL_USE_ROOT/codex-success-transient.stderr" ]; then
   echo "OK"
 else
   echo "FAIL"

--- a/scripts/test-hooks.sh
+++ b/scripts/test-hooks.sh
@@ -90,6 +90,207 @@ else
   ERRORS=$((ERRORS + 1))
 fi
 
+POST_TOOL_USE_ROOT=$(mktemp -d "$HOOK_TMP_BASE/gopher-ai-post-tool-use.XXXXXX")
+POST_TOOL_USE_HOOK="$ROOT_DIR/plugins/go-workflow/hooks/post-tool-use.sh"
+
+printf '%s\n' '{"tool_name":"Bash","tool_response":"main.go:12:3: undefined: missingName"}' \
+  > "$POST_TOOL_USE_ROOT/codex-compilation.json"
+printf '%s\n' '{"tool_name":"Bash","tool_response":{"stdout":"","stderr":"dial tcp 192.0.2.1:443: i/o timeout","exit_code":1}}' \
+  > "$POST_TOOL_USE_ROOT/codex-timeout.json"
+printf '%s\n' '{"tool_name":"Bash","tool_response":{"stdout":"golangci-lint returned an error","exit_code":1}}' \
+  > "$POST_TOOL_USE_ROOT/codex-lint.json"
+printf '%s\n' '{"tool_name":"Bash","tool_response":"open protected.txt: permission denied"}' \
+  > "$POST_TOOL_USE_ROOT/codex-permission.json"
+printf '%s\n' '{"tool_name":"Bash","tool_response":{"stdout":"build completed","exit_code":0}}' \
+  > "$POST_TOOL_USE_ROOT/codex-normal.json"
+jq -n --arg output "$(awk 'BEGIN { for (line = 1; line <= 201; line++) print "line " line }')" \
+  '{tool_name: "Bash", tool_response: $output}' \
+  > "$POST_TOOL_USE_ROOT/codex-long-output.json"
+printf '%s\n' '{"tool_name":"Bash","tool_output":{"stdout":"main.go:9:2: undefined: value","stderr":"","exit_code":1}}' \
+  > "$POST_TOOL_USE_ROOT/claude-compilation.json"
+printf '%s\n' '{"tool_name":"Bash","tool_output":"API rate limit exceeded"}' \
+  > "$POST_TOOL_USE_ROOT/claude-rate-limit.json"
+printf '%s\n' '{"tool_name":"Bash"}' > "$POST_TOOL_USE_ROOT/missing-output.json"
+printf '%s\n' '{not-json' > "$POST_TOOL_USE_ROOT/malformed.json"
+mkdir -p "$POST_TOOL_USE_ROOT/bin" "$POST_TOOL_USE_ROOT/claude-retry"
+printf '%s\n' '#!/bin/bash' "printf \"called\\n\" > \"\${POST_TOOL_USE_SLEEP_MARKER:?}\"" \
+  > "$POST_TOOL_USE_ROOT/bin/sleep"
+chmod +x "$POST_TOOL_USE_ROOT/bin/sleep"
+
+run_post_tool_use_fixture() {
+  local fixture="$1"
+  local stderr_file="$2"
+  PATH="$POST_TOOL_USE_ROOT/bin:$PATH" \
+  POST_TOOL_USE_SLEEP_MARKER="$POST_TOOL_USE_ROOT/codex-sleep-called" \
+  TMPDIR="$POST_TOOL_USE_ROOT" \
+  bash "$POST_TOOL_USE_HOOK" \
+    < "$fixture" 2> "$stderr_file"
+}
+
+is_supported_codex_post_tool_use_response() {
+  jq -e '
+    type == "object" and
+    ((keys - ["continue", "decision", "hookSpecificOutput", "reason", "stopReason", "systemMessage"]) | length == 0) and
+    (has("retry") | not) and
+    (if has("decision") then
+      .decision == "block" and ((.reason // "") | test("[^[:space:]]"))
+    else
+      true
+    end) and
+    (if has("hookSpecificOutput") then
+      .hookSpecificOutput.hookEventName == "PostToolUse" and
+      ((.hookSpecificOutput.additionalContext // "") | test("[^[:space:]]"))
+    else
+      true
+    end)
+  ' >/dev/null 2>&1
+}
+
+echo -n "  Codex PostToolUse reads string tool_response compilation failures... "
+CODEX_COMPILE_OUTPUT=$(run_post_tool_use_fixture \
+  "$POST_TOOL_USE_ROOT/codex-compilation.json" \
+  "$POST_TOOL_USE_ROOT/codex-compilation.stderr")
+if printf '%s\n' "$CODEX_COMPILE_OUTPUT" | is_supported_codex_post_tool_use_response &&
+   printf '%s\n' "$CODEX_COMPILE_OUTPUT" | jq -e '
+     .decision == "block" and
+     (.reason | test("compilation"; "i")) and
+     (.reason | contains("main.go:12:3: undefined: missingName"))
+   ' >/dev/null 2>&1; then
+  echo "OK"
+else
+  echo "FAIL (output: ${CODEX_COMPILE_OUTPUT:-<empty>})"
+  ERRORS=$((ERRORS + 1))
+fi
+
+echo -n "  Codex PostToolUse emits supported safe retry guidance for structured transient failures... "
+CODEX_TIMEOUT_OUTPUT=$(run_post_tool_use_fixture \
+  "$POST_TOOL_USE_ROOT/codex-timeout.json" \
+  "$POST_TOOL_USE_ROOT/codex-timeout.stderr")
+if printf '%s\n' "$CODEX_TIMEOUT_OUTPUT" | is_supported_codex_post_tool_use_response &&
+   printf '%s\n' "$CODEX_TIMEOUT_OUTPUT" | jq -e '
+     .decision == "block" and
+     (has("retry") | not) and
+     (.reason | test("idempoten|safe"; "i")) and
+     (.reason | contains("dial tcp 192.0.2.1:443: i/o timeout"))
+   ' >/dev/null 2>&1 &&
+   [ ! -e "$POST_TOOL_USE_ROOT/codex-sleep-called" ] &&
+   ! compgen -G "$POST_TOOL_USE_ROOT/gopher-ai-retry-*" >/dev/null; then
+  echo "OK"
+else
+  echo "FAIL (output: ${CODEX_TIMEOUT_OUTPUT:-<empty>})"
+  ERRORS=$((ERRORS + 1))
+fi
+
+echo -n "  Codex PostToolUse makes lint and permission failures model-visible... "
+CODEX_LINT_OUTPUT=$(run_post_tool_use_fixture \
+  "$POST_TOOL_USE_ROOT/codex-lint.json" \
+  "$POST_TOOL_USE_ROOT/codex-lint.stderr")
+CODEX_PERMISSION_OUTPUT=$(run_post_tool_use_fixture \
+  "$POST_TOOL_USE_ROOT/codex-permission.json" \
+  "$POST_TOOL_USE_ROOT/codex-permission.stderr")
+if printf '%s\n' "$CODEX_LINT_OUTPUT" | is_supported_codex_post_tool_use_response &&
+   printf '%s\n' "$CODEX_LINT_OUTPUT" | jq -e '
+     .decision == "block" and
+     (.reason | test("lint"; "i")) and
+     (.reason | contains("golangci-lint returned an error"))
+   ' >/dev/null 2>&1 &&
+   printf '%s\n' "$CODEX_PERMISSION_OUTPUT" | is_supported_codex_post_tool_use_response &&
+   printf '%s\n' "$CODEX_PERMISSION_OUTPUT" | jq -e '
+     .decision == "block" and
+     (.reason | test("permission|access"; "i")) and
+     (.reason | contains("open protected.txt: permission denied"))
+   ' >/dev/null 2>&1; then
+  echo "OK"
+else
+  echo "FAIL"
+  ERRORS=$((ERRORS + 1))
+fi
+
+echo -n "  Codex PostToolUse reports long output as non-blocking context... "
+CODEX_LONG_OUTPUT=$(run_post_tool_use_fixture \
+  "$POST_TOOL_USE_ROOT/codex-long-output.json" \
+  "$POST_TOOL_USE_ROOT/codex-long-output.stderr")
+if printf '%s\n' "$CODEX_LONG_OUTPUT" | is_supported_codex_post_tool_use_response &&
+   printf '%s\n' "$CODEX_LONG_OUTPUT" | jq -e '
+     (has("decision") | not) and
+     (.hookSpecificOutput.additionalContext | test("201 lines"))
+   ' >/dev/null 2>&1; then
+  echo "OK"
+else
+  echo "FAIL"
+  ERRORS=$((ERRORS + 1))
+fi
+
+echo -n "  Codex PostToolUse keeps successful ordinary output silent... "
+CODEX_NORMAL_OUTPUT=$(run_post_tool_use_fixture \
+  "$POST_TOOL_USE_ROOT/codex-normal.json" \
+  "$POST_TOOL_USE_ROOT/codex-normal.stderr")
+if [ -z "$CODEX_NORMAL_OUTPUT" ] &&
+   [ ! -s "$POST_TOOL_USE_ROOT/codex-normal.stderr" ]; then
+  echo "OK"
+else
+  echo "FAIL"
+  ERRORS=$((ERRORS + 1))
+fi
+
+echo -n "  Codex PostToolUse schema rejects the legacy retry response... "
+if ! printf '%s\n' '{"retry":true,"reason":"Network timeout"}' |
+  is_supported_codex_post_tool_use_response; then
+  echo "OK"
+else
+  echo "FAIL"
+  ERRORS=$((ERRORS + 1))
+fi
+
+echo -n "  Claude PostToolUse keeps transient retry output platform-specific... "
+CLAUDE_RETRY_OUTPUT=$(
+  PATH="$POST_TOOL_USE_ROOT/bin:$PATH" \
+  POST_TOOL_USE_SLEEP_MARKER="$POST_TOOL_USE_ROOT/claude-sleep-called" \
+  TMPDIR="$POST_TOOL_USE_ROOT/claude-retry" \
+  bash "$POST_TOOL_USE_HOOK" \
+    < "$POST_TOOL_USE_ROOT/claude-rate-limit.json" \
+    2> "$POST_TOOL_USE_ROOT/claude-rate-limit.stderr"
+)
+if printf '%s\n' "$CLAUDE_RETRY_OUTPUT" | jq -e '
+     .retry == true and ((.reason // "") | test("rate limit"; "i"))
+   ' >/dev/null 2>&1 &&
+   [ -e "$POST_TOOL_USE_ROOT/claude-sleep-called" ] &&
+   compgen -G "$POST_TOOL_USE_ROOT/claude-retry/gopher-ai-retry-*" >/dev/null; then
+  echo "OK"
+else
+  echo "FAIL"
+  ERRORS=$((ERRORS + 1))
+fi
+
+echo -n "  Claude PostToolUse reads structured tool_output failures... "
+CLAUDE_COMPILE_OUTPUT=$(run_post_tool_use_fixture \
+  "$POST_TOOL_USE_ROOT/claude-compilation.json" \
+  "$POST_TOOL_USE_ROOT/claude-compilation.stderr")
+if [ -z "$CLAUDE_COMPILE_OUTPUT" ] &&
+   rg -q "Go compilation error detected" "$POST_TOOL_USE_ROOT/claude-compilation.stderr"; then
+  echo "OK"
+else
+  echo "FAIL"
+  ERRORS=$((ERRORS + 1))
+fi
+
+echo -n "  PostToolUse fails open for missing and malformed output... "
+MISSING_OUTPUT=$(run_post_tool_use_fixture \
+  "$POST_TOOL_USE_ROOT/missing-output.json" \
+  "$POST_TOOL_USE_ROOT/missing-output.stderr")
+MALFORMED_OUTPUT=$(run_post_tool_use_fixture \
+  "$POST_TOOL_USE_ROOT/malformed.json" \
+  "$POST_TOOL_USE_ROOT/malformed.stderr")
+if [ -z "$MISSING_OUTPUT" ] &&
+   [ -z "$MALFORMED_OUTPUT" ] &&
+   [ ! -s "$POST_TOOL_USE_ROOT/missing-output.stderr" ] &&
+   [ ! -s "$POST_TOOL_USE_ROOT/malformed.stderr" ]; then
+  echo "OK"
+else
+  echo "FAIL"
+  ERRORS=$((ERRORS + 1))
+fi
+
 echo -n "  Stop hook honors durable driver-input pauses... "
 STOP_HOOK_ROOT=$(mktemp -d "$HOOK_TMP_BASE/gopher-ai-stop-hook.XXXXXX")
 STOP_HOOK_STATE="$STOP_HOOK_ROOT/.local/state/ship.loop.local.json"


### PR DESCRIPTION
## Summary

- Normalize PostToolUse payloads for Claude and Codex while returning schema-valid Codex feedback that preserves actionable command diagnostics.
- Preserve Claude retry behavior while replacing unsupported Codex auto-retry output with side-effect-aware guidance and documenting hosted-tool limitations.
- Extend fixture and real Codex lifecycle coverage across legacy function tools and newer custom shell execution.

## Test Plan

- Hook regression suite, shell/Python syntax checks, targeted shell analysis, and shared-runtime synchronization.
- Real installed-plugin Codex 0.151 failed-Bash lifecycle probe.
- Authoritative repository validation gate.

Fixes #326
