### PR TITLE
test(codex): add current compatibility lane

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -8,8 +8,19 @@ on:
 
 jobs:
   test-codex-plugin-lifecycle:
+    name: 'Codex compatibility (${{ matrix.lane }}: ${{ matrix.codex-version }})'
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - lane: minimum
+            codex-version: '0.146.0'
+            expected-version: '0.146.0'
+          - lane: current
+            codex-version: latest
+            expected-version: ''
     steps:
       - uses: actions/checkout@v4
 
@@ -17,12 +28,12 @@ jobs:
         with:
           node-version: '22'
 
-      - name: Install supported Codex CLI
-        run: npm install --global @openai/codex@0.146.0
+      - name: Install Codex CLI
+        run: npm install --global "@openai/codex@${{ matrix.codex-version }}"
 
       - name: Test real Codex plugin lifecycle
         env:
-          CODEX_LIFECYCLE_EXPECTED_VERSION: 0.146.0
+          CODEX_LIFECYCLE_EXPECTED_VERSION: ${{ matrix.expected-version }}
         run: ./scripts/test-codex-plugin-lifecycle.sh
 
       - name: Probe Default-mode shared-skill input behavior

--- a/scripts/test-codex-compatibility-lanes.sh
+++ b/scripts/test-codex-compatibility-lanes.sh
@@ -60,7 +60,9 @@ expected_source = [
   'printf \'Codex CLI version: %s\\n\' "$ACTUAL_CODEX_VERSION"',
 ]
 missing_source = expected_source.reject { |line| lifecycle_source.lines(chomp: true).include?(line) }
-abort "Codex lifecycle version contract is incomplete" unless missing_source.empty?
+unless missing_source.empty?
+  abort "Codex lifecycle version contract is incomplete: #{missing_source.join(', ')}"
+end
 RUBY
 
 printf 'Codex compatibility lane tests passed.\n'

--- a/scripts/test-codex-compatibility-lanes.sh
+++ b/scripts/test-codex-compatibility-lanes.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+WORKFLOW="$ROOT_DIR/.github/workflows/integration-tests.yml"
+LIFECYCLE_TEST="$ROOT_DIR/scripts/test-codex-plugin-lifecycle.sh"
+
+ruby -ryaml - "$WORKFLOW" <<'RUBY'
+workflow = YAML.safe_load(File.read(ARGV.fetch(0)), aliases: true)
+job = workflow.dig("jobs", "test-codex-plugin-lifecycle")
+abort "missing Codex lifecycle job" unless job
+
+abort "Codex compatibility matrix must disable fail-fast" unless job.dig("strategy", "fail-fast") == false
+
+expected_lanes = [
+  {
+    "lane" => "minimum",
+    "codex-version" => "0.146.0",
+    "expected-version" => "0.146.0",
+  },
+  {
+    "lane" => "current",
+    "codex-version" => "latest",
+    "expected-version" => "",
+  },
+]
+actual_lanes = job.dig("strategy", "matrix", "include")
+abort "Codex compatibility matrix does not define minimum and current lanes" unless actual_lanes == expected_lanes
+
+name = job.fetch("name", "")
+abort "Codex compatibility job name does not identify its lane" unless name.include?("${{ matrix.lane }}")
+
+steps = job.fetch("steps", [])
+install = steps.find { |step| step["name"] == "Install Codex CLI" }
+expected_install = 'npm install --global "@openai/codex@${{ matrix.codex-version }}"'
+abort "Codex install does not use the matrix version" unless install&.fetch("run", "") == expected_install
+
+lifecycle = steps.find { |step| step["name"] == "Test real Codex plugin lifecycle" }
+expected_version = "${{ matrix.expected-version }}"
+unless lifecycle&.dig("env", "CODEX_LIFECYCLE_EXPECTED_VERSION") == expected_version
+  abort "Codex lifecycle expectation does not use the matrix value"
+end
+
+expected_probes = [
+  "./scripts/test-codex-plugin-lifecycle.sh",
+  "python3 ./scripts/test-codex-default-mode-input.py",
+  "python3 ./scripts/test-codex-skill-names.py",
+  "python3 ./scripts/test-codex-skill-arguments.py",
+]
+runs = steps.map { |step| step["run"] }.compact
+missing_probes = expected_probes - runs
+abort "Codex matrix job omits probes: #{missing_probes.join(', ')}" unless missing_probes.empty?
+RUBY
+
+rg -q '^EXPECTED_CODEX_VERSION="\$\{CODEX_LIFECYCLE_EXPECTED_VERSION:-\}"$' "$LIFECYCLE_TEST" \
+    || { printf 'lifecycle test still defaults to a hard-coded Codex version\n' >&2; exit 1; }
+rg -Fq "ACTUAL_CODEX_VERSION=\"\$(awk '\$1 == \"codex-cli\" { print \$2; exit }' <<< \"\$CODEX_VERSION_OUTPUT\")\"" "$LIFECYCLE_TEST" \
+    || { printf 'lifecycle test does not tolerate warnings before the Codex version\n' >&2; exit 1; }
+rg -q "^printf 'Codex CLI version: %s\\\\n' \"\\\$ACTUAL_CODEX_VERSION\"$" "$LIFECYCLE_TEST" \
+    || { printf 'lifecycle test does not print the resolved Codex version\n' >&2; exit 1; }
+
+printf 'Codex compatibility lane tests passed.\n'

