### PR TITLE
fix(address-review): register Codex connector re-review

### DIFF
--- a/plugins/go-workflow/README.md
+++ b/plugins/go-workflow/README.md
@@ -104,7 +104,7 @@ re-review only when discovered among the pull request's actual reviewers.
 - `chatgpt-codex-connector[bot]` → `@codex review`
 - `coderabbitai[bot]` → `@coderabbitai full review`
 - `greptileai` → `@greptileai`
-- `copilot-pull-request-review[bot]` → Re-request through GitHub Reviewers
+- `copilot-pull-request-review[bot]` → Manual re-request through GitHub Reviewers
 
 **To disable auto bot re-review**, add to your project's CLAUDE.md:
 ```markdown

--- a/plugins/go-workflow/README.md
+++ b/plugins/go-workflow/README.md
@@ -97,13 +97,14 @@ automatically:
 
 #### Auto Bot Re-review
 
-When bot reviewers (Codex, CodeRabbit, Greptile, etc.) leave feedback, the skill automatically requests re-review by posting `@bot review` comments.
+When supported bot reviewers leave feedback, the skill automatically requests
+re-review only when discovered among the pull request's actual reviewers.
 
 **Supported bots:**
-- `codex` → `@codex review`
-- `coderabbitai` → `@coderabbitai review`
-- `greptileai` → `@greptileai review`
-- `copilot` → Added via GitHub Reviewers
+- `chatgpt-codex-connector[bot]` → `@codex review`
+- `coderabbitai[bot]` → `@coderabbitai full review`
+- `greptileai` → `@greptileai`
+- `copilot-pull-request-review[bot]` → Re-request through GitHub Reviewers
 
 **To disable auto bot re-review**, add to your project's CLAUDE.md:
 ```markdown

--- a/plugins/go-workflow/skills/address-review/bot-registry.md
+++ b/plugins/go-workflow/skills/address-review/bot-registry.md
@@ -6,7 +6,7 @@ Reference table of known review bots. Used ONLY for matching against bots actual
 
 | Login | Approval Signal | Has Issues Signal | Re-review Trigger |
 |---|---|---|---|
-| `chatgpt-codex-connector[bot]` | Newest `COMMENTED` review has `commit_id == PR_HEAD_SHA` and no unresolved inline comments from the connector | Newest `COMMENTED` review has `commit_id == PR_HEAD_SHA` and unresolved inline comments from the connector | `@codex review` |
+| `chatgpt-codex-connector[bot]` | Current-head `codex-pull-request-review-summary` issue comment has a connector-authored `+1` reaction and no unresolved inline comments from the connector | Current-head summary has unresolved inline comments from the connector | `@codex review` |
 | `coderabbitai[bot]` | Formal `APPROVED` review state (requires `request_changes_workflow` in `.coderabbit.yaml`) | `CHANGES_REQUESTED` review with inline comments | `@coderabbitai full review` |
 | `greptileai` | Greptile status check passes + no inline comments posted | Inline comments on specific file changes | `@greptileai` |
 | `copilot-pull-request-review[bot]` | `COMMENTED` review with no inline file comments ("did not comment on any files") | `COMMENTED` review with inline suggestions | Re-request review button in PR sidebar _(no `@` mention trigger)_ |
@@ -14,7 +14,16 @@ Reference table of known review bots. Used ONLY for matching against bots actual
 
 ## Bot Detection Logic
 
-- **Codex connector**: Inspect REST formal reviews and GraphQL review threads only when discovered as `chatgpt-codex-connector[bot]`. Select the newest connector review whose `commit_id == PR_HEAD_SHA`. Its `COMMENTED` review is approval when it has no unresolved inline comments from the connector; unresolved inline comments are actionable findings. A connector review for any other commit is stale and cannot satisfy current-head approval. Re-trigger with `@codex review`.
+- **Codex connector**: Only when discovered as `chatgpt-codex-connector[bot]`,
+  select its newest REST issue comment containing
+  `codex-pull-request-review-summary`. Confirm the commit displayed in that
+  summary is the prefix of `PR_HEAD_SHA`, then load
+  `repos/$REPO_SLUG/issues/comments/$COMMENT_ID/reactions`. A
+  connector-authored `+1` reaction plus no unresolved inline comments from the
+  connector is current-head approval. Unresolved connector inline comments
+  while that summary targets `PR_HEAD_SHA` are actionable findings. A running
+  summary, missing `+1`, or summary for another commit is pending or stale and
+  cannot satisfy approval. Re-trigger with `@codex review`.
 - **CodeRabbit**: Only bot that uses formal GitHub review states. Use `github_pr_reviews "$PR_NUM"`, select the newest `coderabbitai[bot]` review by `submitted_at`, and treat `APPROVED` as done.
 - **Greptile**: Uses a **status check** (not review states). Use `github_check_snapshot "$PR_HEAD_SHA"`; a successful Greptile item plus no new inline comments means Greptile is satisfied.
 - **Copilot**: Always posts `COMMENTED` formal reviews (never `APPROVED` or `CHANGES_REQUESTED`). Inspect its REST formal reviews. If its newest body says it "did not comment on any files" or has no inline comments, it found no issues. It cannot be re-triggered via comment; use the re-request review button in the GitHub PR sidebar.

