### PR TITLE
test(codex): enforce plugin skill surface

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -28,7 +28,13 @@ jobs:
       - name: Probe Default-mode shared-skill input behavior
         run: python3 ./scripts/test-codex-default-mode-input.py
 
-      - name: Probe qualified go-workflow skill names
+      - name: Validate platform capability matrix
+        run: python3 ./scripts/test-platform-capabilities.py
+
+      - name: Probe declared Tailwind MCP tools
+        run: node ./scripts/test-tailwind-mcp-server.mjs
+
+      - name: Probe all-plugin qualified Codex skill names
         run: python3 ./scripts/test-codex-skill-names.py
 
       - name: Probe explicit go-workflow skill arguments

--- a/README.md
+++ b/README.md
@@ -9,14 +9,13 @@ Gopher AI provides skills and commands for the three major AI coding assistants:
 | Platform | Status | Install Method |
 |----------|--------|----------------|
 | **Claude Code** | Full support | Plugin marketplace |
-| **OpenAI Codex CLI** | Full plugin support | Repo-local, installer script, or manual |
+| **OpenAI Codex CLI** | 6 plugins; capabilities vary | Repo-local, installer script, or manual |
 | **Google Gemini CLI** | Extensions | Manual install |
 
-**What's included:**
-- 7 modules (go-workflow, go-dev, productivity, gopher-guides, llm-tools, go-web, tailwind)
-- 6 auto-invoked reference skills for Go best practices, second opinions, and more
-- 8 workflow skills for issue-to-PR automation (via Codex plugins and Claude Code commands)
-- 20+ slash commands for development workflows
+Shipped surface: 36 Claude Code commands across 7 plugins; 20 Codex skills across 6 plugins; 8 optional Codex MCP tools.
+
+See the [platform capability matrix](docs/platform-capabilities.md) for exact
+qualified names and workflows that are not yet available on Codex.
 
 ## Quick Start
 

--- a/docs/platform-capabilities.json
+++ b/docs/platform-capabilities.json
@@ -317,6 +317,9 @@
             "go-workflow:create-worktree",
             "go-workflow:prune-worktree",
             "go-workflow:remove-worktree"
