### PR TITLE
fix(codex): correct repo install guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -61,17 +61,30 @@ Codex does not resolve a bare `convert-to-go-project` skill name as an alias.
 
 ## Installation
 
-### Repo-Local (Recommended)
+### Repository-Backed
 
-This repo includes `.agents/plugins/marketplace.json` which Codex reads on startup. When you clone this repo and run Codex inside it, all plugins are discovered automatically — no manual installation needed.
-
-Browse available plugins with the `/plugins` command in Codex CLI.
-
-To add these plugins to **your own repo**:
+This repo includes `.agents/plugins/marketplace.json` as a plugin catalog. The
+catalog does not enable plugins based on the working directory. To stage the
+plugins in your own repo and activate all six from that source. For a new
+target catalog named `gopher-ai`:
 
 ```bash
 ./scripts/install-codex.sh --repo /path/to/your-repo
+codex plugin marketplace add /path/to/your-repo
+codex plugin add go-dev@gopher-ai
+codex plugin add go-web@gopher-ai
+codex plugin add go-workflow@gopher-ai
+codex plugin add gopher-guides@gopher-ai
+codex plugin add llm-tools@gopher-ai
+codex plugin add tailwind@gopher-ai
 ```
+
+The activation commands enable plugins throughout the active `CODEX_HOME`.
+If the target already has a named catalog, use the commands printed by the
+installer; they preserve and use that catalog name instead of `gopher-ai`.
+Do not combine this repository-backed source with `--user` in the same home;
+use a dedicated `CODEX_HOME` when repository isolation is required. Use
+`/plugins` to browse the activated plugins.
 
 ### Global (Personal) Use
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Gopher AI provides skills and commands for the three major AI coding assistants:
 | Platform | Status | Install Method |
 |----------|--------|----------------|
 | **Claude Code** | Full support | Plugin marketplace |
-| **OpenAI Codex CLI** | 6 plugins; capabilities vary | Repo-local, installer script, or manual |
+| **OpenAI Codex CLI** | 6 plugins; capabilities vary | Repository-backed, user-wide, or manual |
 | **Google Gemini CLI** | Extensions | Manual install |
 
 Shipped surface: 36 Claude Code commands across 7 plugins; 20 Codex skills across 6 plugins; 8 optional Codex MCP tools.
@@ -71,15 +71,24 @@ git clone https://github.com/gopherguides/gopher-ai
 cd gopher-ai
 ./scripts/install-codex.sh --user
 
-# Repo-local install — plugins available only when running Codex inside this repo:
-codex   # Plugins load automatically from .agents/plugins/marketplace.json
-
-# Add the marketplace to another repo (project-scoped, like the gopher-ai repo itself):
+# Repository-backed staging and activation for a new gopher-ai catalog:
 ./scripts/install-codex.sh --repo /path/to/your-repo