--- a/plugins/go-workflow/skills/address-review/bot-registry.md
+++ b/plugins/go-workflow/skills/address-review/bot-registry.md
@@ -6,6 +6,7 @@ Reference table of known review bots. Used ONLY for matching against bots actual
 
 | Login | Approval Signal | Has Issues Signal | Re-review Trigger |
 |---|---|---|---|
+| `chatgpt-codex-connector[bot]` | Newest `COMMENTED` review has `commit_id == PR_HEAD_SHA` and no unresolved inline comments from the connector | Newest `COMMENTED` review has `commit_id == PR_HEAD_SHA` and unresolved inline comments from the connector | `@codex review` |
 | `coderabbitai[bot]` | Formal `APPROVED` review state (requires `request_changes_workflow` in `.coderabbit.yaml`) | `CHANGES_REQUESTED` review with inline comments | `@coderabbitai full review` |
 | `greptileai` | Greptile status check passes + no inline comments posted | Inline comments on specific file changes | `@greptileai` |
 | `copilot-pull-request-review[bot]` | `COMMENTED` review with no inline file comments ("did not comment on any files") | `COMMENTED` review with inline suggestions | Re-request review button in PR sidebar _(no `@` mention trigger)_ |
@@ -13,6 +14,7 @@ Reference table of known review bots. Used ONLY for matching against bots actual
 
 ## Bot Detection Logic
 
+- **Codex connector**: Inspect REST formal reviews and GraphQL review threads only when discovered as `chatgpt-codex-connector[bot]`. Select the newest connector review whose `commit_id == PR_HEAD_SHA`. Its `COMMENTED` review is approval when it has no unresolved inline comments from the connector; unresolved inline comments are actionable findings. A connector review for any other commit is stale and cannot satisfy current-head approval. Re-trigger with `@codex review`.
 - **CodeRabbit**: Only bot that uses formal GitHub review states. Use `github_pr_reviews "$PR_NUM"`, select the newest `coderabbitai[bot]` review by `submitted_at`, and treat `APPROVED` as done.
 - **Greptile**: Uses a **status check** (not review states). Use `github_check_snapshot "$PR_HEAD_SHA"`; a successful Greptile item plus no new inline comments means Greptile is satisfied.
 - **Copilot**: Always posts `COMMENTED` formal reviews (never `APPROVED` or `CHANGES_REQUESTED`). Inspect its REST formal reviews. If its newest body says it "did not comment on any files" or has no inline comments, it found no issues. It cannot be re-triggered via comment; use the re-request review button in the GitHub PR sidebar.
@@ -106,6 +108,9 @@ fi
 3. If it matches but has no trigger command (e.g., `copilot-pull-request-review[bot]`) → skip, log: "Skipping <login>: no re-trigger mechanism available"
 4. If it's on the ignore list (`github-actions[bot]`, `dependabot[bot]`, etc.) → skip silently
 5. If it doesn't match any registry entry and looks like a bot (contains `[bot]` or `bot` suffix) → skip, log: "Skipping unknown bot <login>: no trigger command known"
+
+For `chatgpt-codex-connector[bot]`, this lookup produces `@codex review` only
+when discovered in the actual reviewer list and the Step 3 feedback list.
 
 **Never iterate the Bot Registry to find bots. Always iterate actual reviewers and look up triggers.**
 

--- a/plugins/go-workflow/skills/address-review/bot-registry.md
+++ b/plugins/go-workflow/skills/address-review/bot-registry.md
@@ -53,6 +53,12 @@ FORMAL_REVIEWS=$(cd "$WORKTREE_PATH" && github_pr_reviews "$PR_NUM") || {
 }
 FORMAL_REVIEWERS=$(jq -r '.[].user.login // empty' <<< "$FORMAL_REVIEWS")
 