+          ],
+          "skill_names": [
+            "go-workflow:worktree"
           ]
         },
         "codex": {
@@ -391,6 +394,9 @@
           "disposition": "command",
           "names": [
             "go-dev:profile"
+          ],
+          "skill_names": [
+            "go-dev:go-profiling-optimization"
           ]
         },
         "codex": {
@@ -417,6 +423,9 @@
         "claude_code": {
           "disposition": "command",
           "names": [
+            "go-dev:validate-skills"
+          ],
+          "skill_names": [
             "go-dev:validate-skills"
           ]
         },
@@ -799,6 +808,9 @@
           "disposition": "command",
           "names": [
             "llm-tools:gemini-image"
+          ],
+          "skill_names": [
+            "llm-tools:gemini-image"
           ]
         },
         "codex": {
@@ -1016,6 +1028,9 @@
         "claude_code": {
           "disposition": "command",
           "names": [
+            "go-web:convert-to-go-project"
+          ],
+          "skill_names": [
             "go-web:convert-to-go-project"
           ]
         },

--- a/docs/platform-capabilities.json
+++ b/docs/platform-capabilities.json
@@ -1,0 +1,1305 @@
+{
+  "schema_version": 1,
+  "plugins": [
+    {
+      "name": "go-workflow",
+      "platforms": {
+        "claude_code": {
+          "status": "supported"
+        },
+        "codex": {
+          "status": "supported"
+        }
+      }
+    },
+    {
+      "name": "go-dev",
+      "platforms": {
+        "claude_code": {
+          "status": "supported"
+        },
+        "codex": {
+          "status": "supported"
+        }
+      }
+    },
+    {
+      "name": "productivity",
+      "platforms": {
+        "claude_code": {
+          "status": "supported"
+        },
+        "codex": {
+          "status": "unsupported",
+          "reason": "intentionally_claude_only"
+        }
+      }
+    },
+    {
+      "name": "gopher-guides",
+      "platforms": {
+        "claude_code": {
+          "status": "supported"
+        },
+        "codex": {
+          "status": "supported"
+        }
+      }
+    },
+    {
+      "name": "llm-tools",
+      "platforms": {
+        "claude_code": {
+          "status": "supported"
+        },
+        "codex": {
+          "status": "supported"
+        }
+      }
+    },
+    {
+      "name": "go-web",
+      "platforms": {
+        "claude_code": {
+          "status": "supported"
+        },
+        "codex": {
+          "status": "supported"
+        }
+      }
+    },
+    {
+      "name": "tailwind",
+      "platforms": {
+        "claude_code": {
+          "status": "supported"
+        },
+        "codex": {
+          "status": "supported"
+        }
+      }
+    }
+  ],
+  "capabilities": [
+    {
+      "id": "go-workflow.start-issue",
+      "plugin": "go-workflow",
+      "summary": "Start issue implementation with TDD and pull request submission.",
+      "sources": [
+        {
+          "kind": "skill",
+          "path": "plugins/go-workflow/skills/start-issue/SKILL.md"
+        }
+      ],
+      "platforms": {
+        "claude_code": {
+          "disposition": "skill",
+          "names": [
+            "go-workflow:start-issue"
+          ]
+        },
+        "codex": {
+          "disposition": "skill",
+          "name": "go-workflow:start-issue"
+        }
+      }
+    },
+    {
+      "id": "go-workflow.address-review",
+      "plugin": "go-workflow",
+      "summary": "Address pull request feedback and resolve review threads.",
+      "sources": [
+        {
+          "kind": "skill",
+          "path": "plugins/go-workflow/skills/address-review/SKILL.md"
+        }
+      ],
+      "platforms": {
+        "claude_code": {
+          "disposition": "skill",
+          "names": [
+            "go-workflow:address-review"
+          ]
+        },
+        "codex": {
+          "disposition": "skill",
+          "name": "go-workflow:address-review"
+        }
+      }
+    },
+    {
+      "id": "go-workflow.commit",
+      "plugin": "go-workflow",
+      "summary": "Create a conventional commit from staged changes.",
+      "sources": [
+        {
+          "kind": "skill",
+          "path": "plugins/go-workflow/skills/commit/SKILL.md"
+        }
+      ],
+      "platforms": {
+        "claude_code": {
+          "disposition": "skill",
+          "names": [
+            "go-workflow:commit"
+          ]
+        },
+        "codex": {
+          "disposition": "skill",
+          "name": "go-workflow:commit"
+        }
+      }
+    },
+    {
+      "id": "go-workflow.complete-issue",
+      "plugin": "go-workflow",
+      "summary": "Take an issue through implementation and merge.",
+      "sources": [
+        {
+          "kind": "skill",
+          "path": "plugins/go-workflow/skills/complete-issue/SKILL.md"
+        }
+      ],
+      "platforms": {
+        "claude_code": {
+          "disposition": "skill",
+          "names": [
+            "go-workflow:complete-issue"
+          ]
+        },
+        "codex": {
+          "disposition": "skill",
+          "name": "go-workflow:complete-issue"
+        }
+      }
+    },
+    {
+      "id": "go-workflow.create-pr",
+      "plugin": "go-workflow",
+      "summary": "Create a pull request using the repository template.",
+      "sources": [
+        {
+          "kind": "skill",
+          "path": "plugins/go-workflow/skills/create-pr/SKILL.md"
+        }
+      ],
+      "platforms": {
+        "claude_code": {
+          "disposition": "skill",
+          "names": [
+            "go-workflow:create-pr"
+          ]
+        },
+        "codex": {
+          "disposition": "skill",
+          "name": "go-workflow:create-pr"
+        }
+      }
+    },
+    {
+      "id": "go-workflow.e2e-verify",
+      "plugin": "go-workflow",
+      "summary": "Run browser-based end-to-end pull request verification.",
+      "sources": [
+        {
+          "kind": "skill",
+          "path": "plugins/go-workflow/skills/e2e-verify/SKILL.md"
+        }
+      ],
+      "platforms": {
+        "claude_code": {
+          "disposition": "skill",
+          "names": [
+            "go-workflow:e2e-verify"
+          ]
+        },
+        "codex": {
+          "disposition": "skill",
+          "name": "go-workflow:e2e-verify"
+        }
+      }
+    },
+    {
+      "id": "go-workflow.review-deep",
+      "plugin": "go-workflow",
+      "summary": "Deep-review a branch or pull request and fix findings.",
+      "sources": [
+        {
+          "kind": "skill",
+          "path": "plugins/go-workflow/skills/review-deep/SKILL.md"
+        }
+      ],
+      "platforms": {
+        "claude_code": {
+          "disposition": "skill",
+          "names": [
+            "go-workflow:review-deep"
+          ]
+        },
+        "codex": {
+          "disposition": "skill",
+          "name": "go-workflow:review-deep"
+        }
+      }
+    },
+    {
+      "id": "go-workflow.ship",
+      "plugin": "go-workflow",
+      "summary": "Verify, publish, review, and merge a pull request.",
+      "sources": [
+        {
+          "kind": "skill",
+          "path": "plugins/go-workflow/skills/ship/SKILL.md"
+        }
+      ],
+      "platforms": {
+        "claude_code": {
+          "disposition": "skill",
+          "names": [
+            "go-workflow:ship"
+          ]
+        },
+        "codex": {
+          "disposition": "skill",
+          "name": "go-workflow:ship"
+        }
+      }
+    },
+    {
+      "id": "go-workflow.tmux-start",
+      "plugin": "go-workflow",
+      "summary": "Start issue work in an isolated tmux window and worktree.",
+      "sources": [
+        {
+          "kind": "skill",
+          "path": "plugins/go-workflow/skills/tmux-start/SKILL.md"
+        }
+      ],
+      "platforms": {
+        "claude_code": {
+          "disposition": "skill",
+          "names": [
+            "go-workflow:tmux-start"
+          ]
+        },
+        "codex": {
+          "disposition": "skill",
+          "name": "go-workflow:tmux-start"
+        }
+      }
+    },
+    {
+      "id": "go-workflow.worktree",
+      "plugin": "go-workflow",
+      "summary": "Create, remove, or prune issue and pull request worktrees.",
+      "sources": [
+        {
+          "kind": "command",
+          "path": "plugins/go-workflow/commands/create-worktree.md"
+        },
+        {
+          "kind": "command",
+          "path": "plugins/go-workflow/commands/prune-worktree.md"
+        },
+        {
+          "kind": "command",
+          "path": "plugins/go-workflow/commands/remove-worktree.md"
+        },
+        {
+          "kind": "skill",
+          "path": "plugins/go-workflow/skills/worktree/SKILL.md"
+        }
+      ],
+      "platforms": {
+        "claude_code": {
+          "disposition": "command",
+          "names": [
+            "go-workflow:create-worktree",
+            "go-workflow:prune-worktree",
+            "go-workflow:remove-worktree"
+          ]
+        },
+        "codex": {
+          "disposition": "skill",
+          "name": "go-workflow:worktree"
+        }
+      }
+    },
+    {
+      "id": "go-workflow.cancel-loop",
+      "plugin": "go-workflow",
+      "summary": "Cancel an active persistent workflow loop.",
+      "sources": [
+        {
+          "kind": "command",
+          "path": "plugins/go-workflow/commands/cancel-loop.md"
+        }
+      ],
+      "platforms": {
+        "claude_code": {
+          "disposition": "command",
+          "names": [
+            "go-workflow:cancel-loop"
+          ]
+        },
+        "codex": {
+          "disposition": "unsupported",
+          "documentation": "docs/platform-capabilities.md#current-matrix",
+          "issue": "https://github.com/gopherguides/gopher-ai/issues/332"
+        }
+      }
+    },
+    {
+      "id": "go-dev.go",
+      "plugin": "go-dev",
+      "summary": "Apply idiomatic Go design, testing, and debugging guidance.",
+      "sources": [
+        {
+          "kind": "skill",
+          "path": "plugins/go-dev/skills/go/SKILL.md"
+        }
+      ],
+      "platforms": {
+        "claude_code": {
+          "disposition": "skill",
+          "names": [
+            "go-dev:go"
+          ]
+        },
+        "codex": {
+          "disposition": "skill",
+          "name": "go-dev:go"
+        }
+      }
+    },
+    {
+      "id": "go-dev.profile",
+      "plugin": "go-dev",
+      "summary": "Profile and optimize Go performance.",
+      "sources": [
+        {
+          "kind": "command",
+          "path": "plugins/go-dev/commands/profile.md"
+        },
+        {
+          "kind": "skill",
+          "path": "plugins/go-dev/skills/go-profiling-optimization/SKILL.md"
+        }
+      ],
+      "platforms": {
+        "claude_code": {
+          "disposition": "command",
+          "names": [
+            "go-dev:profile"
+          ]
+        },
+        "codex": {
+          "disposition": "skill",
+          "name": "go-dev:go-profiling-optimization"
+        }
+      }
+    },
+    {
+      "id": "go-dev.validate-skills",
+      "plugin": "go-dev",
+      "summary": "Validate shell code blocks in command and skill Markdown.",
+      "sources": [
+        {
+          "kind": "command",
+          "path": "plugins/go-dev/commands/validate-skills.md"
+        },
+        {
+          "kind": "skill",
+          "path": "plugins/go-dev/skills/validate-skills/SKILL.md"
+        }
+      ],
+      "platforms": {
+        "claude_code": {
+          "disposition": "command",
+          "names": [
+            "go-dev:validate-skills"
+          ]
+        },
+        "codex": {
+          "disposition": "skill",
+          "name": "go-dev:validate-skills"
+        }
+      }
+    },
+    {
+      "id": "go-dev.bench",
+      "plugin": "go-dev",
+      "summary": "Generate, run, and analyze Go benchmarks.",
+      "sources": [
+        {
+          "kind": "command",
+          "path": "plugins/go-dev/commands/bench.md"
+        }
+      ],
+      "platforms": {
+        "claude_code": {
+          "disposition": "command",
+          "names": [
+            "go-dev:bench"
+          ]
+        },
+        "codex": {
+          "disposition": "unsupported",
+          "documentation": "docs/platform-capabilities.md#current-matrix",
+          "issue": "https://github.com/gopherguides/gopher-ai/issues/333"
+        }
+      }
+    },
+    {
+      "id": "go-dev.build-fix",
+      "plugin": "go-dev",
+      "summary": "Diagnose and repair build failures until clean.",
+      "sources": [
+        {
+          "kind": "command",
+          "path": "plugins/go-dev/commands/build-fix.md"
+        }
+      ],
+      "platforms": {
+        "claude_code": {
+          "disposition": "command",
+          "names": [
+            "go-dev:build-fix"
+          ]
+        },
+        "codex": {
+          "disposition": "unsupported",
+          "documentation": "docs/platform-capabilities.md#current-matrix",
+          "issue": "https://github.com/gopherguides/gopher-ai/issues/333"
+        }
+      }
+    },
+    {
+      "id": "go-dev.cancel-loop",
+      "plugin": "go-dev",
+      "summary": "Cancel an active persistent development loop.",
+      "sources": [
+        {
+          "kind": "command",
+          "path": "plugins/go-dev/commands/cancel-loop.md"
+        }
+      ],
+      "platforms": {
+        "claude_code": {
+          "disposition": "command",
+          "names": [
+            "go-dev:cancel-loop"
+          ]
+        },
+        "codex": {
+          "disposition": "unsupported",
+          "documentation": "docs/platform-capabilities.md#current-matrix",
+          "issue": "https://github.com/gopherguides/gopher-ai/issues/333"
+        }
+      }
+    },
+    {
+      "id": "go-dev.explain",
+      "plugin": "go-dev",
+      "summary": "Explain Go code with structural diagrams.",
+      "sources": [
+        {
+          "kind": "command",
+          "path": "plugins/go-dev/commands/explain.md"
+        }
+      ],
+      "platforms": {
+        "claude_code": {
+          "disposition": "command",
+          "names": [
+            "go-dev:explain"
+          ]
+        },
+        "codex": {
+          "disposition": "unsupported",
+          "documentation": "docs/platform-capabilities.md#current-matrix",
+          "issue": "https://github.com/gopherguides/gopher-ai/issues/333"
+        }
+      }
+    },
+    {
+      "id": "go-dev.lint-fix",
+      "plugin": "go-dev",
+      "summary": "Repair Go lint findings.",
+      "sources": [
+        {
+          "kind": "command",
+          "path": "plugins/go-dev/commands/lint-fix.md"
+        }
+      ],
+      "platforms": {
+        "claude_code": {
+          "disposition": "command",
+          "names": [
+            "go-dev:lint-fix"
+          ]
+        },
+        "codex": {
+          "disposition": "unsupported",
+          "documentation": "docs/platform-capabilities.md#current-matrix",
+          "issue": "https://github.com/gopherguides/gopher-ai/issues/333"
+        }
+      }
+    },
+    {
+      "id": "go-dev.refactor-clean",
+      "plugin": "go-dev",
+      "summary": "Remove dead Go code and reduce complexity.",
+      "sources": [
+        {
+          "kind": "command",
+          "path": "plugins/go-dev/commands/refactor-clean.md"
+        }
+      ],
+      "platforms": {
+        "claude_code": {
+          "disposition": "command",
+          "names": [
+            "go-dev:refactor-clean"
+          ]
+        },
+        "codex": {
+          "disposition": "unsupported",
+          "documentation": "docs/platform-capabilities.md#current-matrix",
+          "issue": "https://github.com/gopherguides/gopher-ai/issues/333"
+        }
+      }
+    },
+    {
+      "id": "go-dev.test-gen",
+      "plugin": "go-dev",
+      "summary": "Generate comprehensive Go tests.",
+      "sources": [
+        {
+          "kind": "command",
+          "path": "plugins/go-dev/commands/test-gen.md"
+        }
+      ],
+      "platforms": {
+        "claude_code": {
+          "disposition": "command",
+          "names": [
+            "go-dev:test-gen"
+          ]
+        },
+        "codex": {
+          "disposition": "unsupported",
+          "documentation": "docs/platform-capabilities.md#current-matrix",
+          "issue": "https://github.com/gopherguides/gopher-ai/issues/333"
+        }
+      }
+    },
+    {
+      "id": "go-dev.verify",
+      "plugin": "go-dev",
+      "summary": "Run the full pre-push Go verification workflow.",
+      "sources": [
+        {
+          "kind": "command",
+          "path": "plugins/go-dev/commands/verify.md"
+        }
+      ],
+      "platforms": {
+        "claude_code": {
+          "disposition": "command",
+          "names": [
+            "go-dev:verify"
+          ]
+        },
+        "codex": {
+          "disposition": "unsupported",
+          "documentation": "docs/platform-capabilities.md#current-matrix",
+          "issue": "https://github.com/gopherguides/gopher-ai/issues/333"
+        }
+      }
+    },
+    {
+      "id": "productivity.changelog",
+      "plugin": "productivity",
+      "summary": "Generate a changelog from Git history.",
+      "sources": [
+        {
+          "kind": "command",
+          "path": "plugins/productivity/commands/changelog.md"
+        }
+      ],
+      "platforms": {
+        "claude_code": {
+          "disposition": "command",
+          "names": [
+            "productivity:changelog"
+          ]
+        },
+        "codex": {
+          "disposition": "unsupported",
+          "documentation": "docs/platform-capabilities.md#current-matrix"
+        }
+      }
+    },
+    {
+      "id": "productivity.gopher-ai-refresh",
+      "plugin": "productivity",
+      "summary": "Refresh installed gopher-ai plugins.",
+      "sources": [
+        {
+          "kind": "command",
+          "path": "plugins/productivity/commands/gopher-ai-refresh.md"
+        }
+      ],
+      "platforms": {
+        "claude_code": {
+          "disposition": "command",
+          "names": [
+            "productivity:gopher-ai-refresh"
+          ]
+        },
+        "codex": {
+          "disposition": "unsupported",
+          "documentation": "docs/platform-capabilities.md#current-matrix"
+        }
+      }
+    },
+    {
+      "id": "productivity.release",
+      "plugin": "productivity",
+      "summary": "Create a versioned project release.",
+      "sources": [
+        {
+          "kind": "command",
+          "path": "plugins/productivity/commands/release.md"
+        }
+      ],
+      "platforms": {
+        "claude_code": {
+          "disposition": "command",
+          "names": [
+            "productivity:release"
+          ]
+        },
+        "codex": {
+          "disposition": "unsupported",
+          "documentation": "docs/platform-capabilities.md#current-matrix"
+        }
+      }
+    },
+    {
+      "id": "productivity.standup",
+      "plugin": "productivity",
+      "summary": "Generate standup notes from Git activity.",
+      "sources": [
+        {
+          "kind": "command",
+          "path": "plugins/productivity/commands/standup.md"
+        }
+      ],
+      "platforms": {
+        "claude_code": {
+          "disposition": "command",
+          "names": [
+            "productivity:standup"
+          ]
+        },
+        "codex": {
+          "disposition": "unsupported",
+          "documentation": "docs/platform-capabilities.md#current-matrix"
+        }
+      }
+    },
+    {
+      "id": "productivity.weekly-summary",
+      "plugin": "productivity",
+      "summary": "Generate a weekly summary from Git activity.",
+      "sources": [
+        {
+          "kind": "command",
+          "path": "plugins/productivity/commands/weekly-summary.md"
+        }
+      ],
+      "platforms": {
+        "claude_code": {
+          "disposition": "command",
+          "names": [
+            "productivity:weekly-summary"
+          ]
+        },
+        "codex": {
+          "disposition": "unsupported",
+          "documentation": "docs/platform-capabilities.md#current-matrix"
+        }
+      }
+    },
+    {
+      "id": "gopher-guides.gopher-guides",
+      "plugin": "gopher-guides",
+      "summary": "Retrieve authoritative Gopher Guides training guidance.",
+      "sources": [
+        {
+          "kind": "skill",
+          "path": "plugins/gopher-guides/skills/gopher-guides/SKILL.md"
+        }
+      ],
+      "platforms": {
+        "claude_code": {
+          "disposition": "skill",
+          "names": [
+            "gopher-guides:gopher-guides"
+          ]
+        },
+        "codex": {
+          "disposition": "skill",
+          "name": "gopher-guides:gopher-guides"
+        }
+      }
+    },
+    {
+      "id": "gopher-guides.clear-cache",
+      "plugin": "gopher-guides",
+      "summary": "Clear the Gopher Guides API response cache.",
+      "sources": [
+        {
+          "kind": "command",
+          "path": "plugins/gopher-guides/commands/clear-cache.md"
+        }
+      ],
+      "platforms": {
+        "claude_code": {
+          "disposition": "command",
+          "names": [
+            "gopher-guides:clear-cache"
+          ]
+        },
+        "codex": {
+          "disposition": "unsupported",
+          "documentation": "docs/platform-capabilities.md#current-matrix",
+          "issue": "https://github.com/gopherguides/gopher-ai/issues/337"
+        }
+      }
+    },
+    {
+      "id": "llm-tools.gemini-image",
+      "plugin": "llm-tools",
+      "summary": "Generate and edit images with Gemini.",
+      "sources": [
+        {
+          "kind": "command",
+          "path": "plugins/llm-tools/commands/gemini-image.md"
+        },
+        {
+          "kind": "skill",
+          "path": "plugins/llm-tools/skills/gemini-image/SKILL.md"
+        }
+      ],
+      "platforms": {
+        "claude_code": {
+          "disposition": "command",
+          "names": [
+            "llm-tools:gemini-image"
+          ]
+        },
+        "codex": {
+          "disposition": "skill",
+          "name": "llm-tools:gemini-image"
+        }
+      }
+    },
+    {
+      "id": "llm-tools.second-opinion",
+      "plugin": "llm-tools",
+      "summary": "Request a second model opinion on consequential decisions.",
+      "sources": [
+        {
+          "kind": "skill",
+          "path": "plugins/llm-tools/skills/second-opinion/SKILL.md"
+        }
+      ],
+      "platforms": {
+        "claude_code": {
+          "disposition": "skill",
+          "names": [
+            "llm-tools:second-opinion"
+          ]
+        },
+        "codex": {
+          "disposition": "skill",
+          "name": "llm-tools:second-opinion"
+        }
+      }
+    },
+    {
+      "id": "llm-tools.cancel-loop",
+      "plugin": "llm-tools",
+      "summary": "Cancel an active persistent LLM workflow.",
+      "sources": [
+        {
+          "kind": "command",
+          "path": "plugins/llm-tools/commands/cancel-loop.md"
+        }
+      ],
+      "platforms": {
+        "claude_code": {
+          "disposition": "command",
+          "names": [
+            "llm-tools:cancel-loop"
+          ]
+        },
+        "codex": {
+          "disposition": "unsupported",
+          "documentation": "docs/platform-capabilities.md#current-matrix",
+          "issue": "https://github.com/gopherguides/gopher-ai/issues/335"
+        }
+      }
+    },
+    {
+      "id": "llm-tools.codex",
+      "plugin": "llm-tools",
+      "summary": "Delegate a task to Codex from Claude Code.",
+      "sources": [
+        {
+          "kind": "command",
+          "path": "plugins/llm-tools/commands/codex.md"
+        }
+      ],
+      "platforms": {
+        "claude_code": {
+          "disposition": "command",
+          "names": [
+            "llm-tools:codex"
+          ]
+        },
+        "codex": {
+          "disposition": "unsupported",
+          "documentation": "docs/platform-capabilities.md#current-matrix",
+          "issue": "https://github.com/gopherguides/gopher-ai/issues/335"
+        }
+      }
+    },
+    {
+      "id": "llm-tools.convert",
+      "plugin": "llm-tools",
+      "summary": "Convert between formats, languages, and data structures.",
+      "sources": [
+        {
+          "kind": "command",
+          "path": "plugins/llm-tools/commands/convert.md"
+        }
+      ],
+      "platforms": {
+        "claude_code": {
+          "disposition": "command",
+          "names": [
+            "llm-tools:convert"
+          ]
+        },
+        "codex": {
+          "disposition": "unsupported",
+          "documentation": "docs/platform-capabilities.md#current-matrix",
+          "issue": "https://github.com/gopherguides/gopher-ai/issues/335"
+        }
+      }
+    },
+    {
+      "id": "llm-tools.gemini",
+      "plugin": "llm-tools",
+      "summary": "Delegate a task to the Gemini CLI.",
+      "sources": [
+        {
+          "kind": "command",
+          "path": "plugins/llm-tools/commands/gemini.md"
+        }
+      ],
+      "platforms": {
+        "claude_code": {
+          "disposition": "command",
+          "names": [
+            "llm-tools:gemini"
+          ]
+        },
+        "codex": {
+          "disposition": "unsupported",
+          "documentation": "docs/platform-capabilities.md#current-matrix",
+          "issue": "https://github.com/gopherguides/gopher-ai/issues/335"
+        }
+      }
+    },
+    {
+      "id": "llm-tools.llm-compare",
+      "plugin": "llm-tools",
+      "summary": "Compare answers from multiple language models.",
+      "sources": [
+        {
+          "kind": "command",
+          "path": "plugins/llm-tools/commands/llm-compare.md"
+        }
+      ],
+      "platforms": {
+        "claude_code": {
+          "disposition": "command",
+          "names": [
+            "llm-tools:llm-compare"
+          ]
+        },
+        "codex": {
+          "disposition": "unsupported",
+          "documentation": "docs/platform-capabilities.md#current-matrix",
+          "issue": "https://github.com/gopherguides/gopher-ai/issues/335"
+        }
+      }
+    },
+    {
+      "id": "llm-tools.ollama",
+      "plugin": "llm-tools",
+      "summary": "Delegate a private task to local Ollama models.",
+      "sources": [
+        {
+          "kind": "command",
+          "path": "plugins/llm-tools/commands/ollama.md"
+        }
+      ],
+      "platforms": {
+        "claude_code": {
+          "disposition": "command",
+          "names": [
+            "llm-tools:ollama"
+          ]
+        },
+        "codex": {
+          "disposition": "unsupported",
+          "documentation": "docs/platform-capabilities.md#current-matrix",
+          "issue": "https://github.com/gopherguides/gopher-ai/issues/335"
+        }
+      }
+    },
+    {
+      "id": "llm-tools.review-loop",
+      "plugin": "llm-tools",
+      "summary": "Iterate model review, repair, and verification until clean.",
+      "sources": [
+        {
+          "kind": "command",
+          "path": "plugins/llm-tools/commands/review-loop.md"
+        }
+      ],
+      "platforms": {
+        "claude_code": {
+          "disposition": "command",
+          "names": [
+            "llm-tools:review-loop"
+          ]
+        },
+        "codex": {
+          "disposition": "unsupported",
+          "documentation": "docs/platform-capabilities.md#current-matrix",
+          "issue": "https://github.com/gopherguides/gopher-ai/issues/335"
+        }
+      }
+    },
+    {
+      "id": "go-web.convert-to-go-project",
+      "plugin": "go-web",
+      "summary": "Convert an existing project to Go, Templ, HTMX, and Tailwind.",
+      "sources": [
+        {
+          "kind": "command",
+          "path": "plugins/go-web/commands/convert-to-go-project.md"
+        },
+        {
+          "kind": "skill",
+          "path": "plugins/go-web/skills/convert-to-go-project/SKILL.md"
+        }
+      ],
+      "platforms": {
+        "claude_code": {
+          "disposition": "command",
+          "names": [
+            "go-web:convert-to-go-project"
+          ]
+        },
+        "codex": {
+          "disposition": "skill",
+          "name": "go-web:convert-to-go-project"
+        }
+      }
+    },
+    {
+      "id": "go-web.htmx",
+      "plugin": "go-web",
+      "summary": "Apply HTMX patterns in Go and Templ applications.",
+      "sources": [
+        {
+          "kind": "skill",
+          "path": "plugins/go-web/skills/htmx/SKILL.md"
+        }
+      ],
+      "platforms": {
+        "claude_code": {
+          "disposition": "skill",
+          "names": [
+            "go-web:htmx"
+          ]
+        },
+        "codex": {
+          "disposition": "skill",
+          "name": "go-web:htmx"
+        }
+      }
+    },
+    {
+      "id": "go-web.templui",
+      "plugin": "go-web",
+      "summary": "Build templUI components and client interactions.",
+      "sources": [
+        {
+          "kind": "skill",
+          "path": "plugins/go-web/skills/templui/SKILL.md"
+        }
+      ],
+      "platforms": {
+        "claude_code": {
+          "disposition": "skill",
+          "names": [
+            "go-web:templui"
+          ]
+        },
+        "codex": {
+          "disposition": "skill",
+          "name": "go-web:templui"
+        }
+      }
+    },
+    {
+      "id": "go-web.cancel-loop",
+      "plugin": "go-web",
+      "summary": "Cancel an active persistent Go web workflow.",
+      "sources": [
+        {
+          "kind": "command",
+          "path": "plugins/go-web/commands/cancel-loop.md"
+        }
+      ],
+      "platforms": {
+        "claude_code": {
+          "disposition": "command",
+          "names": [
+            "go-web:cancel-loop"
+          ]
+        },
+        "codex": {
+          "disposition": "unsupported",
+          "documentation": "docs/platform-capabilities.md#current-matrix",
+          "issue": "https://github.com/gopherguides/gopher-ai/issues/334"
+        }
+      }
+    },
+    {
+      "id": "go-web.create-go-project",
+      "plugin": "go-web",
+      "summary": "Create a Go web project from scratch.",
+      "sources": [
+        {
+          "kind": "command",
+          "path": "plugins/go-web/commands/create-go-project.md"
+        }
+      ],
+      "platforms": {
+        "claude_code": {
+          "disposition": "command",
+          "names": [
+            "go-web:create-go-project"
+          ]
+        },
+        "codex": {
+          "disposition": "unsupported",
+          "documentation": "docs/platform-capabilities.md#current-matrix",
+          "issue": "https://github.com/gopherguides/gopher-ai/issues/334"
+        }
+      }
+    },
+    {
+      "id": "tailwind.tailwind-best-practices",
+      "plugin": "tailwind",
+      "summary": "Apply Tailwind CSS v4 syntax and best practices.",
+      "sources": [
+        {
+          "kind": "skill",
+          "path": "plugins/tailwind/skills/tailwind-best-practices/SKILL.md"
+        }
+      ],
+      "platforms": {
+        "claude_code": {
+          "disposition": "skill",
+          "names": [
+            "tailwind:tailwind-best-practices"
+          ]
+        },
+        "codex": {
+          "disposition": "skill",
+          "name": "tailwind:tailwind-best-practices"
+        }
+      }
+    },
+    {
+      "id": "tailwind.audit",
+      "plugin": "tailwind",
+      "summary": "Audit Tailwind usage for consistency and best practices.",
+      "sources": [
+        {
+          "kind": "command",
+          "path": "plugins/tailwind/commands/audit.md"
+        }
+      ],
+      "platforms": {
+        "claude_code": {
+          "disposition": "command",
+          "names": [
+            "tailwind:audit"
+          ]
+        },
+        "codex": {
+          "disposition": "unsupported",
+          "documentation": "docs/platform-capabilities.md#current-matrix",
+          "issue": "https://github.com/gopherguides/gopher-ai/issues/336"
+        }
+      }
+    },
+    {
+      "id": "tailwind.cancel-loop",
+      "plugin": "tailwind",
+      "summary": "Cancel an active persistent Tailwind workflow.",
+      "sources": [
+        {
+          "kind": "command",
+          "path": "plugins/tailwind/commands/cancel-loop.md"
+        }
+      ],
+      "platforms": {
+        "claude_code": {
+          "disposition": "command",
+          "names": [
+            "tailwind:cancel-loop"
+          ]
+        },
+        "codex": {
+          "disposition": "unsupported",
+          "documentation": "docs/platform-capabilities.md#current-matrix",
+          "issue": "https://github.com/gopherguides/gopher-ai/issues/336"
+        }
+      }
+    },
+    {
+      "id": "tailwind.init",
+      "plugin": "tailwind",
+      "summary": "Initialize Tailwind CSS v4 in an existing project.",
+      "sources": [
+        {
+          "kind": "command",
+          "path": "plugins/tailwind/commands/init.md"
+        }
+      ],
+      "platforms": {
+        "claude_code": {
+          "disposition": "command",
+          "names": [
+            "tailwind:init"
+          ]
+        },
+        "codex": {
+          "disposition": "unsupported",
+          "documentation": "docs/platform-capabilities.md#current-matrix",
+          "issue": "https://github.com/gopherguides/gopher-ai/issues/336"
+        }
+      }
+    },
+    {
+      "id": "tailwind.migrate",
+      "plugin": "tailwind",
+      "summary": "Migrate Tailwind CSS v3 configuration to v4.",
+      "sources": [
+        {
+          "kind": "command",
+          "path": "plugins/tailwind/commands/migrate.md"
+        }
+      ],
+      "platforms": {
+        "claude_code": {
+          "disposition": "command",
+          "names": [
+            "tailwind:migrate"
+          ]
+        },
+        "codex": {
+          "disposition": "unsupported",
+          "documentation": "docs/platform-capabilities.md#current-matrix",
+          "issue": "https://github.com/gopherguides/gopher-ai/issues/336"
+        }
+      }
+    },
+    {
+      "id": "tailwind.optimize",
+      "plugin": "tailwind",
+      "summary": "Analyze and optimize generated Tailwind CSS.",
+      "sources": [
+        {
+          "kind": "command",
+          "path": "plugins/tailwind/commands/optimize.md"
+        }
+      ],
+      "platforms": {
+        "claude_code": {
+          "disposition": "command",
+          "names": [
+            "tailwind:optimize"
+          ]
+        },
+        "codex": {
+          "disposition": "unsupported",
+          "documentation": "docs/platform-capabilities.md#current-matrix",
+          "issue": "https://github.com/gopherguides/gopher-ai/issues/336"
+        }
+      }
+    },
+    {
+      "id": "tailwind.supplementary-mcp-tools",
+      "plugin": "tailwind",
+      "summary": "Look up Tailwind guidance and generate focused examples through MCP.",
+      "sources": [
+        {
+          "kind": "mcp_manifest",
+          "path": "plugins/tailwind/.mcp.json"
+        }
+      ],
+      "platforms": {
+        "claude_code": {
+          "disposition": "mcp_tool",
+          "names": [
+            "mcp__tailwindcss__search_tailwind_docs",
+            "mcp__tailwindcss__get_tailwind_utilities",
+            "mcp__tailwindcss__get_tailwind_colors",
+            "mcp__tailwindcss__get_tailwind_config_guide",
+            "mcp__tailwindcss__install_tailwind",
+            "mcp__tailwindcss__convert_css_to_tailwind",
+            "mcp__tailwindcss__generate_color_palette",
+            "mcp__tailwindcss__generate_component_template"
+          ]
+        },
+        "codex": {
+          "disposition": "mcp_tool",
+          "names": [
+            "mcp__tailwindcss__search_tailwind_docs",
+            "mcp__tailwindcss__get_tailwind_utilities",
+            "mcp__tailwindcss__get_tailwind_colors",
+            "mcp__tailwindcss__get_tailwind_config_guide",
+            "mcp__tailwindcss__install_tailwind",
+            "mcp__tailwindcss__convert_css_to_tailwind",
+            "mcp__tailwindcss__generate_color_palette",
+            "mcp__tailwindcss__generate_component_template"
+          ]
+        }
+      }
+    }
+  ]
+}

--- a/docs/platform-capabilities.md
+++ b/docs/platform-capabilities.md
@@ -1,0 +1,26 @@
+# Platform capabilities
+
+The canonical machine-readable inventory is
+[`platform-capabilities.json`](platform-capabilities.json). Unsupported means a
+capability is unavailable on that platform today, not that an installed plugin
+provides an equivalent workflow by another name.
+
+Shipped surface: 36 Claude Code commands across 7 plugins; 20 Codex skills across 6 plugins; 8 optional Codex MCP tools.
+
+## Current matrix
+
+| Plugin | Claude Code sources | Codex disposition |
+| --- | --- | --- |
+| `go-workflow` | Commands: `cancel-loop`, `create-worktree`, `prune-worktree`, `remove-worktree`. Skills: `address-review`, `commit`, `complete-issue`, `create-pr`, `e2e-verify`, `review-deep`, `ship`, `start-issue`, `tmux-start`, `worktree`. | Skills: `$go-workflow:address-review`, `$go-workflow:commit`, `$go-workflow:complete-issue`, `$go-workflow:create-pr`, `$go-workflow:e2e-verify`, `$go-workflow:review-deep`, `$go-workflow:ship`, `$go-workflow:start-issue`, `$go-workflow:tmux-start`, `$go-workflow:worktree`. `cancel-loop` is unsupported ([#332](https://github.com/gopherguides/gopher-ai/issues/332)). |
+| `go-dev` | Commands: `bench`, `build-fix`, `cancel-loop`, `explain`, `lint-fix`, `profile`, `refactor-clean`, `test-gen`, `validate-skills`, `verify`. Skills: `go`, `go-profiling-optimization`, `validate-skills`. | Skills: `$go-dev:go`, `$go-dev:go-profiling-optimization`, `$go-dev:validate-skills`. The remaining command workflows are unsupported ([#333](https://github.com/gopherguides/gopher-ai/issues/333)). |
+| `productivity` | Commands: `changelog`, `gopher-ai-refresh`, `release`, `standup`, `weekly-summary`. | Intentionally Claude-only; all five commands are unsupported. |
+| `gopher-guides` | Command: `clear-cache`. Skill: `gopher-guides`. | Skill: `$gopher-guides:gopher-guides`. `clear-cache` is unsupported ([#337](https://github.com/gopherguides/gopher-ai/issues/337)). |
+| `llm-tools` | Commands: `cancel-loop`, `codex`, `convert`, `gemini`, `gemini-image`, `llm-compare`, `ollama`, `review-loop`. Skills: `gemini-image`, `second-opinion`. | Skills: `$llm-tools:gemini-image`, `$llm-tools:second-opinion`. The remaining command workflows are unsupported ([#335](https://github.com/gopherguides/gopher-ai/issues/335)). |
+| `go-web` | Commands: `cancel-loop`, `convert-to-go-project`, `create-go-project`. Skills: `convert-to-go-project`, `htmx`, `templui`. | Skills: `$go-web:convert-to-go-project`, `$go-web:htmx`, `$go-web:templui`. Conversion resolved [#323](https://github.com/gopherguides/gopher-ai/issues/323); `cancel-loop` and `create-go-project` are unsupported ([#334](https://github.com/gopherguides/gopher-ai/issues/334)). |
+| `tailwind` | Commands: `audit`, `cancel-loop`, `init`, `migrate`, `optimize`. Skill: `tailwind-best-practices`. | Skill: `$tailwind:tailwind-best-practices`. All five command workflows are unsupported ([#336](https://github.com/gopherguides/gopher-ai/issues/336)). |
+
+The optional Tailwind MCP server exposes `search_tailwind_docs`,
+`get_tailwind_utilities`, `get_tailwind_colors`, `get_tailwind_config_guide`,
+`install_tailwind`, `convert_css_to_tailwind`, `generate_color_palette`, and
+`generate_component_template`. These supplementary tools do not replace the
+end-to-end `audit`, `init`, `migrate`, or `optimize` workflows.

--- a/scripts/test-codex-skill-names.py
+++ b/scripts/test-codex-skill-names.py
@@ -8,35 +8,22 @@ import subprocess
 import tempfile
 import threading
 import time
+from collections import Counter
 from pathlib import Path
 
 
 ROOT_DIR = Path(__file__).resolve().parent.parent
-TOP_LEVEL_DOCUMENTATION_FILES = (
-    ROOT_DIR / "AGENTS.md",
-    ROOT_DIR / "README.md",
-    ROOT_DIR / "plugins/go-workflow/README.md",
+MATRIX_PATH = ROOT_DIR / "docs/platform-capabilities.json"
+README_PATH = ROOT_DIR / "README.md"
+COUNT_PATTERN = re.compile(
+    r"Shipped surface: (\d+) Claude Code commands across (\d+) plugins; "
+    r"(\d+) Codex skills across (\d+) plugins; "
+    r"(\d+) optional Codex MCP tools\."
 )
-PACKAGED_DOCUMENTATION_DIRS = (
-    ROOT_DIR / "plugins/go-workflow/skills",
-    ROOT_DIR / "plugins/go-workflow/lib",
-)
-QUALIFIED_SKILL_PATTERN = re.compile(r"\$(go-workflow:[a-z][a-z0-9-]*)")
-BARE_SKILL_PATTERN = re.compile(r"\$([a-z][a-z0-9-]*)(?![a-z0-9_-])")
-WORKTREE_SLASH_COMMANDS = {"create-worktree", "remove-worktree", "prune-worktree"}
-
-
-def documentation_files():
-    packaged_files = (
-        path
-        for directory in PACKAGED_DOCUMENTATION_DIRS
-        for path in directory.rglob("*.md")
-    )
-    return (*TOP_LEVEL_DOCUMENTATION_FILES, *packaged_files)
 
 
 class AppServerClient:
-    def __init__(self, env):
+    def __init__(self, env, cwd):
         self.process = subprocess.Popen(
             ["codex", "app-server", "--stdio"],
             stdin=subprocess.PIPE,
@@ -45,6 +32,7 @@ class AppServerClient:
             text=True,
             bufsize=1,
             env=env,
+            cwd=cwd,
         )
         self.messages = queue.Queue()
         self.stderr = []
@@ -70,7 +58,7 @@ class AppServerClient:
         request_id = self.next_request_id
         self.next_request_id += 1
         self.send({"method": method, "id": request_id, "params": params})
-        deadline = time.monotonic() + 15
+        deadline = time.monotonic() + 30
         deferred = []
         while time.monotonic() < deadline:
             try:
@@ -100,109 +88,195 @@ class AppServerClient:
                 self.process.wait(timeout=5)
 
 
-def run_codex(env, *args):
+def load_matrix():
+    try:
+        matrix = json.loads(MATRIX_PATH.read_text(encoding="utf-8"))
+    except FileNotFoundError as error:
+        raise AssertionError(f"missing capability matrix: {MATRIX_PATH}") from error
+    except json.JSONDecodeError as error:
+        raise AssertionError(f"invalid capability matrix: {error}") from error
+    if matrix.get("schema_version") != 1:
+        raise AssertionError(
+            f"unsupported capability matrix schema: {matrix.get('schema_version')}"
+        )
+    return matrix
+
+
+def declared_surface(matrix):
+    plugin_names = [
+        plugin["name"]
+        for plugin in matrix["plugins"]
+        if plugin["platforms"]["codex"]["status"] == "supported"
+    ]
+    skill_names = [
+        capability["platforms"]["codex"]["name"]
+        for capability in matrix["capabilities"]
+        if capability["platforms"]["codex"]["disposition"] == "skill"
+    ]
+    duplicate_plugins = sorted(
+        name for name, count in Counter(plugin_names).items() if count > 1
+    )
+    duplicate_skills = sorted(
+        name for name, count in Counter(skill_names).items() if count > 1
+    )
+    if duplicate_plugins or duplicate_skills:
+        raise AssertionError(
+            "capability matrix contains duplicates: "
+            f"plugins={duplicate_plugins}, skills={duplicate_skills}"
+        )
+    if not plugin_names or not skill_names:
+        raise AssertionError("capability matrix declares no Codex plugin skill surface")
+    return plugin_names, skill_names
+
+
+def assert_readme_counts(matrix, plugin_names, skill_names):
+    command_count = sum(
+        source["kind"] == "command"
+        for capability in matrix["capabilities"]
+        for source in capability["sources"]
+    )
+    mcp_tool_count = sum(
+        len(capability["platforms"]["codex"]["names"])
+        for capability in matrix["capabilities"]
+        if capability["platforms"]["codex"]["disposition"] == "mcp_tool"
+    )
+    expected = (
+        command_count,
+        len(matrix["plugins"]),
+        len(skill_names),
+        len(plugin_names),
+        mcp_tool_count,
+    )
+    match = COUNT_PATTERN.search(README_PATH.read_text(encoding="utf-8"))
+    if not match:
+        raise AssertionError("README.md is missing the shipped-surface count statement")
+    actual = tuple(int(value) for value in match.groups())
+    if actual != expected:
+        raise AssertionError(
+            f"stale README shipped-surface counts: expected {expected}, got {actual}"
+        )
+
+
+def run_codex(env, cwd, *args):
     subprocess.run(
         ["codex", *args],
-        cwd=ROOT_DIR,
+        cwd=cwd,
         env=env,
         check=True,
         capture_output=True,
         text=True,
+        timeout=60,
     )
 
 
-def documented_skill_names():
-    names = set()
-    for path in documentation_files():
-        names.update(QUALIFIED_SKILL_PATTERN.findall(path.read_text(encoding="utf-8")))
-    if not names:
-        raise AssertionError("documentation contains no qualified go-workflow skills")
-    return names
+def query_resolver(env, cwd):
+    client = AppServerClient(env, cwd)
+    try:
+        client.request(
+            "initialize",
+            {
+                "clientInfo": {
+                    "name": "gopher_ai_skill_name_probe",
+                    "title": "Gopher AI Skill Name Probe",
+                    "version": "1.0.0",
+                },
+                "capabilities": {"experimentalApi": True},
+            },
+        )
+        client.send({"method": "initialized", "params": {}})
+        return client.request(
+            "skills/list",
+            {"cwds": [str(cwd)], "forceReload": True},
+        )
+    finally:
+        client.close()
 
 
-def documented_bare_names():
-    names = set()
-    for path in documentation_files():
-        names.update(BARE_SKILL_PATTERN.findall(path.read_text(encoding="utf-8")))
-    return names
+def assert_resolver_surface(response, plugin_names, skill_names):
+    if len(response["data"]) != 1:
+        raise AssertionError(
+            f"expected one workspace entry, got {len(response['data'])}"
+        )
+    entry = response["data"][0]
+    if entry["errors"]:
+        raise AssertionError(f"skills/list returned errors: {entry['errors']}")
+
+    resolver_name_list = [skill["name"] for skill in entry["skills"]]
+    duplicate_names = sorted(
+        name for name, count in Counter(resolver_name_list).items() if count > 1
+    )
+    if duplicate_names:
+        raise AssertionError(f"skills/list returned duplicate names: {duplicate_names}")
+
+    resolver_names = set(resolver_name_list)
+    expected_names = set(skill_names)
+    prefixes = tuple(f"{plugin}:" for plugin in plugin_names)
+    gopher_ai_qualified_names = {
+        name for name in resolver_names if name.startswith(prefixes)
+    }
+    missing = sorted(expected_names - gopher_ai_qualified_names)
+    unexpected = sorted(gopher_ai_qualified_names - expected_names)
+    if missing or unexpected:
+        raise AssertionError(
+            "gopher-ai qualified skill surface differs from the matrix: "
+            f"missing={missing}, unexpected={unexpected}"
+        )
+
+    suffixes = {name.split(":", 1)[1] for name in expected_names}
+    bare_aliases = sorted(suffixes & resolver_names)
+    if bare_aliases:
+        raise AssertionError(
+            f"skills/list unexpectedly advertised bare aliases: {bare_aliases}"
+        )
 
 
 def main():
-    temp_base = os.environ.get("TMPDIR") or os.environ.get("TMP") or os.environ.get("TEMP")
-    with tempfile.TemporaryDirectory(prefix="gopher-ai-skill-names-", dir=temp_base) as root:
-        test_root = Path(root)
-        codex_home = test_root / ".codex"
+    matrix = load_matrix()
+    plugin_names, skill_names = declared_surface(matrix)
+    assert_readme_counts(matrix, plugin_names, skill_names)
+
+    temp_base = (
+        os.environ.get("TMPDIR")
+        or os.environ.get("TMP")
+        or os.environ.get("TEMP")
+        or "/tmp"
+    )
+    temp_base_path = Path(temp_base).resolve()
+    with tempfile.TemporaryDirectory(
+        prefix="gopher-ai-skill-home-", dir=temp_base
+    ) as home_root, tempfile.TemporaryDirectory(
+        prefix="gopher-ai-skill-cwd-", dir=temp_base
+    ) as cwd_root:
+        test_home = Path(home_root)
+        clean_cwd = Path(cwd_root).resolve()
+        codex_home = test_home / ".codex"
         codex_home.mkdir()
         env = os.environ.copy()
-        env.update({"HOME": str(test_root), "CODEX_HOME": str(codex_home)})
-
-        run_codex(env, "plugin", "marketplace", "add", str(ROOT_DIR), "--json")
-        run_codex(env, "plugin", "add", "go-workflow@gopher-ai", "--json")
-
-        client = AppServerClient(env)
-        try:
-            client.request(
-                "initialize",
-                {
-                    "clientInfo": {
-                        "name": "gopher_ai_skill_name_probe",
-                        "title": "Gopher AI Skill Name Probe",
-                        "version": "1.0.0",
-                    },
-                    "capabilities": {"experimentalApi": True},
-                },
-            )
-            client.send({"method": "initialized", "params": {}})
-            response = client.request(
-                "skills/list",
-                {"cwds": [str(ROOT_DIR)], "forceReload": True},
-            )
-        finally:
-            client.close()
-
-        if len(response["data"]) != 1:
-            raise AssertionError(
-                f"expected one workspace entry, got {len(response['data'])}"
+        env.update({"HOME": str(test_home), "CODEX_HOME": str(codex_home)})
+        if temp_base_path.is_relative_to(ROOT_DIR.resolve()):
+            existing_ceiling = env.get("GIT_CEILING_DIRECTORIES")
+            env["GIT_CEILING_DIRECTORIES"] = os.pathsep.join(
+                value
+                for value in (str(temp_base_path), existing_ceiling)
+                if value
             )
 
-        entry = response["data"][0]
-        if entry["errors"]:
-            raise AssertionError(f"skills/list returned errors: {entry['errors']}")
-
-        resolver_names = {skill["name"] for skill in entry["skills"]}
-        workflow_resolver_names = {
-            name for name in resolver_names if name.startswith("go-workflow:")
-        }
-        documented_names = documented_skill_names()
-        missing_names = documented_names - resolver_names
-        if missing_names:
-            raise AssertionError(
-                f"documented skills missing from skills/list: {sorted(missing_names)}"
+        run_codex(env, clean_cwd, "plugin", "marketplace", "add", str(ROOT_DIR), "--json")
+        for plugin_name in plugin_names:
+            run_codex(
+                env,
+                clean_cwd,
+                "plugin",
+                "add",
+                f"{plugin_name}@gopher-ai",
+                "--json",
             )
+        response = query_resolver(env, clean_cwd)
 
-        bare_aliases = {
-            name.removeprefix("go-workflow:") for name in documented_names
-        } & resolver_names
-        if bare_aliases:
-            raise AssertionError(
-                f"skills/list unexpectedly advertised bare aliases: {sorted(bare_aliases)}"
-            )
-
-        resolver_suffixes = {
-            name.removeprefix("go-workflow:") for name in workflow_resolver_names
-        }
-        bare_references = documented_bare_names() & (
-            resolver_suffixes | WORKTREE_SLASH_COMMANDS
-        )
-        if bare_references:
-            raise AssertionError(
-                "documentation contains bare Codex skill references: "
-                f"{sorted(bare_references)}"
-            )
-
+    assert_resolver_surface(response, plugin_names, skill_names)
     print(
-        "Codex qualified skill-name probe passed: "
-        + ", ".join(sorted(documented_names))
+        "Codex all-plugin qualified skill-name probe passed: "
+        f"{len(skill_names)} skills: {', '.join(sorted(skill_names))}"
     )
 
 

--- a/scripts/test-codex-skill-names.py
+++ b/scripts/test-codex-skill-names.py
@@ -15,6 +15,7 @@ from pathlib import Path
 ROOT_DIR = Path(__file__).resolve().parent.parent
 MATRIX_PATH = ROOT_DIR / "docs/platform-capabilities.json"
 README_PATH = ROOT_DIR / "README.md"
+BARE_SKILL_PATTERN = re.compile(r"\$([a-z][a-z0-9-]*)(?![a-z0-9_:-])")
 COUNT_PATTERN = re.compile(
     r"Shipped surface: (\d+) Claude Code commands across (\d+) plugins; "
     r"(\d+) Codex skills across (\d+) plugins; "
@@ -157,6 +158,37 @@ def assert_readme_counts(matrix, plugin_names, skill_names):
         )
 
 
+def documentation_files(plugin_names):
+    paths = {ROOT_DIR / "AGENTS.md", README_PATH}
+    for plugin_name in plugin_names:
+        plugin_root = ROOT_DIR / "plugins" / plugin_name
+        paths.add(plugin_root / "README.md")
+        for directory_name in ("skills", "lib"):
+            directory = plugin_root / directory_name
+            if directory.is_dir():
+                paths.update(directory.rglob("*.md"))
+    return sorted(path for path in paths if path.is_file())
+
+
+def assert_no_bare_documentation_references(plugin_names, skill_names):
+    suffixes = {name.split(":", 1)[1] for name in skill_names}
+    offenders = []
+    for path in documentation_files(plugin_names):
+        for line_number, line in enumerate(
+            path.read_text(encoding="utf-8").splitlines(), start=1
+        ):
+            for match in BARE_SKILL_PATTERN.finditer(line):
+                if match.group(1) in suffixes:
+                    offenders.append(
+                        f"{path.relative_to(ROOT_DIR)}:{line_number}:{match.group(0)}"
+                    )
+    if offenders:
+        raise AssertionError(
+            "documentation contains unresolvable bare Codex skill references: "
+            + ", ".join(offenders)
+        )
+
+
 def run_codex(env, cwd, *args):
     subprocess.run(
         ["codex", *args],
@@ -234,6 +266,7 @@ def main():
     matrix = load_matrix()
     plugin_names, skill_names = declared_surface(matrix)
     assert_readme_counts(matrix, plugin_names, skill_names)
+    assert_no_bare_documentation_references(plugin_names, skill_names)
 
     temp_base = (
         os.environ.get("TMPDIR")

--- a/scripts/test-platform-capabilities.py
+++ b/scripts/test-platform-capabilities.py
@@ -404,15 +404,35 @@ def validate_capabilities(matrix, plugin_records, supported_codex):
         if not isinstance(claude_names, list) or not claude_names:
             fail(f"capability {identifier} must declare Claude names")
         if expected_claude_disposition == "command":
-            expected_names = sorted(
+            expected_command_names = sorted(
                 f"{plugin}:{Path(source['path']).stem}"
                 for source in sources
                 if source["kind"] == "command"
             )
-            if sorted(claude_names) != expected_names:
+            if sorted(claude_names) != expected_command_names:
                 fail(
                     f"capability {identifier} Claude command names differ from sources: "
-                    f"expected {expected_names}, got {sorted(claude_names)}"
+                    f"expected {expected_command_names}, got {sorted(claude_names)}"
+                )
+            expected_skill_names = sorted(
+                f"{plugin}:{frontmatter_name(ROOT_DIR / source_path)}"
+                for source_path in skill_sources
+            )
+            claude_skill_names = claude.get("skill_names")
+            if expected_skill_names:
+                if not isinstance(claude_skill_names, list) or not claude_skill_names:
+                    fail(
+                        f"capability {identifier} must declare mixed Claude skill names"
+                    )
+                if sorted(claude_skill_names) != expected_skill_names:
+                    fail(
+                        f"capability {identifier} Claude skill names differ from sources: "
+                        f"expected {expected_skill_names}, "
+                        f"got {sorted(claude_skill_names)}"
+                    )
+            elif "skill_names" in claude:
+                fail(
+                    f"command-only capability {identifier} declares Claude skill names"
                 )
 
         codex = platforms["codex"]

--- a/scripts/test-platform-capabilities.py
+++ b/scripts/test-platform-capabilities.py
@@ -1,0 +1,544 @@
+#!/usr/bin/env python3
+
+import json
+import re
+from collections import Counter
+from pathlib import Path
+
+
+ROOT_DIR = Path(__file__).resolve().parent.parent
+MATRIX_PATH = ROOT_DIR / "docs/platform-capabilities.json"
+DOCUMENTATION_PATH = ROOT_DIR / "docs/platform-capabilities.md"
+README_PATH = ROOT_DIR / "README.md"
+PLATFORMS = {"claude_code", "codex"}
+CODEX_DISPOSITIONS = {"skill", "mcp_tool", "unsupported"}
+COUNT_PATTERN = re.compile(
+    r"Shipped surface: (\d+) Claude Code commands across (\d+) plugins; "
+    r"(\d+) Codex skills across (\d+) plugins; "
+    r"(\d+) optional Codex MCP tools\."
+)
+ISSUE_PATTERN = re.compile(
+    r"https://github\.com/gopherguides/gopher-ai/issues/[1-9][0-9]*"
+)
+
+
+def fail(message):
+    raise AssertionError(message)
+
+
+def load_json(path, label):
+    if not path.is_file():
+        fail(f"missing {label}: {path.relative_to(ROOT_DIR)}")
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as error:
+        fail(f"invalid JSON in {path.relative_to(ROOT_DIR)}: {error}")
+
+
+def relative_source_paths(pattern):
+    return {
+        path.relative_to(ROOT_DIR).as_posix()
+        for path in ROOT_DIR.glob(pattern)
+        if path.is_file()
+    }
+
+
+def frontmatter_name(path):
+    text = path.read_text(encoding="utf-8")
+    lines = text.splitlines()
+    if not lines or lines[0] != "---":
+        fail(f"skill is missing frontmatter: {path.relative_to(ROOT_DIR)}")
+    try:
+        end = lines.index("---", 1)
+    except ValueError:
+        fail(f"skill has unterminated frontmatter: {path.relative_to(ROOT_DIR)}")
+    names = []
+    for line in lines[1:end]:
+        match = re.fullmatch(r"name:\s*['\"]?([^'\"\s]+)['\"]?\s*", line)
+        if match:
+            names.append(match.group(1))
+    if len(names) != 1:
+        fail(
+            f"skill must have exactly one frontmatter name: "
+            f"{path.relative_to(ROOT_DIR)}"
+        )
+    return names[0]
+
+
+def validate_documentation_reference(reference):
+    path_text, separator, fragment = reference.partition("#")
+    relative_path = Path(path_text)
+    if relative_path.is_absolute() or ".." in relative_path.parts:
+        fail(f"documentation reference must stay inside the repository: {reference}")
+    path = ROOT_DIR / relative_path
+    if not path.is_file():
+        fail(f"documentation reference does not exist: {reference}")
+    if separator:
+        headings = re.findall(
+            r"^#{1,6}\s+(.+?)\s*$", path.read_text(encoding="utf-8"), re.MULTILINE
+        )
+        anchors = {
+            re.sub(r"[^a-z0-9 -]", "", heading.lower()).replace(" ", "-")
+            for heading in headings
+        }
+        if fragment not in anchors:
+            fail(f"documentation anchor does not exist: {reference}")
+
+
+def validate_counts(path, expected):
+    if not path.is_file():
+        fail(f"missing documentation: {path.relative_to(ROOT_DIR)}")
+    match = COUNT_PATTERN.search(path.read_text(encoding="utf-8"))
+    if not match:
+        fail(
+            f"{path.relative_to(ROOT_DIR)} is missing the canonical shipped-surface "
+            "count statement"
+        )
+    actual = tuple(int(value) for value in match.groups())
+    if actual != expected:
+        fail(
+            f"stale shipped-surface counts in {path.relative_to(ROOT_DIR)}: "
+            f"expected {expected}, got {actual}"
+        )
+
+
+def documented_section_names(cell, section, pattern):
+    match = re.search(rf"(?:^|\. ){section}s?: (.*?)(?:\.|$)", cell)
+    if not match:
+        return []
+    return re.findall(pattern, match.group(1))
+
+
+def validate_documentation(matrix, expected_counts):
+    validate_counts(DOCUMENTATION_PATH, expected_counts)
+    text = DOCUMENTATION_PATH.read_text(encoding="utf-8")
+    row_matches = re.findall(
+        r"^\| `([^`]+)` \| (.+?) \| (.+?) \|$", text, re.MULTILINE
+    )
+    row_counts = Counter(plugin for plugin, _, _ in row_matches)
+    plugin_names = {plugin["name"] for plugin in matrix["plugins"]}
+    if row_counts != Counter({plugin: 1 for plugin in plugin_names}):
+        fail(
+            "documentation plugin rows differ from the matrix: "
+            f"expected={sorted(plugin_names)}, got={dict(sorted(row_counts.items()))}"
+        )
+    rows = {plugin: (claude, codex) for plugin, claude, codex in row_matches}
+
+    resolved_issues = {"go-web": {"323"}}
+    for plugin in matrix["plugins"]:
+        plugin_name = plugin["name"]
+        capabilities = [
+            capability
+            for capability in matrix["capabilities"]
+            if capability["plugin"] == plugin_name
+        ]
+        claude_cell, codex_cell = rows[plugin_name]
+        expected_claude_commands = Counter(
+            Path(source["path"]).stem
+            for capability in capabilities
+            for source in capability["sources"]
+            if source["kind"] == "command"
+        )
+        documented_claude_commands = Counter(
+            documented_section_names(
+                claude_cell, "Command", r"`([a-z][a-z0-9-]*)`"
+            )
+        )
+        if documented_claude_commands != expected_claude_commands:
+            fail(
+                f"documentation Claude commands differ for {plugin_name}: "
+                f"expected={dict(sorted(expected_claude_commands.items()))}, "
+                f"got={dict(sorted(documented_claude_commands.items()))}"
+            )
+
+        expected_claude_skills = Counter(
+            Path(source["path"]).parent.name
+            for capability in capabilities
+            for source in capability["sources"]
+            if source["kind"] == "skill"
+        )
+        documented_claude_skills = Counter(
+            documented_section_names(
+                claude_cell, "Skill", r"`([a-z][a-z0-9-]*)`"
+            )
+        )
+        if documented_claude_skills != expected_claude_skills:
+            fail(
+                f"documentation Claude skills differ for {plugin_name}: "
+                f"expected={dict(sorted(expected_claude_skills.items()))}, "
+                f"got={dict(sorted(documented_claude_skills.items()))}"
+            )
+
+        expected_codex_skills = Counter(
+            capability["platforms"]["codex"]["name"]
+            for capability in capabilities
+            if capability["platforms"]["codex"]["disposition"] == "skill"
+        )
+        documented_codex_skills = Counter(
+            documented_section_names(
+                codex_cell,
+                "Skill",
+                r"\$([a-z][a-z0-9-]*:[a-z][a-z0-9-]*)",
+            )
+        )
+        if documented_codex_skills != expected_codex_skills:
+            fail(
+                f"documentation Codex skills differ for {plugin_name}: "
+                f"expected={dict(sorted(expected_codex_skills.items()))}, "
+                f"got={dict(sorted(documented_codex_skills.items()))}"
+            )
+
+        unsupported = [
+            capability
+            for capability in capabilities
+            if capability["platforms"]["codex"]["disposition"] == "unsupported"
+        ]
+        if unsupported and "unsupported" not in codex_cell.lower():
+            fail(f"documentation omits unsupported status for {plugin_name}")
+        expected_issue_names = {
+            capability["platforms"]["codex"]["issue"].rsplit("/", 1)[-1]
+            for capability in unsupported
+            if "issue" in capability["platforms"]["codex"]
+        } | resolved_issues.get(plugin_name, set())
+        expected_issues = Counter({issue: 1 for issue in expected_issue_names})
+        documented_issues = Counter(
+            re.findall(
+                r"https://github\.com/gopherguides/gopher-ai/issues/([1-9][0-9]*)",
+                codex_cell,
+            )
+        )
+        if documented_issues != expected_issues:
+            fail(
+                f"documentation issue links differ for {plugin_name}: "
+                f"expected={dict(sorted(expected_issues.items()))}, "
+                f"got={dict(sorted(documented_issues.items()))}"
+            )
+
+    mcp_capabilities = [
+        capability
+        for capability in matrix["capabilities"]
+        if capability["platforms"]["codex"]["disposition"] == "mcp_tool"
+    ]
+    expected_mcp_names = Counter(
+        name.rsplit("__", 1)[-1]
+        for capability in mcp_capabilities
+        for name in capability["platforms"]["codex"]["names"]
+    )
+    mcp_text = text.partition("The optional Tailwind MCP server exposes")[2]
+    mcp_text = mcp_text.partition("These supplementary tools")[0]
+    documented_mcp_names = Counter(
+        re.findall(r"`([a-z][a-z0-9_]*)`", mcp_text)
+    )
+    if documented_mcp_names != expected_mcp_names:
+        fail(
+            "documentation MCP tools differ from the matrix: "
+            f"expected={dict(sorted(expected_mcp_names.items()))}, "
+            f"got={dict(sorted(documented_mcp_names.items()))}"
+        )
+
+
+def validate_plugins(matrix):
+    records = matrix.get("plugins")
+    if not isinstance(records, list) or not records:
+        fail("matrix plugins must be a non-empty list")
+    names = [record.get("name") for record in records]
+    duplicates = sorted(name for name, count in Counter(names).items() if count > 1)
+    if duplicates:
+        fail(f"duplicate matrix plugins: {duplicates}")
+
+    claude_plugins = {
+        path.parent.parent.name
+        for path in ROOT_DIR.glob("plugins/*/.claude-plugin/plugin.json")
+    }
+    codex_plugins = {
+        path.parent.parent.name
+        for path in ROOT_DIR.glob("plugins/*/.codex-plugin/plugin.json")
+    }
+    marketplace = load_json(
+        ROOT_DIR / ".agents/plugins/marketplace.json", "Codex marketplace"
+    )
+    marketplace_entries = marketplace.get("plugins", [])
+    marketplace_name_list = [entry.get("name") for entry in marketplace_entries]
+    marketplace_duplicates = sorted(
+        name
+        for name, count in Counter(marketplace_name_list).items()
+        if count > 1
+    )
+    if marketplace_duplicates:
+        fail(f"duplicate Codex marketplace plugins: {marketplace_duplicates}")
+    marketplace_names = set(marketplace_name_list)
+    if marketplace_names != codex_plugins:
+        fail(
+            "Codex marketplace/manifests disagree: "
+            f"marketplace={sorted(marketplace_names)}, manifests={sorted(codex_plugins)}"
+        )
+    for entry in marketplace_entries:
+        expected_path = f"./plugins/{entry['name']}"
+        if entry.get("source") != {"source": "local", "path": expected_path}:
+            fail(f"invalid marketplace source for {entry['name']}: {entry.get('source')}")
+        manifest = load_json(
+            ROOT_DIR / f"plugins/{entry['name']}/.codex-plugin/plugin.json",
+            f"{entry['name']} Codex manifest",
+        )
+        if manifest.get("name") != entry["name"] or manifest.get("skills") != "./skills/":
+            fail(f"invalid Codex manifest identity or skill path for {entry['name']}")
+
+    if set(names) != claude_plugins:
+        fail(
+            "matrix plugin inventory differs from Claude manifests: "
+            f"matrix={sorted(names)}, manifests={sorted(claude_plugins)}"
+        )
+
+    supported_codex = set()
+    plugin_records = {}
+    for record in records:
+        name = record.get("name")
+        platforms = record.get("platforms")
+        if not isinstance(platforms, dict) or set(platforms) != PLATFORMS:
+            fail(f"plugin {name} must declare exactly {sorted(PLATFORMS)}")
+        if platforms["claude_code"] != {"status": "supported"}:
+            fail(f"plugin {name} must match its shipped Claude manifest")
+        codex = platforms["codex"]
+        if codex.get("status") == "supported":
+            if set(codex) != {"status"}:
+                fail(f"supported Codex plugin {name} has unexpected status fields")
+            supported_codex.add(name)
+        elif codex == {
+            "status": "unsupported",
+            "reason": "intentionally_claude_only",
+        }:
+            pass
+        else:
+            fail(f"invalid Codex plugin status for {name}: {codex}")
+        plugin_records[name] = record
+
+    if supported_codex != codex_plugins:
+        fail(
+            "matrix Codex support differs from marketplace/manifests: "
+            f"matrix={sorted(supported_codex)}, shipped={sorted(codex_plugins)}"
+        )
+    return plugin_records, supported_codex
+
+
+def validate_capabilities(matrix, plugin_records, supported_codex):
+    capabilities = matrix.get("capabilities")
+    if not isinstance(capabilities, list) or not capabilities:
+        fail("matrix capabilities must be a non-empty list")
+    identifiers = [capability.get("id") for capability in capabilities]
+    duplicates = sorted(
+        identifier
+        for identifier, count in Counter(identifiers).items()
+        if count > 1
+    )
+    if duplicates:
+        fail(f"duplicate capability ids: {duplicates}")
+
+    discovered_commands = relative_source_paths("plugins/*/commands/*.md")
+    discovered_skills = relative_source_paths("plugins/*/skills/*/SKILL.md")
+    covered_commands = []
+    covered_skills = []
+    declared_skill_names = []
+    mcp_tool_names = []
+
+    for capability in capabilities:
+        identifier = capability.get("id")
+        plugin = capability.get("plugin")
+        if plugin not in plugin_records:
+            fail(f"capability {identifier} references unknown plugin {plugin}")
+        if not isinstance(identifier, str) or not identifier.startswith(f"{plugin}."):
+            fail(f"capability id must start with {plugin}.: {identifier}")
+        if not isinstance(capability.get("summary"), str) or not capability["summary"]:
+            fail(f"capability {identifier} is missing a summary")
+
+        sources = capability.get("sources")
+        if not isinstance(sources, list) or not sources:
+            fail(f"capability {identifier} must declare source files")
+        source_kinds = []
+        skill_sources = []
+        for source in sources:
+            if not isinstance(source, dict) or set(source) != {"kind", "path"}:
+                fail(f"capability {identifier} has an invalid source mapping")
+            kind = source["kind"]
+            source_text = source["path"]
+            source_path = Path(source_text)
+            path = ROOT_DIR / source_path
+            if source_path.is_absolute() or ".." in source_path.parts:
+                fail(f"capability {identifier} has a non-relative source: {source_text}")
+            if not path.is_file():
+                fail(f"capability {identifier} source does not exist: {source_text}")
+            parts = Path(source_text).parts
+            if len(parts) < 2 or parts[0] != "plugins" or parts[1] != plugin:
+                fail(f"capability {identifier} source belongs to another plugin: {source_text}")
+            if kind == "command":
+                covered_commands.append(source_text)
+                if source_text not in discovered_commands:
+                    fail(f"capability {identifier} has an invalid command source: {source_text}")
+            elif kind == "skill":
+                covered_skills.append(source_text)
+                skill_sources.append(source_text)
+                if source_text not in discovered_skills:
+                    fail(f"capability {identifier} has an invalid skill source: {source_text}")
+            elif kind == "mcp_manifest":
+                if Path(source_text).name != ".mcp.json":
+                    fail(f"capability {identifier} has an invalid MCP source: {source_text}")
+            else:
+                fail(f"capability {identifier} has an invalid source kind: {kind}")
+            source_kinds.append(kind)
+
+        platforms = capability.get("platforms")
+        if not isinstance(platforms, dict) or set(platforms) != PLATFORMS:
+            fail(f"capability {identifier} must map exactly {sorted(PLATFORMS)}")
+        claude = platforms["claude_code"]
+        if "command" in source_kinds:
+            expected_claude_disposition = "command"
+        elif "skill" in source_kinds:
+            expected_claude_disposition = "skill"
+        else:
+            expected_claude_disposition = "mcp_tool"
+        if claude.get("disposition") != expected_claude_disposition:
+            fail(
+                f"capability {identifier} must use Claude disposition "
+                f"{expected_claude_disposition}"
+            )
+        claude_names = claude.get("names")
+        if not isinstance(claude_names, list) or not claude_names:
+            fail(f"capability {identifier} must declare Claude names")
+        if expected_claude_disposition == "command":
+            expected_names = sorted(
+                f"{plugin}:{Path(source['path']).stem}"
+                for source in sources
+                if source["kind"] == "command"
+            )
+            if sorted(claude_names) != expected_names:
+                fail(
+                    f"capability {identifier} Claude command names differ from sources: "
+                    f"expected {expected_names}, got {sorted(claude_names)}"
+                )
+
+        codex = platforms["codex"]
+        disposition = codex.get("disposition")
+        if disposition not in CODEX_DISPOSITIONS:
+            fail(f"capability {identifier} has invalid Codex disposition: {disposition}")
+        if skill_sources and disposition != "skill":
+            fail(f"Codex skill source in {identifier} is not classified as a skill")
+        if disposition == "skill":
+            if plugin not in supported_codex:
+                fail(f"unsupported Codex plugin {plugin} declares a skill")
+            if set(codex) != {"disposition", "name"}:
+                fail(f"capability {identifier} has invalid Codex skill fields")
+            if len(skill_sources) != 1:
+                fail(f"Codex skill capability {identifier} must own one skill source")
+            source_path = ROOT_DIR / skill_sources[0]
+            expected_name = f"{plugin}:{frontmatter_name(source_path)}"
+            if codex["name"] != expected_name:
+                fail(
+                    f"capability {identifier} Codex name differs from skill source: "
+                    f"expected {expected_name}, got {codex['name']}"
+                )
+            declared_skill_names.append(codex["name"])
+            if claude.get("disposition") == "skill" and claude_names != [expected_name]:
+                fail(
+                    f"capability {identifier} Claude skill name differs from source: "
+                    f"expected {[expected_name]}, got {claude_names}"
+                )
+        elif disposition == "mcp_tool":
+            if plugin not in supported_codex:
+                fail(f"unsupported Codex plugin {plugin} declares MCP tools")
+            if set(codex) != {"disposition", "names"}:
+                fail(f"capability {identifier} has invalid Codex MCP fields")
+            names = codex["names"]
+            if not isinstance(names, list) or not names:
+                fail(f"capability {identifier} must declare MCP tool names")
+            if source_kinds != ["mcp_manifest"]:
+                fail(
+                    f"capability {identifier} MCP tools must own only one MCP manifest"
+                )
+            invalid_names = sorted(
+                name
+                for name in names
+                if not re.fullmatch(r"mcp__[a-z0-9_-]+__[a-z][a-z0-9_]*", name)
+            )
+            if invalid_names:
+                fail(f"capability {identifier} has invalid MCP tool names: {invalid_names}")
+            manifest = load_json(
+                ROOT_DIR / f"plugins/{plugin}/.codex-plugin/plugin.json",
+                f"{plugin} Codex manifest",
+            )
+            if "mcpServers" not in manifest:
+                fail(f"capability {identifier} plugin manifest does not expose MCP")
+            if claude_names != names:
+                fail(
+                    f"capability {identifier} Claude and Codex MCP names differ: "
+                    f"Claude={claude_names}, Codex={names}"
+                )
+            mcp_tool_names.extend(names)
+        else:
+            expected_fields = {"disposition", "documentation"}
+            if plugin_records[plugin]["platforms"]["codex"].get("reason") != (
+                "intentionally_claude_only"
+            ):
+                expected_fields.add("issue")
+            if set(codex) != expected_fields:
+                fail(f"capability {identifier} has invalid unsupported fields")
+            validate_documentation_reference(codex["documentation"])
+            if "issue" in codex and not ISSUE_PATTERN.fullmatch(codex["issue"]):
+                fail(f"capability {identifier} has invalid issue reference")
+            if skill_sources:
+                fail(f"unsupported capability {identifier} owns a Codex skill source")
+
+    for label, discovered, covered in (
+        ("command", discovered_commands, covered_commands),
+        ("skill", discovered_skills, covered_skills),
+    ):
+        counter = Counter(covered)
+        duplicate_sources = sorted(path for path, count in counter.items() if count > 1)
+        if duplicate_sources:
+            fail(f"duplicate {label} source coverage: {duplicate_sources}")
+        missing = sorted(discovered - set(covered))
+        extra = sorted(set(covered) - discovered)
+        if missing or extra:
+            fail(f"incomplete {label} source coverage: missing={missing}, extra={extra}")
+
+    duplicate_skill_names = sorted(
+        name for name, count in Counter(declared_skill_names).items() if count > 1
+    )
+    if duplicate_skill_names:
+        fail(f"duplicate declared Codex skill names: {duplicate_skill_names}")
+    duplicate_mcp_names = sorted(
+        name for name, count in Counter(mcp_tool_names).items() if count > 1
+    )
+    if duplicate_mcp_names:
+        fail(f"duplicate declared Codex MCP tool names: {duplicate_mcp_names}")
+    return (
+        len(discovered_commands),
+        len(plugin_records),
+        len(declared_skill_names),
+        len(supported_codex),
+        len(mcp_tool_names),
+    )
+
+
+def main():
+    matrix = load_json(MATRIX_PATH, "canonical platform capability matrix")
+    if matrix.get("schema_version") != 1:
+        fail(f"unsupported matrix schema_version: {matrix.get('schema_version')}")
+    if set(matrix) != {"schema_version", "plugins", "capabilities"}:
+        fail(f"unexpected top-level matrix fields: {sorted(matrix)}")
+
+    plugin_records, supported_codex = validate_plugins(matrix)
+    expected_counts = validate_capabilities(matrix, plugin_records, supported_codex)
+    validate_counts(README_PATH, expected_counts)
+    validate_documentation(matrix, expected_counts)
+    readme = README_PATH.read_text(encoding="utf-8")
+    if "[platform capability matrix](docs/platform-capabilities.md)" not in readme:
+        fail("README.md does not link the platform capability matrix")
+
+    print(
+        "Platform capability matrix passed: "
+        f"{expected_counts[0]} commands, {expected_counts[2]} Codex skills, "
+        f"{expected_counts[4]} Codex MCP tools"
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/test-tailwind-mcp-server.mjs
+++ b/scripts/test-tailwind-mcp-server.mjs
@@ -6,19 +6,11 @@ import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 
 const root = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+const capabilityMatrixPath = resolve(root, "docs/platform-capabilities.json");
 const claudeManifestPath = resolve(root, "plugins/tailwind/.claude-plugin/plugin.json");
 const mcpManifestPath = resolve(root, "plugins/tailwind/.mcp.json");
 const protocolVersion = "2026-07-28";
 const legacyProtocolVersion = "2024-11-05";
-const requiredTools = [
-  "search_tailwind_docs",
-  "get_tailwind_utilities",
-  "get_tailwind_colors",
-  "convert_css_to_tailwind",
-  "generate_component_template",
-  "install_tailwind",
-  "get_tailwind_config_guide",
-];
 
 function assert(condition, message) {
   if (!condition) {
@@ -30,10 +22,30 @@ async function readJson(path) {
   return JSON.parse(await readFile(path, "utf8"));
 }
 
-const [claudeManifest, mcpManifest] = await Promise.all([
+const [capabilityMatrix, claudeManifest, mcpManifest] = await Promise.all([
+  readJson(capabilityMatrixPath),
   readJson(claudeManifestPath),
   readJson(mcpManifestPath),
 ]);
+const toolCapability = capabilityMatrix.capabilities?.find(
+  (capability) => capability.id === "tailwind.supplementary-mcp-tools",
+);
+const toolPrefix = "mcp__tailwindcss__";
+const declaredToolNames = toolCapability?.platforms?.codex?.names;
+
+assert(
+  Array.isArray(declaredToolNames) && declaredToolNames.length > 0,
+  "capability matrix is missing the Tailwind MCP tool surface",
+);
+assert(
+  declaredToolNames.every((name) => name.startsWith(toolPrefix)),
+  "capability matrix contains a non-Tailwind MCP tool name",
+);
+const requiredTools = declaredToolNames.map((name) => name.slice(toolPrefix.length));
+assert(
+  new Set(requiredTools).size === requiredTools.length,
+  "capability matrix contains duplicate Tailwind MCP tool names",
+);
 const claudeConfig = claudeManifest.mcpServers?.tailwindcss;
 const serverConfig = mcpManifest.tailwindcss;
 
@@ -204,13 +216,23 @@ try {
   );
   assert(toolsResponse.result?.tools, "tools/list did not return tools");
 
-  const advertisedTools = new Set(
-    toolsResponse.result.tools.map((tool) => tool.name),
+  const advertisedToolNames = toolsResponse.result.tools.map((tool) => tool.name);
+  const advertisedTools = new Set(advertisedToolNames);
+  assert(
+    advertisedTools.size === advertisedToolNames.length,
+    "tools/list returned duplicate tool names",
   );
   const missingTools = requiredTools.filter((tool) => !advertisedTools.has(tool));
+  const unexpectedTools = [...advertisedTools].filter(
+    (tool) => !requiredTools.includes(tool),
+  );
   assert(
     missingTools.length === 0,
     `tools/list is missing required tools: ${missingTools.join(", ")}`,
+  );
+  assert(
+    unexpectedTools.length === 0,
+    `tools/list returned undeclared tools: ${unexpectedTools.join(", ")}`,
   );
 
   process.stdout.write(


### PR DESCRIPTION
## Summary
- declare a source-backed platform capability contract for every shipped command, skill, and optional MCP tool
- install all six Codex plugins in isolated state and enforce the exact qualified skill surface, aliases, resolver errors, duplicates, and documentation counts
- validate user-facing capability documentation and pinned Tailwind tool discovery against the same canonical contract

Fixes #331

## Test Plan
- `python3 scripts/test-platform-capabilities.py`
- `node scripts/test-tailwind-mcp-server.mjs`
- `python3 scripts/test-codex-skill-names.py`
- authoritative validation command from `gate.run` in `detent.yaml`