+codex plugin marketplace add /path/to/your-repo
+codex plugin add go-dev@gopher-ai
+codex plugin add go-web@gopher-ai
+codex plugin add go-workflow@gopher-ai
+codex plugin add gopher-guides@gopher-ai
+codex plugin add llm-tools@gopher-ai
+codex plugin add tailwind@gopher-ai
 ```
 
-**Pick one mode.** `--user` and `--repo`-when-cwd'd-into-our-repo will both load the
-plugins, so having both active doubles the skill metadata Codex loads. The
+`--repo` copies the plugins and writes a marketplace catalog; the catalog alone
+does not enable anything. The follow-up commands enable the plugins throughout
+the active `CODEX_HOME`, not only while Codex runs in that repository. Do not
+combine repository-backed activation and `--user` in the same `CODEX_HOME`.
+If the target already has a named marketplace catalog, run the commands printed
+by the installer; they use the preserved catalog name instead of `gopher-ai`.
+Use a dedicated `CODEX_HOME` for an isolated repository-backed setup. The
 SessionStart hook on the Claude Code side auto-removes stale unmarked installs
 from earlier README versions and clears any stale gopher-ai marketplace cache
 when a marked global install is present.
@@ -307,11 +316,11 @@ SHELL=/bin/bash claude
 
 Plugins are distributed via the [Codex plugin system](https://developers.openai.com/codex/plugins). Each plugin contains skills that activate automatically or can be invoked explicitly.
 
-**Repo-local discovery:** Codex reads `.agents/plugins/marketplace.json` on startup and syncs plugins automatically. Use `/plugins` to browse and manage installed plugins. Plugins with `.codex-plugin/plugin.json` are packaged for Codex. Today that set is `go-workflow`, `go-dev`, `gopher-guides`, `llm-tools`, `go-web`, and `tailwind`. The repo's `productivity` module remains Claude-only.
+**Repository-backed catalog:** `.agents/plugins/marketplace.json` describes the available plugins but does not enable them by cwd. Use `/plugins` to browse and manage plugins after registering the marketplace and activating them in the current `CODEX_HOME`. Plugins with `.codex-plugin/plugin.json` are packaged for Codex. Today that set is `go-workflow`, `go-dev`, `gopher-guides`, `llm-tools`, `go-web`, and `tailwind`. The repo's `productivity` module remains Claude-only.
 
 **Codex model defaults:** The `llm-tools` Codex commands omit `-m` by default so Codex CLI chooses its provider default. If `~/.codex/config.toml` contains a `model = "..."` line, that local pin overrides the provider default for every llm-tools Codex call that omits `-m`; leave it unset to keep using the latest recommended Codex model.
 
-**Install into another repo:** `./scripts/install-codex.sh --repo /path/to/your-repo` copies the current plugin set and merges entries into that repo's `.agents/plugins/marketplace.json` without removing unrelated plugin entries.
+**Stage in another repo:** `./scripts/install-codex.sh --repo /path/to/your-repo` copies the current plugin set and merges entries into that repo's `.agents/plugins/marketplace.json` without removing unrelated plugin entries. It then prints the marketplace registration command and all six `codex plugin add` commands required to activate the staged plugins, using the merged catalog's actual name in each selector. Those commands modify the active `CODEX_HOME`, so use either this repository-backed source or `--user` in a given home, never both. Set a dedicated `CODEX_HOME` when the activation must be isolated from your normal Codex setup.
 
 **GitHub one-liner:** `bash -c "$(curl -fsSL https://raw.githubusercontent.com/gopherguides/gopher-ai/main/scripts/install-all.sh)"` auto-detects all platforms — installs Claude Code and Gemini, and installs Codex plugins globally so skills load in every Codex session. The Codex install registers or upgrades the gopher-ai marketplace, then runs `codex plugin add <plugin>@gopher-ai` for all six Codex-capable plugins. Codex owns the cache publication and plugin enablement; the installer does not write private cache roots or `config.toml` plugin entries.
 

--- a/scripts/build-universal.sh
+++ b/scripts/build-universal.sh
@@ -128,17 +128,30 @@ $prune-worktree
 
 ## Installation
 
-### Repo-Local (Recommended)
+### Repository-Backed
 
-This repo includes `.agents/plugins/marketplace.json` which Codex reads on startup. When you clone this repo and run Codex inside it, all plugins are discovered automatically.
-
-Use `/plugins` to browse available plugins.
-
-To add these plugins to another repo:
+This repo includes `.agents/plugins/marketplace.json` as a plugin catalog. The
+catalog does not enable plugins based on the working directory. To stage the
+plugins in another repo and activate all six from that source. For a new
+target catalog named `gopher-ai`:
 
 ```bash
 ./scripts/install-codex.sh --repo /path/to/your-repo