--- a/scripts/test-codex-compatibility-lanes.sh
+++ b/scripts/test-codex-compatibility-lanes.sh
@@ -7,8 +7,9 @@ ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
 WORKFLOW="$ROOT_DIR/.github/workflows/integration-tests.yml"
 LIFECYCLE_TEST="$ROOT_DIR/scripts/test-codex-plugin-lifecycle.sh"
 
-ruby -ryaml - "$WORKFLOW" <<'RUBY'
+ruby -ryaml - "$WORKFLOW" "$LIFECYCLE_TEST" <<'RUBY'
 workflow = YAML.safe_load(File.read(ARGV.fetch(0)), aliases: true)
+lifecycle_source = File.read(ARGV.fetch(1))
 job = workflow.dig("jobs", "test-codex-plugin-lifecycle")
 abort "missing Codex lifecycle job" unless job
 
@@ -52,13 +53,14 @@ expected_probes = [
 runs = steps.map { |step| step["run"] }.compact
 missing_probes = expected_probes - runs
 abort "Codex matrix job omits probes: #{missing_probes.join(', ')}" unless missing_probes.empty?
-RUBY
 
-rg -q '^EXPECTED_CODEX_VERSION="\$\{CODEX_LIFECYCLE_EXPECTED_VERSION:-\}"$' "$LIFECYCLE_TEST" \
-    || { printf 'lifecycle test still defaults to a hard-coded Codex version\n' >&2; exit 1; }
-rg -Fq "ACTUAL_CODEX_VERSION=\"\$(awk '\$1 == \"codex-cli\" { print \$2; exit }' <<< \"\$CODEX_VERSION_OUTPUT\")\"" "$LIFECYCLE_TEST" \
-    || { printf 'lifecycle test does not tolerate warnings before the Codex version\n' >&2; exit 1; }
-rg -q "^printf 'Codex CLI version: %s\\\\n' \"\\\$ACTUAL_CODEX_VERSION\"$" "$LIFECYCLE_TEST" \
-    || { printf 'lifecycle test does not print the resolved Codex version\n' >&2; exit 1; }
+expected_source = [
+  'EXPECTED_CODEX_VERSION="${CODEX_LIFECYCLE_EXPECTED_VERSION:-}"',
+  'ACTUAL_CODEX_VERSION="$(awk \'$1 == "codex-cli" { print $2; exit }\' <<< "$CODEX_VERSION_OUTPUT")"',
+  'printf \'Codex CLI version: %s\\n\' "$ACTUAL_CODEX_VERSION"',
+]
+missing_source = expected_source.reject { |line| lifecycle_source.lines(chomp: true).include?(line) }
+abort "Codex lifecycle version contract is incomplete" unless missing_source.empty?
+RUBY
 
 printf 'Codex compatibility lane tests passed.\n'

--- a/scripts/test-codex-plugin-lifecycle.sh
+++ b/scripts/test-codex-plugin-lifecycle.sh
@@ -4,7 +4,7 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
-EXPECTED_CODEX_VERSION="${CODEX_LIFECYCLE_EXPECTED_VERSION:-0.146.0}"
+EXPECTED_CODEX_VERSION="${CODEX_LIFECYCLE_EXPECTED_VERSION:-}"
 TMP_BASE="${TMPDIR:-${TMP:-${TEMP:-/tmp}}}"
 TEST_ROOT="$(mktemp -d "$TMP_BASE/gopher-ai-codex-lifecycle.XXXXXX")"
 FIXTURE_WORK="$TEST_ROOT/fixture-work"
@@ -75,9 +75,16 @@ for command_name in codex curl git jq python3; do
     command -v "$command_name" >/dev/null 2>&1 || fail "missing required command: $command_name"
 done
 
-ACTUAL_CODEX_VERSION="$(codex --version 2>/dev/null | awk '{print $2}')"
-[[ "$ACTUAL_CODEX_VERSION" == "$EXPECTED_CODEX_VERSION" ]] \
-    || fail "expected codex-cli $EXPECTED_CODEX_VERSION, got ${ACTUAL_CODEX_VERSION:-unknown}"
+CODEX_VERSION_OUTPUT="$(codex --version 2>&1)" \
+    || fail "codex --version failed: ${CODEX_VERSION_OUTPUT:-no output}"
+ACTUAL_CODEX_VERSION="$(awk '$1 == "codex-cli" { print $2; exit }' <<< "$CODEX_VERSION_OUTPUT")"
+[[ -n "$ACTUAL_CODEX_VERSION" ]] \
+    || fail "could not parse Codex CLI version from: $CODEX_VERSION_OUTPUT"
+printf 'Codex CLI version: %s\n' "$ACTUAL_CODEX_VERSION"
+if [[ -n "$EXPECTED_CODEX_VERSION" ]]; then
+    [[ "$ACTUAL_CODEX_VERSION" == "$EXPECTED_CODEX_VERSION" ]] \
+        || fail "expected codex-cli $EXPECTED_CODEX_VERSION, got $ACTUAL_CODEX_VERSION"
+fi
 
 mkdir -p \
     "$FIXTURE_WORK/.agents/plugins" \

--- a/scripts/test-codex-skill-arguments.py
+++ b/scripts/test-codex-skill-arguments.py
@@ -3,9 +3,11 @@
 import argparse
 import json
 import os
+import shutil
 import subprocess
 import tempfile
 import threading
+import time
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from pathlib import Path
 
@@ -101,6 +103,27 @@ def run_codex(env, cwd, *args):
     )
 
 
