### PR TITLE
fix(workflow): bound PR check terminal wait

### DIFF
--- a/plugins/go-workflow/lib/github-rest.sh
+++ b/plugins/go-workflow/lib/github-rest.sh
@@ -4,6 +4,7 @@ GITHUB_CHECKS_FAILED=1
 GITHUB_CHECKS_REGISTRATION_TIMEOUT=2
 GITHUB_CHECKS_API_ERROR=3
 GITHUB_CHECKS_HEAD_SHIFT=4
+GITHUB_CHECKS_TERMINAL_TIMEOUT=5
 
 github_pr() {
   local pr_number="${1:?PR number is required}"
@@ -119,6 +120,7 @@ github_watch_pr_checks() {
   local registration_attempts="${GITHUB_CHECK_REGISTRATION_ATTEMPTS:-12}"
   local stability_polls="${GITHUB_CHECK_STABILITY_POLLS:-2}"
   local poll_seconds="${GITHUB_CHECK_POLL_SECONDS:-10}"
+  local terminal_attempts="${GITHUB_CHECK_TERMINAL_ATTEMPTS:-60}"
   local pr_json
   local current_sha
   local snapshot=""
@@ -130,6 +132,8 @@ github_watch_pr_checks() {
   local signature
   local stable_signature=""
   local stable_count=0
+  local terminal_attempt=1
+  local pending_checks
 
   if ! pr_json=$(github_pr "$pr_number"); then
     return "$GITHUB_CHECKS_API_ERROR"
@@ -179,6 +183,27 @@ github_watch_pr_checks() {
       stable_count=0
     fi
 
+    if [ "$terminal_attempt" -ge "$terminal_attempts" ]; then
+      if ! pr_json=$(github_pr "$pr_number"); then
+        return "$GITHUB_CHECKS_API_ERROR"
+      fi
+      current_sha=$(jq -er '.head.sha' <<< "$pr_json") || return "$GITHUB_CHECKS_API_ERROR"
+      if [ "$current_sha" != "$expected_sha" ]; then
+        return "$GITHUB_CHECKS_HEAD_SHIFT"
+      fi
+
+      pending_checks=$(jq -r '.items[] | select(.terminal == false) | "\(.name): \(.state)"' <<< "$snapshot") || return "$GITHUB_CHECKS_API_ERROR"
+      printf 'Timed out waiting for PR #%s checks at %s to reach a stable terminal state after %s polls.\n' \
+        "$pr_number" "$expected_sha" "$terminal_attempts" >&2
+      if [ -n "$pending_checks" ]; then
+        printf 'Pending checks:\n%s\n' "$pending_checks" >&2
+      else
+        printf 'No checks are pending, but the terminal check set did not stabilize.\n' >&2
+      fi
+      return "$GITHUB_CHECKS_TERMINAL_TIMEOUT"
+    fi
+
+    terminal_attempt=$((terminal_attempt + 1))
     sleep "$poll_seconds"
     if ! snapshot=$(github_check_snapshot "$expected_sha"); then
       return "$GITHUB_CHECKS_API_ERROR"

--- a/plugins/go-workflow/lib/ship/ci-watch.md
+++ b/plugins/go-workflow/lib/ship/ci-watch.md
@@ -31,10 +31,11 @@ echo "Watching CI for commit: $HEAD_SHA"
 
 ## 10b. Watch every check source for the correct SHA
 
-Use the shared watcher. It provides the bounded registration window, combines
-check runs with legacy commit statuses, waits through a stability window for
-late registrations, aggregates every terminal failure, and verifies the PR
-head after watching.
+Use the shared watcher. It bounds both registration and terminal polling,
+combines check runs with legacy commit statuses, waits through a stability
+window for late registrations, aggregates every terminal failure, and verifies
+the PR head after watching. `GITHUB_CHECK_TERMINAL_ATTEMPTS` configures the
+post-registration poll limit.
 
 ```bash
 if CI_SNAPSHOT=$(cd "$WORKTREE_PATH" && github_watch_pr_checks "$PR_NUM" "$HEAD_SHA"); then
@@ -60,6 +61,9 @@ case "$CI_STATUS" in
   "$GITHUB_CHECKS_HEAD_SHIFT")
     WORKFLOW_REASON="ci-head-shift"
     ;;
+  "$GITHUB_CHECKS_TERMINAL_TIMEOUT")
+    WORKFLOW_REASON="ci-terminal-timeout"
+    ;;
   *)
     WORKFLOW_REASON="ci-watch-unknown-error"
     ;;
@@ -69,9 +73,11 @@ esac
 On status 0, persist `has_ci: true`, clear `ci_skip_reason`, display
 `CI_SNAPSHOT`, and continue to Step 11. On `GITHUB_CHECKS_FAILED`, display the
 full snapshot and continue to Step 10e. On `GITHUB_CHECKS_HEAD_SHIFT`, continue
-to Step 10d. On `GITHUB_CHECKS_API_ERROR` or an unknown status, follow **Hard
-Invariant Failure** immediately with the supplied reason. Never treat an API
-failure or head shift as passing CI.
+to Step 10d. On `GITHUB_CHECKS_TERMINAL_TIMEOUT`, retain the pending check
+names and states printed by the helper and stop incomplete with
+`ci-terminal-timeout`. On `GITHUB_CHECKS_API_ERROR` or an unknown status,
+follow **Hard Invariant Failure** immediately with the supplied reason. Never
+treat a timeout, API failure, or head shift as passing CI.
 
 On `GITHUB_CHECKS_REGISTRATION_TIMEOUT`, determine whether any workflow can
 produce a check for this PR before stopping:

--- a/scripts/test-github-rest.sh
+++ b/scripts/test-github-rest.sh
@@ -32,6 +32,16 @@ assert_status() {
   fi
 }
 
+assert_contains() {
+  local haystack="$1"
+  local needle="$2"
+  local label="$3"
+
+  if [[ "$haystack" != *"$needle"* ]]; then
+    fail "$label (missing '$needle')"
+  fi
+}
+
 printf '=== GitHub REST Helper Tests ===\n'
 
 if [ ! -f "$REST_LIB" ]; then
@@ -166,6 +176,40 @@ failure_status=$?
 set -e
 assert_status "$GITHUB_CHECKS_FAILED" "$failure_status" "terminal check failures use the failure status"
 assert_equal "2" "$(printf '%s' "$failure_output" | jq '[.items[] | select(.terminal and (.successful | not))] | length')" "all terminal failures are reported together"
+
+terminal_wait_state=$(mktemp "${TMPDIR:-/tmp}/github-rest-terminal-wait-XXXXXX")
+printf '0\n' > "$terminal_wait_state"
+set +e
+terminal_timeout_output=$(
+  gh() {
+    if [[ "$*" == *"pulls/41"* ]]; then
+      printf '%s\n' '{"number":41,"head":{"sha":"head-sha"}}'
+    elif [[ "$*" == *"check-runs"* ]]; then
+      local count
+      count=$(cat "$terminal_wait_state")
+      count=$((count + 1))
+      printf '%s\n' "$count" > "$terminal_wait_state"
+      if [ "$count" -le 2 ]; then
+        printf '%s\n' '[{"check_runs":[{"id":1,"name":"unit","status":"in_progress","conclusion":null,"app":{"slug":"actions"}}]}]'
+      else
+        return 1
+      fi
+    elif [[ "$*" == *"/status"* ]]; then
+      printf '%s\n' '{"statuses":[{"id":7,"context":"legacy","state":"pending"}]}'
+    else
+      return 1
+    fi
+  }
+  sleep() { :; }
+  GITHUB_CHECK_TERMINAL_ATTEMPTS=2 github_watch_pr_checks 41 "head-sha" 2>&1
+)
+terminal_timeout_status=$?
+set -e
+rm -f "$terminal_wait_state"
+assert_equal "5" "${GITHUB_CHECKS_TERMINAL_TIMEOUT:-}" "terminal wait timeout exposes a distinct status"
+assert_status 5 "$terminal_timeout_status" "permanently pending checks hit the terminal wait bound"
+assert_contains "$terminal_timeout_output" "unit: in_progress" "terminal wait timeout reports the pending check-run"
+assert_contains "$terminal_timeout_output" "legacy: pending" "terminal wait timeout reports the pending commit status"
 
 late_state=$(mktemp "${TMPDIR:-/tmp}/github-rest-late-XXXXXX")
 printf '0\n' > "$late_state"


### PR DESCRIPTION
## Summary

- bound post-registration PR check polling with a configurable maximum and a distinct terminal-timeout result
- report pending check names and states while preserving registration, API, head-shift, stability, and terminal-failure behavior
- teach the ship CI workflow to stop incomplete with a specific terminal-timeout reason

## Test Plan

- `bash scripts/test-github-rest.sh`
- authoritative `gate.run` command from `detent.yaml`
- `shellcheck --severity=error plugins/go-workflow/lib/github-rest.sh scripts/test-github-rest.sh`

Fixes #356