+codex plugin marketplace add /path/to/your-repo
+codex plugin add go-dev@gopher-ai
+codex plugin add go-web@gopher-ai
+codex plugin add go-workflow@gopher-ai
+codex plugin add gopher-guides@gopher-ai
+codex plugin add llm-tools@gopher-ai
+codex plugin add tailwind@gopher-ai
 ```
+
+The activation commands enable plugins throughout the active `CODEX_HOME`.
+If the target already has a named catalog, use the commands printed by the
+installer; they preserve and use that catalog name instead of `gopher-ai`.
+Do not combine this repository-backed source with `--user` in the same home;
+use a dedicated `CODEX_HOME` when repository isolation is required. Use
+`/plugins` to browse the activated plugins.
 
 ### Global (Personal) Use
 
@@ -575,8 +588,9 @@ print_summary() {
     echo ""
     echo "Installation instructions:"
     echo ""
-    echo "  Codex CLI (repo-level plugins):"
+    echo "  Codex CLI (repository-backed marketplace staging):"
     echo "    ./scripts/install-codex.sh --repo /path/to/your-repo"
+    echo "    Then run the marketplace and plugin activation commands printed by the installer."
     echo ""
     echo "  Codex CLI (clean up legacy ~/.codex/skills/ entries):"
     echo "    ./scripts/install-codex.sh --cleanup"

--- a/scripts/install-codex.sh
+++ b/scripts/install-codex.sh
@@ -31,11 +31,28 @@ gopher-ai for Codex can be installed in two ways:
                 older installs (with --yes semantics — assumes the user wants
                 the migration).
 
-  --repo PATH   Install plugins into PATH/plugins and merge entries into
-                PATH/.agents/plugins/marketplace.json. Use this for project-
-                scoped installs where you want the plugins to load only when
-                running Codex inside that repo. Also runs the legacy
-                ~/.codex/skills/ cleanup.
+  --repo PATH   Stage plugins in PATH/plugins and merge entries into
+                PATH/.agents/plugins/marketplace.json. This marketplace file
+                is a catalog only; it does not enable plugins by working
+                directory. Also runs the legacy ~/.codex/skills/ cleanup.
+
+                After staging, the installer prints the exact activation
+                commands. For a new catalog named gopher-ai, they are:
+                  codex plugin marketplace add /path/to/repo
+                  codex plugin add go-dev@gopher-ai
+                  codex plugin add go-web@gopher-ai
+                  codex plugin add go-workflow@gopher-ai
+                  codex plugin add gopher-guides@gopher-ai
+                  codex plugin add llm-tools@gopher-ai
+                  codex plugin add tailwind@gopher-ai
+
+                If PATH already has a named marketplace catalog, its name is
+                preserved and used in the printed plugin selectors.
+
+                These commands enable plugins in the active CODEX_HOME, not
+                only in PATH. Do not combine this repository-backed source
+                with --user in the same CODEX_HOME. Set a dedicated CODEX_HOME
+                when repository isolation is required.
 
   --cleanup     Remove legacy gopher-ai skills from ~/.codex/skills/ left over
                 from the old `--user` mode (which copied skills there). Two
@@ -813,6 +830,29 @@ write_repo_marketplace() {
     echo "updated marketplace: $marketplace_file"
 }
 
+print_repo_activation_instructions() {
+    local target_repo="$1"
+    local marketplace_name
+
+    marketplace_name="$(jq -er '.name' "$target_repo/.agents/plugins/marketplace.json")"
+
+    echo ""
+    echo "repository staging complete. The marketplace file is a catalog only; it does not enable plugins."
+    echo "Run these commands to enable all Gopher AI plugins in the active CODEX_HOME:"
+    printf '  codex plugin marketplace add %q\n' "$target_repo"
+
+    local plugin_dir
+    for plugin_dir in "$ROOT_DIR"/plugins/*; do
+        [[ -d "$plugin_dir" ]] || continue
+        [[ -f "$plugin_dir/.codex-plugin/plugin.json" ]] || continue
+        printf '  codex plugin add %q\n' "$(basename "$plugin_dir")@$marketplace_name"
+    done
+
+    echo "These activations apply throughout that CODEX_HOME, not only in $target_repo."
+    echo "Do not combine this repository-backed source with --user in the same CODEX_HOME."
+    echo "Use a dedicated CODEX_HOME when repository isolation is required."
+}
+
 main() {
     case "${1:-}" in
         --help|-h)
@@ -856,6 +896,7 @@ main() {
             write_repo_marketplace "$target_repo"
             # --repo is itself an explicit migration action; auto-confirm cleanup.
             cleanup_legacy_user_skills "true"
+            print_repo_activation_instructions "$target_repo"
             ;;
         *)
             usage >&2

--- a/scripts/test-codex-skill-names.py
+++ b/scripts/test-codex-skill-names.py
@@ -4,6 +4,7 @@ import json
 import os
 import queue
 import re
+import shlex
 import subprocess
 import tempfile
 import threading
@@ -20,6 +21,16 @@ COUNT_PATTERN = re.compile(
     r"Shipped surface: (\d+) Claude Code commands across (\d+) plugins; "
     r"(\d+) Codex skills across (\d+) plugins; "
     r"(\d+) optional Codex MCP tools\."
+)
+REPOSITORY_GUIDANCE_FILES = (
+    ROOT_DIR / "README.md",
+    ROOT_DIR / "AGENTS.md",
+    ROOT_DIR / "scripts/build-universal.sh",
+)
+STALE_REPOSITORY_GUIDANCE = (
+    "Repo-local",
+    "Plugins load automatically from .agents/plugins/marketplace.json",
+    "Codex reads `.agents/plugins/marketplace.json` on startup",
 )
 
 
@@ -190,7 +201,7 @@ def assert_no_bare_documentation_references(plugin_names, skill_names):
 
 
 def run_codex(env, cwd, *args):
-    subprocess.run(
+    return subprocess.run(
         ["codex", *args],
         cwd=cwd,
         env=env,
@@ -224,7 +235,15 @@ def query_resolver(env, cwd):
         client.close()
 
 
-def assert_resolver_surface(response, plugin_names, skill_names):
+def parsed_activation_commands(output):
+    return [
+        shlex.split(line.strip())
+        for line in output.splitlines()
+        if line.strip().startswith("codex plugin ")
+    ]
+
+
+def resolver_skill_names(response):
     if len(response["data"]) != 1:
         raise AssertionError(
             f"expected one workspace entry, got {len(response['data'])}"
@@ -232,8 +251,11 @@ def assert_resolver_surface(response, plugin_names, skill_names):
     entry = response["data"][0]
     if entry["errors"]:
         raise AssertionError(f"skills/list returned errors: {entry['errors']}")
+    return [skill["name"] for skill in entry["skills"]]
 
-    resolver_name_list = [skill["name"] for skill in entry["skills"]]
+
+def assert_resolver_surface(response, plugin_names, skill_names):
+    resolver_name_list = resolver_skill_names(response)
     duplicate_names = sorted(
         name for name, count in Counter(resolver_name_list).items() if count > 1
     )
@@ -262,11 +284,28 @@ def assert_resolver_surface(response, plugin_names, skill_names):
         )
 
 
+def validate_repository_guidance():
+    stale_matches = []
+    for path in REPOSITORY_GUIDANCE_FILES:
+        content = path.read_text(encoding="utf-8")
+        stale_matches.extend(
+            f"{path.relative_to(ROOT_DIR)}: {phrase}"
+            for phrase in STALE_REPOSITORY_GUIDANCE
+            if phrase in content
+        )
+    if stale_matches:
+        raise AssertionError(
+            "documentation contains stale repository discovery guidance: "
+            f"{stale_matches}"
+        )
+
+
 def main():
     matrix = load_matrix()
     plugin_names, skill_names = declared_surface(matrix)
     assert_readme_counts(matrix, plugin_names, skill_names)
     assert_no_bare_documentation_references(plugin_names, skill_names)
+    validate_repository_guidance()
 
     temp_base = (
         os.environ.get("TMPDIR")
@@ -277,15 +316,43 @@ def main():
     temp_base_path = Path(temp_base).resolve()
     with tempfile.TemporaryDirectory(
         prefix="gopher-ai-skill-home-", dir=temp_base
-    ) as home_root, tempfile.TemporaryDirectory(
-        prefix="gopher-ai-skill-cwd-", dir=temp_base
-    ) as cwd_root:
-        test_home = Path(home_root)
-        clean_cwd = Path(cwd_root).resolve()
-        codex_home = test_home / ".codex"
+    ) as root:
+        test_root = Path(root)
+        codex_home = test_root / ".codex"
         codex_home.mkdir()
+        target_repo = test_root / "target repo"
+        target_repo.mkdir()
+        marketplace_dir = target_repo / ".agents/plugins"
+        marketplace_dir.mkdir(parents=True)
+        (marketplace_dir / "marketplace.json").write_text(
+            json.dumps({"name": "repo-plugins", "plugins": []}),
+            encoding="utf-8",
+        )
+        temp_bin = test_root / "bin"
+        temp_bin.mkdir()
+        mktemp = temp_bin / "mktemp"
+        mktemp.write_text(
+            "#!/bin/bash\n"
+            "if [[ $# -eq 0 ]]; then\n"
+            '  exec /usr/bin/mktemp "${TMPDIR:?}/gopher-ai-test.XXXXXX"\n'
+            "elif [[ $# -eq 1 && $1 == -d ]]; then\n"
+            '  exec /usr/bin/mktemp -d "${TMPDIR:?}/gopher-ai-test.XXXXXX"\n'
+            "fi\n"
+            'exec /usr/bin/mktemp "$@"\n',
+            encoding="utf-8",
+        )
+        mktemp.chmod(0o755)
         env = os.environ.copy()
-        env.update({"HOME": str(test_home), "CODEX_HOME": str(codex_home)})
+        env.update(
+            {
+                "HOME": str(test_root),
+                "CODEX_HOME": str(codex_home),
+                "PATH": f"{temp_bin}{os.pathsep}{env['PATH']}",
+                "TMPDIR": str(test_root),
+                "TMP": str(test_root),
+                "TEMP": str(test_root),
+            }
+        )
         if temp_base_path.is_relative_to(ROOT_DIR.resolve()):
             existing_ceiling = env.get("GIT_CEILING_DIRECTORIES")
             env["GIT_CEILING_DIRECTORIES"] = os.pathsep.join(
@@ -294,21 +361,77 @@ def main():
                 if value
             )
 
-        run_codex(env, clean_cwd, "plugin", "marketplace", "add", str(ROOT_DIR), "--json")
-        for plugin_name in plugin_names:
-            run_codex(
-                env,
-                clean_cwd,
-                "plugin",
-                "add",
-                f"{plugin_name}@gopher-ai",
-                "--json",
+        install = subprocess.run(
+            [str(ROOT_DIR / "scripts/install-codex.sh"), "--repo", str(target_repo)],
+            cwd=ROOT_DIR,
+            env=env,
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+        marketplace_name = json.loads(
+            (marketplace_dir / "marketplace.json").read_text(encoding="utf-8")
+        )["name"]
+        activation_commands = [
+            ["codex", "plugin", "marketplace", "add", str(target_repo)],
+            *(
+                ["codex", "plugin", "add", f"{name}@{marketplace_name}"]
+                for name in sorted(plugin_names)
+            ),
+        ]
+        emitted_commands = parsed_activation_commands(install.stdout)
+        if emitted_commands != activation_commands:
+            raise AssertionError(
+                "installer output activation commands differ from expected: "
+                f"{emitted_commands}"
             )
-        response = query_resolver(env, clean_cwd)
+
+        unsafe_repo = test_root / "unsafe target"
+        unsafe_marketplace_dir = unsafe_repo / ".agents/plugins"
+        unsafe_marketplace_dir.mkdir(parents=True)
+        unsafe_marketplace_name = "repo plugins;$(touch injected)"
+        (unsafe_marketplace_dir / "marketplace.json").write_text(
+            json.dumps({"name": unsafe_marketplace_name, "plugins": []}),
+            encoding="utf-8",
+        )
+        unsafe_install = subprocess.run(
+            [str(ROOT_DIR / "scripts/install-codex.sh"), "--repo", str(unsafe_repo)],
+            cwd=ROOT_DIR,
+            env=env,
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+        unsafe_commands = parsed_activation_commands(unsafe_install.stdout)
+        unsafe_expected = [
+            ["codex", "plugin", "marketplace", "add", str(unsafe_repo)],
+            *(
+                ["codex", "plugin", "add", f"{name}@{unsafe_marketplace_name}"]
+                for name in sorted(plugin_names)
+            ),
+        ]
+        if unsafe_commands != unsafe_expected:
+            raise AssertionError(
+                "installer output did not safely preserve activation arguments: "
+                f"{unsafe_commands}"
+            )
+
+        inactive_names = set(resolver_skill_names(query_resolver(env, target_repo)))
+        unexpectedly_active = set(skill_names) & inactive_names
+        if unexpectedly_active:
+            raise AssertionError(
+                "repo-staged skills unexpectedly active before plugin activation: "
+                f"{sorted(unexpectedly_active)}"
+            )
+
+        for command in emitted_commands:
+            run_codex(env, target_repo, *command[1:])
+
+        response = query_resolver(env, target_repo)
 
     assert_resolver_surface(response, plugin_names, skill_names)
     print(
-        "Codex all-plugin qualified skill-name probe passed: "
+        "Codex repo activation and all-plugin qualified skill-name probe passed: "
         f"{len(skill_names)} skills: {', '.join(sorted(skill_names))}"
     )
 


### PR DESCRIPTION
## Summary
- Correct repository-backed Codex guidance to separate marketplace catalogs, registration, and plugin activation in the active `CODEX_HOME`.
- Make repository staging print shell-safe activation commands that preserve the merged marketplace name.
- Verify the documented clean-home path exposes all 20 qualified skills across the six Codex-capable plugins.

Fixes #329

## Test Plan
- `python3 scripts/test-codex-skill-names.py`
- `shellcheck scripts/install-codex.sh scripts/build-universal.sh`
- Authoritative Detent `gate.run` command