+ISSUE_COMMENT_PAGES=$(gh api --paginate --slurp "repos/$REPO_SLUG/issues/$PR_NUM/comments?per_page=100") || {
+  WORKFLOW_RESULT=INCOMPLETE
+  WORKFLOW_REASON=issue-comment-api-failure
+}
+ISSUE_COMMENT_REVIEWERS=$(jq -r '.[][] | .user.login // empty' <<< "$ISSUE_COMMENT_PAGES")
+
 THREAD_RESULT=$(cd "$WORKTREE_PATH" && gh api graphql -f query='
   query($owner: String!, $repo: String!, $pr: Int!) {
     repository(owner: $owner, name: $repo) {
@@ -77,18 +83,25 @@ THREAD_REVIEWERS=$(jq -r '
   .data.repository.pullRequest.reviewThreads.nodes[]?.comments.nodes[]?.author.login // empty
 ' <<< "$THREAD_RESULT")
 
-ACTUAL_REVIEWERS=$(printf '%s\n%s\n' "$FORMAL_REVIEWERS" "$THREAD_REVIEWERS" | jq -Rsc '
+if printf '%s\n' "$ISSUE_COMMENT_REVIEWERS" | grep -qx 'chatgpt-codex-connector\[bot\]'; then
+  THREAD_REVIEWERS=$(printf '%s\n' "$THREAD_REVIEWERS" | sed 's/^chatgpt-codex-connector$/chatgpt-codex-connector[bot]/')
+fi
+
+ACTUAL_REVIEWERS=$(printf '%s\n%s\n%s\n' "$FORMAL_REVIEWERS" "$ISSUE_COMMENT_REVIEWERS" "$THREAD_REVIEWERS" | jq -Rsc '
   split("\n") | map(select(length > 0)) | unique | .[]
 ')
 
 echo "Actual reviewers on PR: $ACTUAL_REVIEWERS"
 ```
 
-If PR metadata, formal reviews, or review threads cannot be loaded, follow the
+If PR metadata, formal reviews, issue comments, or review threads cannot be loaded, follow the
 top-level **Hard Invariant Failure** procedure. An API failure must not produce
 an empty reviewer set.
 
-Cross-reference this list with the Step 3 reviewer list. Only proceed with reviewers that appear in BOTH.
+Cross-reference this list with the Step 3 reviewer list. When the canonical
+Codex issue-comment author was discovered, treat its GraphQL thread alias
+`chatgpt-codex-connector` as `chatgpt-codex-connector[bot]` in both lists.
+Only proceed with reviewers that appear in both normalized lists.
 
 If the reviewer list is empty (no reviewers left feedback), skip this entire step.
 

--- a/plugins/go-workflow/skills/address-review/setup-and-discovery.md
+++ b/plugins/go-workflow/skills/address-review/setup-and-discovery.md
@@ -51,6 +51,12 @@ FORMAL_REVIEWS=$(cd "$WORKTREE_PATH" && github_pr_reviews "$PR_NUM") || {
 }
 FORMAL_REVIEW_AUTHORS=$(jq -r '.[].user.login // empty' <<< "$FORMAL_REVIEWS")
 
+ISSUE_COMMENT_PAGES=$(gh api --paginate --slurp "repos/$REPO_SLUG/issues/$PR_NUM/comments?per_page=100") || {
+  WORKFLOW_RESULT=INCOMPLETE
+  WORKFLOW_REASON=issue-comment-api-failure
+}
+ISSUE_COMMENT_AUTHORS=$(jq -r '.[][] | .user.login // empty' <<< "$ISSUE_COMMENT_PAGES")
+
 THREAD_RESULT=$(cd "$WORKTREE_PATH" && gh api graphql -f query='
   query($owner: String!, $repo: String!, $pr: Int!) {
     repository(owner: $owner, name: $repo) {
@@ -75,14 +81,18 @@ THREAD_REVIEW_AUTHORS=$(jq -r '
   .data.repository.pullRequest.reviewThreads.nodes[]?.comments.nodes[]?.author.login // empty
 ' <<< "$THREAD_RESULT")
 
-BOT_AUTHORS=$(printf '%s\n%s\n' "$FORMAL_REVIEW_AUTHORS" "$THREAD_REVIEW_AUTHORS" | jq -Rsc '
+if printf '%s\n' "$ISSUE_COMMENT_AUTHORS" | grep -qx 'chatgpt-codex-connector\[bot\]'; then
+  THREAD_REVIEW_AUTHORS=$(printf '%s\n' "$THREAD_REVIEW_AUTHORS" | sed 's/^chatgpt-codex-connector$/chatgpt-codex-connector[bot]/')
+fi
+
+BOT_AUTHORS=$(printf '%s\n%s\n%s\n' "$FORMAL_REVIEW_AUTHORS" "$ISSUE_COMMENT_AUTHORS" "$THREAD_REVIEW_AUTHORS" | jq -Rsc '
   split("\n") | map(select(length > 0)) | unique | .[]
 ')
 
 echo "All unique authors on PR: $BOT_AUTHORS"
 ```
 
-Treat a REST review failure or GraphQL review-thread failure as a hard
+Treat a REST review, REST issue-comment, or GraphQL review-thread failure as a hard
 invariant failure. Do not interpret missing API data as an empty reviewer list.
 
 Match authors against the bot registry (read `bot-registry.md` for the full table). Display discovered bots or "No review bots detected on this PR." If no bots found: complete fix cycle (Steps 1-11) but skip Step 12.

--- a/scripts/test-commands.sh
+++ b/scripts/test-commands.sh
@@ -158,6 +158,23 @@ file_contains() {
   awk -v needle="$needle" 'index($0, needle) { found = 1 } END { exit found ? 0 : 1 }' "$file"
 }
 
+ADDRESS_REVIEW_BOT_REGISTRY="$ROOT_DIR/plugins/go-workflow/skills/address-review/bot-registry.md"
+GO_WORKFLOW_README="$ROOT_DIR/plugins/go-workflow/README.md"
+
+echo -n "Address-review registers current-head Codex connector re-review... "
+if ! file_contains '`chatgpt-codex-connector[bot]`' "$ADDRESS_REVIEW_BOT_REGISTRY" ||
+   ! file_contains '`@codex review`' "$ADDRESS_REVIEW_BOT_REGISTRY" ||
+   ! file_contains 'commit_id == PR_HEAD_SHA' "$ADDRESS_REVIEW_BOT_REGISTRY" ||
+   ! file_contains 'no unresolved inline comments' "$ADDRESS_REVIEW_BOT_REGISTRY" ||
+   ! file_contains 'unresolved inline comments' "$ADDRESS_REVIEW_BOT_REGISTRY" ||
+   ! file_contains 'only when discovered' "$GO_WORKFLOW_README" ||
+   ! file_contains '`chatgpt-codex-connector[bot]`' "$GO_WORKFLOW_README"; then
+  echo "FAIL (Codex connector detection, trigger, or signal contract missing)"
+  ERRORS=$((ERRORS + 1))
+else
+  echo "OK"
+fi
+
 echo -n "Shared skill resources use the cross-platform plugin-root contract... "
 GO_WORKFLOW_SKILLS="$ROOT_DIR/plugins/go-workflow/skills"
 GO_WORKFLOW_SKILL_RESOURCES=(

--- a/scripts/test-commands.sh
+++ b/scripts/test-commands.sh
@@ -160,16 +160,12 @@ file_contains() {
 
 ADDRESS_REVIEW_BOT_REGISTRY="$ROOT_DIR/plugins/go-workflow/skills/address-review/bot-registry.md"
 GO_WORKFLOW_README="$ROOT_DIR/plugins/go-workflow/README.md"
+CODEX_CONNECTOR_REGISTRY_ROW='| `chatgpt-codex-connector[bot]` | Current-head `codex-pull-request-review-summary` issue comment has a connector-authored `+1` reaction and no unresolved inline comments from the connector | Current-head summary has unresolved inline comments from the connector | `@codex review` |'
 
 echo -n "Address-review registers current-head Codex connector re-review... "
-if ! file_contains '`chatgpt-codex-connector[bot]`' "$ADDRESS_REVIEW_BOT_REGISTRY" ||
-   ! file_contains '`@codex review`' "$ADDRESS_REVIEW_BOT_REGISTRY" ||
-   ! file_contains 'codex-pull-request-review-summary' "$ADDRESS_REVIEW_BOT_REGISTRY" ||
+if ! file_contains "$CODEX_CONNECTOR_REGISTRY_ROW" "$ADDRESS_REVIEW_BOT_REGISTRY" ||
    ! file_contains 'PR_HEAD_SHA' "$ADDRESS_REVIEW_BOT_REGISTRY" ||
-   ! file_contains 'reactions' "$ADDRESS_REVIEW_BOT_REGISTRY" ||
-   ! file_contains 'connector-authored `+1`' "$ADDRESS_REVIEW_BOT_REGISTRY" ||
-   ! file_contains 'no unresolved inline comments' "$ADDRESS_REVIEW_BOT_REGISTRY" ||
-   ! file_contains 'unresolved inline comments' "$ADDRESS_REVIEW_BOT_REGISTRY" ||
+   ! file_contains 'repos/$REPO_SLUG/issues/comments/$COMMENT_ID/reactions' "$ADDRESS_REVIEW_BOT_REGISTRY" ||
    ! file_contains 'only when discovered' "$GO_WORKFLOW_README" ||
    ! file_contains '`chatgpt-codex-connector[bot]`' "$GO_WORKFLOW_README"; then
   echo "FAIL (Codex connector detection, trigger, or signal contract missing)"

--- a/scripts/test-commands.sh
+++ b/scripts/test-commands.sh
@@ -159,6 +159,7 @@ file_contains() {
 }
 
 ADDRESS_REVIEW_BOT_REGISTRY="$ROOT_DIR/plugins/go-workflow/skills/address-review/bot-registry.md"
+ADDRESS_REVIEW_DISCOVERY="$ROOT_DIR/plugins/go-workflow/skills/address-review/setup-and-discovery.md"
 GO_WORKFLOW_README="$ROOT_DIR/plugins/go-workflow/README.md"
 CODEX_CONNECTOR_REGISTRY_ROW='| `chatgpt-codex-connector[bot]` | Current-head `codex-pull-request-review-summary` issue comment has a connector-authored `+1` reaction and no unresolved inline comments from the connector | Current-head summary has unresolved inline comments from the connector | `@codex review` |'
 
@@ -166,8 +167,13 @@ echo -n "Address-review registers current-head Codex connector re-review... "
 if ! file_contains "$CODEX_CONNECTOR_REGISTRY_ROW" "$ADDRESS_REVIEW_BOT_REGISTRY" ||
    ! file_contains 'PR_HEAD_SHA' "$ADDRESS_REVIEW_BOT_REGISTRY" ||
    ! file_contains 'repos/$REPO_SLUG/issues/comments/$COMMENT_ID/reactions' "$ADDRESS_REVIEW_BOT_REGISTRY" ||
+   ! file_contains 'ISSUE_COMMENT_AUTHORS' "$ADDRESS_REVIEW_DISCOVERY" ||
+   ! file_contains 'chatgpt-codex-connector[bot]' "$ADDRESS_REVIEW_DISCOVERY" ||
+   ! file_contains 'chatgpt-codex-connector' "$ADDRESS_REVIEW_DISCOVERY" ||
+   ! file_contains 'ISSUE_COMMENT_REVIEWERS' "$ADDRESS_REVIEW_BOT_REGISTRY" ||
    ! file_contains 'only when discovered' "$GO_WORKFLOW_README" ||
-   ! file_contains '`chatgpt-codex-connector[bot]`' "$GO_WORKFLOW_README"; then
+   ! file_contains '`chatgpt-codex-connector[bot]`' "$GO_WORKFLOW_README" ||
+   ! file_contains 'Manual re-request through GitHub Reviewers' "$GO_WORKFLOW_README"; then
   echo "FAIL (Codex connector detection, trigger, or signal contract missing)"
   ERRORS=$((ERRORS + 1))
 else

--- a/scripts/test-commands.sh
+++ b/scripts/test-commands.sh
@@ -164,7 +164,10 @@ GO_WORKFLOW_README="$ROOT_DIR/plugins/go-workflow/README.md"
 echo -n "Address-review registers current-head Codex connector re-review... "
 if ! file_contains '`chatgpt-codex-connector[bot]`' "$ADDRESS_REVIEW_BOT_REGISTRY" ||
    ! file_contains '`@codex review`' "$ADDRESS_REVIEW_BOT_REGISTRY" ||
-   ! file_contains 'commit_id == PR_HEAD_SHA' "$ADDRESS_REVIEW_BOT_REGISTRY" ||
+   ! file_contains 'codex-pull-request-review-summary' "$ADDRESS_REVIEW_BOT_REGISTRY" ||
+   ! file_contains 'PR_HEAD_SHA' "$ADDRESS_REVIEW_BOT_REGISTRY" ||
+   ! file_contains 'reactions' "$ADDRESS_REVIEW_BOT_REGISTRY" ||
+   ! file_contains 'connector-authored `+1`' "$ADDRESS_REVIEW_BOT_REGISTRY" ||
    ! file_contains 'no unresolved inline comments' "$ADDRESS_REVIEW_BOT_REGISTRY" ||
    ! file_contains 'unresolved inline comments' "$ADDRESS_REVIEW_BOT_REGISTRY" ||
    ! file_contains 'only when discovered' "$GO_WORKFLOW_README" ||


### PR DESCRIPTION
## Summary

- register the actual ChatGPT Codex connector reviewer login
- require exact-head review signals and distinguish clean reviews from actionable inline findings
- keep re-review discovery data-driven and align the plugin documentation
- add regression coverage for detection, triggering, and review signals

## Test plan

- authoritative Detent validation gate
- exact-head pull request CI

Fixes #357