+def cleanup_temp_tree(
+    path,
+    *,
+    attempts=20,
+    delay=0.1,
+    remove=shutil.rmtree,
+    pause=time.sleep,
+    path_exists=lambda candidate: candidate.exists(),
+):
+    for attempt in range(attempts):
+        try:
+            remove(path)
+            return
+        except OSError as error:
+            if isinstance(error, FileNotFoundError) and not path_exists(path):
+                return
+            if attempt == attempts - 1:
+                raise
+            pause(delay)
+
+
 def assert_static_contract():
     argument_contract = " ".join(
         (WORKFLOW_ROOT / "lib/skill-arguments.md")
@@ -163,6 +186,62 @@ def assert_static_contract():
             )
 
 
+def assert_cleanup_retry_contract():
+    path = Path("fixture")
+    attempts = []
+    pauses = []
+
+    def transient_remove(candidate):
+        attempts.append(candidate)
+        if len(attempts) < 3:
+            raise OSError("directory not empty")
+
+    cleanup_temp_tree(
+        path,
+        attempts=3,
+        delay=0.25,
+        remove=transient_remove,
+        pause=pauses.append,
+    )
+    if attempts != [path, path, path] or pauses != [0.25, 0.25]:
+        raise AssertionError("temporary tree cleanup did not retry bounded failures")
+
+    descendant_attempts = []
+    descendant_pauses = []
+
+    def descendant_disappears(candidate):
+        descendant_attempts.append(candidate)
+        if len(descendant_attempts) == 1:
+            raise FileNotFoundError("descendant disappeared")
+
+    cleanup_temp_tree(
+        path,
+        attempts=2,
+        delay=0.25,
+        remove=descendant_disappears,
+        pause=descendant_pauses.append,
+        path_exists=lambda _: True,
+    )
+    if descendant_attempts != [path, path] or descendant_pauses != [0.25]:
+        raise AssertionError("temporary tree cleanup accepted a missing descendant")
+
+    def persistent_remove(candidate):
+        raise OSError(f"cannot remove {candidate}")
+
+    try:
+        cleanup_temp_tree(
+            path,
+            attempts=2,
+            delay=0,
+            remove=persistent_remove,
+            pause=lambda _: None,
+        )
+    except OSError:
+        pass
+    else:
+        raise AssertionError("temporary tree cleanup suppressed a persistent failure")
+
+
 def run_live_probe(env, workspace, provider, skill_name, invocation):
     request_offset = len(ProbeResponsesHandler.request_bodies)
     run_codex(
@@ -210,6 +289,7 @@ def main():
     args = parser.parse_args()
 
     assert_static_contract()
+    assert_cleanup_retry_contract()
     if args.static_only:
         print("Workflow skill argument contract checks passed.")
         return
@@ -220,8 +300,11 @@ def main():
     server_thread.start()
 
     temp_base = os.environ.get("TMPDIR") or os.environ.get("TMP") or os.environ.get("TEMP")
-    with tempfile.TemporaryDirectory(prefix="gopher-ai-skill-arguments-", dir=temp_base) as root:
-        test_root = Path(root)
+    test_root = None
+    try:
+        test_root = Path(
+            tempfile.mkdtemp(prefix="gopher-ai-skill-arguments-", dir=temp_base)
+        )
         codex_home = test_root / ".codex"
         workspace = test_root / "workspace"
         codex_home.mkdir()
@@ -244,12 +327,14 @@ def main():
 
         run_codex(env, test_root, "plugin", "marketplace", "add", str(ROOT_DIR), "--json")
         run_codex(env, test_root, "plugin", "add", "go-workflow@gopher-ai", "--json")
-        try:
-            for skill_name, invocation in PROBES:
-                run_live_probe(env, workspace, provider, skill_name, invocation)
-        finally:
-            server.shutdown()
-            server.server_close()
+        for skill_name, invocation in PROBES:
+            run_live_probe(env, workspace, provider, skill_name, invocation)
+    finally:
+        server.shutdown()
+        server.server_close()
+        server_thread.join(timeout=5)
+        if test_root is not None:
+            cleanup_temp_tree(test_root)
 
     print("Codex skill argument probes passed: positional argument and flag.")
 

--- a/scripts/test-commands.sh
+++ b/scripts/test-commands.sh
@@ -10,6 +10,7 @@ ERRORS=0
 echo "=== Command File Tests ==="
 
 bash "$ROOT_DIR/scripts/test-review-plan.sh"
+bash "$ROOT_DIR/scripts/test-codex-compatibility-lanes.sh"
 bash "$ROOT_DIR/scripts/test-codex-review-model.sh"
 bash "$ROOT_DIR/scripts/test-ship-ollama-model.sh"
 bash "$ROOT_DIR/scripts/test-review-deep-actions.sh"


### PR DESCRIPTION
## Summary

- run Codex plugin lifecycle and app-server probes in explicit minimum and current compatibility lanes
- install `@openai/codex@latest` for the current lane while retaining `0.146.0` as the exact minimum
- report the resolved CLI version and guard the matrix contract in the standard command test gate

Fixes #330

## Test Plan

- `./scripts/test-codex-compatibility-lanes.sh`
- `./scripts/test-commands.sh`
- authoritative `detent.yaml` validation gate
- independent spec-compliance and quality reviews

## Review Notes

- current Codex `0.152.0` exposed asynchronous plugin Git cleanup after the probe returned; teardown now retries transient removal failures within a bounded window and still propagates persistent failures
- the legacy-hash blocker in #347 is resolved; this head is rebased onto current `main` and the full installation lane passes
