### PR TITLE
fix(address-review): recognize Codex clean-result comments

### DIFF
--- a/plugins/go-workflow/skills/address-review/bot-registry.md
+++ b/plugins/go-workflow/skills/address-review/bot-registry.md
@@ -6,7 +6,7 @@ Reference table of known review bots. Used ONLY for matching against bots actual
 
 | Login | Approval Signal | Has Issues Signal | Re-review Trigger |
 |---|---|---|---|
-| `chatgpt-codex-connector[bot]` | Current-head `codex-pull-request-review-summary` issue comment has a connector-authored `+1` reaction and no unresolved inline comments from the connector | Current-head summary has unresolved inline comments from the connector | `@codex review` |
+| `chatgpt-codex-connector[bot]` | Current-head `codex-pull-request-review-summary` issue comment has either a connector-authored `+1` reaction or a clean-result comment, and no unresolved inline comments from the connector | Current-head summary has unresolved inline comments from the connector | `@codex review` |
 | `coderabbitai[bot]` | Formal `APPROVED` review state (requires `request_changes_workflow` in `.coderabbit.yaml`) | `CHANGES_REQUESTED` review with inline comments | `@coderabbitai full review` |
 | `greptileai` | Greptile status check passes + no inline comments posted | Inline comments on specific file changes | `@greptileai` |
 | `copilot-pull-request-review[bot]` | `COMMENTED` review with no inline file comments ("did not comment on any files") | `COMMENTED` review with inline suggestions | Re-request review button in PR sidebar _(no `@` mention trigger)_ |
@@ -19,11 +19,48 @@ Reference table of known review bots. Used ONLY for matching against bots actual
   `codex-pull-request-review-summary`. Confirm the commit displayed in that
   summary is the prefix of `PR_HEAD_SHA`, then load
   `repos/$REPO_SLUG/issues/comments/$COMMENT_ID/reactions`. A
-  connector-authored `+1` reaction plus no unresolved inline comments from the
-  connector is current-head approval. Unresolved connector inline comments
-  while that summary targets `PR_HEAD_SHA` are actionable findings. A running
-  summary, missing `+1`, or summary for another commit is pending or stale and
-  cannot satisfy approval. Re-trigger with `@codex review`.
+  connector-authored `+1` reaction or a summary body containing
+  `Didn’t find any major issues` is a clean-result signal. The clean-result
+  form must contain `Reviewed commit:` followed by a commit prefix matching
+  `PR_HEAD_SHA`. Either signal counts as current-head approval only when the
+  summary targets `PR_HEAD_SHA` and the connector has no unresolved inline
+  comments. Unresolved connector inline comments while that summary targets
+  `PR_HEAD_SHA` are actionable findings. A running summary, a clean-result
+  summary without matching reviewed-commit evidence, or a summary for another
+  commit is pending or stale and cannot satisfy approval. Re-trigger with
+  `@codex review`.
+
+Evaluate the two approval forms independently, then apply the shared
+current-head and unresolved-thread requirements:
+
+```bash
+CODEX_REVIEWED_COMMIT=$(sed -n 's/.*Reviewed commit:[[:space:]]*`\{0,1\}\([0-9a-fA-F]\{7,40\}\).*/\1/p' <<< "$CODEX_SUMMARY_BODY" | head -1)
+CODEX_CURRENT_HEAD=false
+if [ -n "$CODEX_REVIEWED_COMMIT" ] && [[ "$PR_HEAD_SHA" == "$CODEX_REVIEWED_COMMIT"* ]]; then
+  CODEX_CURRENT_HEAD=true
+fi
+
+CODEX_REACTION_APPROVED=$(jq -r '
+  any(.[];
+    .content == "+1" and
+    .user.login == "chatgpt-codex-connector[bot]")
+' <<< "$CODEX_REACTIONS")
+CODEX_CLEAN_RESULT_APPROVED=false
+if grep -Fq 'Didn’t find any major issues' <<< "$CODEX_SUMMARY_BODY"; then
+  CODEX_CLEAN_RESULT_APPROVED=true
+fi
+CODEX_UNRESOLVED_THREADS=$(jq '[
+  .data.repository.pullRequest.reviewThreads.nodes[]?
+  | select(.isResolved == false)
+  | select(any(.comments.nodes[]?; .author.login == "chatgpt-codex-connector"))
+] | length' <<< "$THREAD_RESULT")
+
+if [ "$CODEX_CURRENT_HEAD" = true ] &&
+   [ "$CODEX_UNRESOLVED_THREADS" -eq 0 ] &&
+   { [ "$CODEX_REACTION_APPROVED" = true ] || [ "$CODEX_CLEAN_RESULT_APPROVED" = true ]; }; then
+  echo "Codex connector approved the current head"
+fi
+```
 - **CodeRabbit**: Only bot that uses formal GitHub review states. Use `github_pr_reviews "$PR_NUM"`, select the newest `coderabbitai[bot]` review by `submitted_at`, and treat `APPROVED` as done.
 - **Greptile**: Uses a **status check** (not review states). Use `github_check_snapshot "$PR_HEAD_SHA"`; a successful Greptile item plus no new inline comments means Greptile is satisfied.
 - **Copilot**: Always posts `COMMENTED` formal reviews (never `APPROVED` or `CHANGES_REQUESTED`). Inspect its REST formal reviews. If its newest body says it "did not comment on any files" or has no inline comments, it found no issues. It cannot be re-triggered via comment; use the re-request review button in the GitHub PR sidebar.

--- a/plugins/go-workflow/skills/address-review/bot-registry.md
+++ b/plugins/go-workflow/skills/address-review/bot-registry.md
@@ -45,6 +45,7 @@ fi
 CODEX_CLEAN_RESULT_COMMENT=$(jq -c '[
   .[]
   | select(.user.login == "chatgpt-codex-connector[bot]")
+  | select((.body | contains("codex-pull-request-review-summary")) | not)
   | select(.body | test("Didn[\u0027’]t find any major issues"))
 ] | sort_by(.created_at) | last // empty' <<< "$ISSUE_COMMENTS")
 CODEX_CLEAN_RESULT_BODY=$(jq -r '.body // empty' <<< "$CODEX_CLEAN_RESULT_COMMENT")

--- a/plugins/go-workflow/skills/address-review/bot-registry.md
+++ b/plugins/go-workflow/skills/address-review/bot-registry.md
@@ -21,8 +21,8 @@ Reference table of known review bots. Used ONLY for matching against bots actual
   `repos/$REPO_SLUG/issues/comments/$COMMENT_ID/reactions`. A
   connector-authored `+1` reaction on that current-head summary is one approval
   signal. Select the newest connector-authored issue comment containing
-  `find any major issues` independently from the persistent summary, allowing
-  either straight or curly apostrophe punctuation around the preceding word.
+  `Didn't find any major issues` independently from the persistent summary,
+  allowing either a straight or curly apostrophe.
   That clean-result comment is a second approval signal only when it contains
   `Reviewed commit:` followed by a commit prefix matching `PR_HEAD_SHA`.
   Either signal counts as current-head approval only when the connector has no
@@ -45,7 +45,7 @@ fi
 CODEX_CLEAN_RESULT_COMMENT=$(jq -c '[
   .[]
   | select(.user.login == "chatgpt-codex-connector[bot]")
-  | select(.body | contains("find any major issues"))
+  | select(.body | test("Didn[\u0027’]t find any major issues"))
 ] | sort_by(.created_at) | last // empty' <<< "$ISSUE_COMMENTS")
 CODEX_CLEAN_RESULT_BODY=$(jq -r '.body // empty' <<< "$CODEX_CLEAN_RESULT_COMMENT")
 CODEX_REVIEWED_COMMIT=$(sed -n 's/.*Reviewed commit:[[:space:]]*`\{0,1\}\([0-9a-fA-F]\{7,40\}\).*/\1/p' <<< "$CODEX_CLEAN_RESULT_BODY" | head -1)

--- a/plugins/go-workflow/skills/address-review/bot-registry.md
+++ b/plugins/go-workflow/skills/address-review/bot-registry.md
@@ -6,7 +6,7 @@ Reference table of known review bots. Used ONLY for matching against bots actual
 
 | Login | Approval Signal | Has Issues Signal | Re-review Trigger |
 |---|---|---|---|
-| `chatgpt-codex-connector[bot]` | Current-head `codex-pull-request-review-summary` issue comment has either a connector-authored `+1` reaction or a clean-result comment, and no unresolved inline comments from the connector | Current-head summary has unresolved inline comments from the connector | `@codex review` |
+| `chatgpt-codex-connector[bot]` | Connector-authored `+1` reaction on the current-head `codex-pull-request-review-summary`, or a separate connector-authored clean-result comment with matching `Reviewed commit:` evidence; either requires no unresolved inline comments from the connector | Current-head summary has unresolved inline comments from the connector | `@codex review` |
 | `coderabbitai[bot]` | Formal `APPROVED` review state (requires `request_changes_workflow` in `.coderabbit.yaml`) | `CHANGES_REQUESTED` review with inline comments | `@coderabbitai full review` |
 | `greptileai` | Greptile status check passes + no inline comments posted | Inline comments on specific file changes | `@greptileai` |
 | `copilot-pull-request-review[bot]` | `COMMENTED` review with no inline file comments ("did not comment on any files") | `COMMENTED` review with inline suggestions | Re-request review button in PR sidebar _(no `@` mention trigger)_ |
@@ -21,7 +21,8 @@ Reference table of known review bots. Used ONLY for matching against bots actual
   `repos/$REPO_SLUG/issues/comments/$COMMENT_ID/reactions`. A
   connector-authored `+1` reaction on that current-head summary is one approval
   signal. Select the newest connector-authored issue comment containing
-  `Didn’t find any major issues` independently from the persistent summary.
+  `find any major issues` independently from the persistent summary, allowing
+  either straight or curly apostrophe punctuation around the preceding word.
   That clean-result comment is a second approval signal only when it contains
   `Reviewed commit:` followed by a commit prefix matching `PR_HEAD_SHA`.
   Either signal counts as current-head approval only when the connector has no
@@ -44,7 +45,7 @@ fi
 CODEX_CLEAN_RESULT_COMMENT=$(jq -c '[
   .[]
   | select(.user.login == "chatgpt-codex-connector[bot]")
-  | select(.body | contains("Didn’t find any major issues"))
+  | select(.body | contains("find any major issues"))
 ] | sort_by(.created_at) | last // empty' <<< "$ISSUE_COMMENTS")
 CODEX_CLEAN_RESULT_BODY=$(jq -r '.body // empty' <<< "$CODEX_CLEAN_RESULT_COMMENT")
 CODEX_REVIEWED_COMMIT=$(sed -n 's/.*Reviewed commit:[[:space:]]*`\{0,1\}\([0-9a-fA-F]\{7,40\}\).*/\1/p' <<< "$CODEX_CLEAN_RESULT_BODY" | head -1)

--- a/plugins/go-workflow/skills/address-review/bot-registry.md
+++ b/plugins/go-workflow/skills/address-review/bot-registry.md
@@ -19,34 +19,37 @@ Reference table of known review bots. Used ONLY for matching against bots actual
   `codex-pull-request-review-summary`. Confirm the commit displayed in that
   summary is the prefix of `PR_HEAD_SHA`, then load
   `repos/$REPO_SLUG/issues/comments/$COMMENT_ID/reactions`. A
-  connector-authored `+1` reaction or a summary body containing
-  `Didn’t find any major issues` is a clean-result signal. The clean-result
-  form must contain `Reviewed commit:` followed by a commit prefix matching
-  `PR_HEAD_SHA`. Either signal counts as current-head approval only when the
-  summary targets `PR_HEAD_SHA` and the connector has no unresolved inline
-  comments. Unresolved connector inline comments while that summary targets
-  `PR_HEAD_SHA` are actionable findings. A running summary, a clean-result
-  summary without matching reviewed-commit evidence, or a summary for another
-  commit is pending or stale and cannot satisfy approval. Re-trigger with
-  `@codex review`.
+  connector-authored `+1` reaction on that current-head summary is one approval
+  signal. Select the newest connector-authored issue comment containing
+  `Didn’t find any major issues` independently from the persistent summary.
+  That clean-result comment is a second approval signal only when it contains
+  `Reviewed commit:` followed by a commit prefix matching `PR_HEAD_SHA`.
+  Either signal counts as current-head approval only when the connector has no
+  unresolved inline comments. Unresolved connector inline comments are
+  actionable findings. A running summary, a clean-result comment without
+  matching reviewed-commit evidence, or a signal for another commit is pending
+  or stale and cannot satisfy approval. Re-trigger with `@codex review`.
 
 Evaluate the two approval forms independently, then apply the shared
 current-head and unresolved-thread requirements:
 
 ```bash
-CODEX_REVIEWED_COMMIT=$(sed -n 's/.*Reviewed commit:[[:space:]]*`\{0,1\}\([0-9a-fA-F]\{7,40\}\).*/\1/p' <<< "$CODEX_SUMMARY_BODY" | head -1)
-CODEX_CURRENT_HEAD=false
-if [ -n "$CODEX_REVIEWED_COMMIT" ] && [[ "$PR_HEAD_SHA" == "$CODEX_REVIEWED_COMMIT"* ]]; then
-  CODEX_CURRENT_HEAD=true
+CODEX_SUMMARY_COMMIT=$(sed -n 's/.*`\([0-9a-fA-F]\{7,40\}\)`.*/\1/p' <<< "$CODEX_SUMMARY_BODY" | head -1)
+CODEX_REACTION_APPROVED=false
+if [ -n "$CODEX_SUMMARY_COMMIT" ] && [[ "$PR_HEAD_SHA" == "$CODEX_SUMMARY_COMMIT"* ]] &&
+   jq -e 'any(.[]; .content == "+1" and .user.login == "chatgpt-codex-connector[bot]")' <<< "$CODEX_REACTIONS" >/dev/null; then
+  CODEX_REACTION_APPROVED=true
 fi
 
-CODEX_REACTION_APPROVED=$(jq -r '
-  any(.[];
-    .content == "+1" and
-    .user.login == "chatgpt-codex-connector[bot]")
-' <<< "$CODEX_REACTIONS")
+CODEX_CLEAN_RESULT_COMMENT=$(jq -c '[
+  .[]
+  | select(.user.login == "chatgpt-codex-connector[bot]")
+  | select(.body | contains("Didn’t find any major issues"))
+] | sort_by(.created_at) | last // empty' <<< "$ISSUE_COMMENTS")
+CODEX_CLEAN_RESULT_BODY=$(jq -r '.body // empty' <<< "$CODEX_CLEAN_RESULT_COMMENT")
+CODEX_REVIEWED_COMMIT=$(sed -n 's/.*Reviewed commit:[[:space:]]*`\{0,1\}\([0-9a-fA-F]\{7,40\}\).*/\1/p' <<< "$CODEX_CLEAN_RESULT_BODY" | head -1)
 CODEX_CLEAN_RESULT_APPROVED=false
-if grep -Fq 'Didn’t find any major issues' <<< "$CODEX_SUMMARY_BODY"; then
+if [ -n "$CODEX_REVIEWED_COMMIT" ] && [[ "$PR_HEAD_SHA" == "$CODEX_REVIEWED_COMMIT"* ]]; then
   CODEX_CLEAN_RESULT_APPROVED=true
 fi
 CODEX_UNRESOLVED_THREADS=$(jq '[
@@ -55,8 +58,7 @@ CODEX_UNRESOLVED_THREADS=$(jq '[
   | select(any(.comments.nodes[]?; .author.login == "chatgpt-codex-connector"))
 ] | length' <<< "$THREAD_RESULT")
 
-if [ "$CODEX_CURRENT_HEAD" = true ] &&
-   [ "$CODEX_UNRESOLVED_THREADS" -eq 0 ] &&
+if [ "$CODEX_UNRESOLVED_THREADS" -eq 0 ] &&
    { [ "$CODEX_REACTION_APPROVED" = true ] || [ "$CODEX_CLEAN_RESULT_APPROVED" = true ]; }; then
   echo "Codex connector approved the current head"
 fi

--- a/scripts/test-commands.sh
+++ b/scripts/test-commands.sh
@@ -170,7 +170,8 @@ if ! file_contains "$CODEX_CONNECTOR_REGISTRY_ROW" "$ADDRESS_REVIEW_BOT_REGISTRY
    ! file_contains "Didn't find any major issues" "$ADDRESS_REVIEW_BOT_REGISTRY" ||
    ! file_contains 'Reviewed commit:' "$ADDRESS_REVIEW_BOT_REGISTRY" ||
    ! file_contains 'CODEX_CLEAN_RESULT_BODY' "$ADDRESS_REVIEW_BOT_REGISTRY" ||
-   ! file_contains 'test("Didn[\u0027’]t find any major issues")' "$ADDRESS_REVIEW_BOT_REGISTRY" ||
+   ! file_contains '| select(.body | test("Didn[' "$ADDRESS_REVIEW_BOT_REGISTRY" ||
+   ! file_contains 't find any major issues"))' "$ADDRESS_REVIEW_BOT_REGISTRY" ||
    ! file_contains 'independently from the persistent summary' "$ADDRESS_REVIEW_BOT_REGISTRY" ||
    ! file_contains 'CODEX_REACTION_APPROVED' "$ADDRESS_REVIEW_BOT_REGISTRY" ||
    ! file_contains 'CODEX_CLEAN_RESULT_APPROVED' "$ADDRESS_REVIEW_BOT_REGISTRY" ||

--- a/scripts/test-commands.sh
+++ b/scripts/test-commands.sh
@@ -169,6 +169,8 @@ if ! file_contains "$CODEX_CONNECTOR_REGISTRY_ROW" "$ADDRESS_REVIEW_BOT_REGISTRY
    ! file_contains 'repos/$REPO_SLUG/issues/comments/$COMMENT_ID/reactions' "$ADDRESS_REVIEW_BOT_REGISTRY" ||
    ! file_contains 'Didn’t find any major issues' "$ADDRESS_REVIEW_BOT_REGISTRY" ||
    ! file_contains 'Reviewed commit:' "$ADDRESS_REVIEW_BOT_REGISTRY" ||
+   ! file_contains 'CODEX_CLEAN_RESULT_BODY' "$ADDRESS_REVIEW_BOT_REGISTRY" ||
+   ! file_contains 'independently from the persistent summary' "$ADDRESS_REVIEW_BOT_REGISTRY" ||
    ! file_contains 'CODEX_REACTION_APPROVED' "$ADDRESS_REVIEW_BOT_REGISTRY" ||
    ! file_contains 'CODEX_CLEAN_RESULT_APPROVED' "$ADDRESS_REVIEW_BOT_REGISTRY" ||
    ! file_contains '[ "$CODEX_UNRESOLVED_THREADS" -eq 0 ]' "$ADDRESS_REVIEW_BOT_REGISTRY" ||
@@ -187,36 +189,40 @@ fi
 
 codex_connector_approved() {
   local summary_body="$1"
-  local reactions="$2"
-  local head_sha="$3"
-  local unresolved_threads="$4"
-  local reviewed_commit reaction_approved clean_result_approved
+  local clean_result_body="$2"
+  local reactions="$3"
+  local head_sha="$4"
+  local unresolved_threads="$5"
+  local summary_commit reviewed_commit reaction_approved clean_result_approved
 
-  reviewed_commit=$(sed -n 's/.*Reviewed commit:[[:space:]]*`\{0,1\}\([0-9a-fA-F]\{7,40\}\).*/\1/p' <<< "$summary_body" | head -1)
+  summary_commit=$(sed -n 's/.*`\([0-9a-fA-F]\{7,40\}\)`.*/\1/p' <<< "$summary_body" | head -1)
+  reviewed_commit=$(sed -n 's/.*Reviewed commit:[[:space:]]*`\{0,1\}\([0-9a-fA-F]\{7,40\}\).*/\1/p' <<< "$clean_result_body" | head -1)
   reaction_approved=$(jq -r 'any(.[]; .content == "+1" and .user.login == "chatgpt-codex-connector[bot]")' <<< "$reactions")
   clean_result_approved=false
-  if grep -Fq 'Didn’t find any major issues' <<< "$summary_body"; then
+  if grep -Fq 'Didn’t find any major issues' <<< "$clean_result_body"; then
     clean_result_approved=true
   fi
 
-  [ -n "$reviewed_commit" ] &&
-    [[ "$head_sha" == "$reviewed_commit"* ]] &&
-    [ "$unresolved_threads" -eq 0 ] &&
-    { [ "$reaction_approved" = true ] || [ "$clean_result_approved" = true ]; }
+  [ "$unresolved_threads" -eq 0 ] && {
+    { [ -n "$summary_commit" ] && [[ "$head_sha" == "$summary_commit"* ]] && [ "$reaction_approved" = true ]; } ||
+      { [ -n "$reviewed_commit" ] && [[ "$head_sha" == "$reviewed_commit"* ]] && [ "$clean_result_approved" = true ]; }
+  }
 }
 
 echo -n "Codex connector approval requires a clean current-head result... "
 CODEX_TEST_HEAD="0123456789abcdef0123456789abcdef01234567"
-CODEX_CLEAN_SUMMARY=$'<!-- codex-pull-request-review-summary -->\nDidn’t find any major issues\nReviewed commit: `0123456`'
-CODEX_WRONG_HEAD_SUMMARY=$'<!-- codex-pull-request-review-summary -->\nDidn’t find any major issues\nReviewed commit: `abcdef0`'
-CODEX_REACTION_SUMMARY=$'<!-- codex-pull-request-review-summary -->\nReviewed commit: `0123456`'
+CODEX_SUMMARY=$'<!-- codex-pull-request-review-summary -->\n| Code Review | Complete | `0123456` |'
+CODEX_CLEAN_RESULT=$'Didn’t find any major issues\nReviewed commit: `0123456`'
+CODEX_WRONG_HEAD_RESULT=$'Didn’t find any major issues\nReviewed commit: `abcdef0`'
+CODEX_COMBINED_SUMMARY=$'<!-- codex-pull-request-review-summary -->\nDidn’t find any major issues\nReviewed commit: `0123456`'
 CODEX_NO_REACTIONS='[]'
 CODEX_PLUS_ONE='[{"content":"+1","user":{"login":"chatgpt-codex-connector[bot]"}}]'
-if ! codex_connector_approved "$CODEX_CLEAN_SUMMARY" "$CODEX_NO_REACTIONS" "$CODEX_TEST_HEAD" 0 ||
-   codex_connector_approved "$CODEX_WRONG_HEAD_SUMMARY" "$CODEX_NO_REACTIONS" "$CODEX_TEST_HEAD" 0 ||
-   codex_connector_approved "$CODEX_CLEAN_SUMMARY" "$CODEX_NO_REACTIONS" "$CODEX_TEST_HEAD" 1 ||
-   ! codex_connector_approved "$CODEX_REACTION_SUMMARY" "$CODEX_PLUS_ONE" "$CODEX_TEST_HEAD" 0; then
-  echo "FAIL (clean-result, wrong-head, unresolved-thread, or reaction path regressed)"
+if ! codex_connector_approved "$CODEX_SUMMARY" "$CODEX_CLEAN_RESULT" "$CODEX_NO_REACTIONS" "$CODEX_TEST_HEAD" 0 ||
+   codex_connector_approved "$CODEX_SUMMARY" "$CODEX_WRONG_HEAD_RESULT" "$CODEX_NO_REACTIONS" "$CODEX_TEST_HEAD" 0 ||
+   codex_connector_approved "$CODEX_SUMMARY" "$CODEX_CLEAN_RESULT" "$CODEX_NO_REACTIONS" "$CODEX_TEST_HEAD" 1 ||
+   ! codex_connector_approved "$CODEX_SUMMARY" "" "$CODEX_PLUS_ONE" "$CODEX_TEST_HEAD" 0 ||
+   codex_connector_approved "$CODEX_COMBINED_SUMMARY" "" "$CODEX_NO_REACTIONS" "$CODEX_TEST_HEAD" 0; then
+  echo "FAIL (separate clean-result, wrong-head, unresolved-thread, reaction, or combined-body path regressed)"
   ERRORS=$((ERRORS + 1))
 else
   echo "OK"

--- a/scripts/test-commands.sh
+++ b/scripts/test-commands.sh
@@ -167,10 +167,10 @@ echo -n "Address-review registers current-head Codex connector re-review... "
 if ! file_contains "$CODEX_CONNECTOR_REGISTRY_ROW" "$ADDRESS_REVIEW_BOT_REGISTRY" ||
    ! file_contains 'PR_HEAD_SHA' "$ADDRESS_REVIEW_BOT_REGISTRY" ||
    ! file_contains 'repos/$REPO_SLUG/issues/comments/$COMMENT_ID/reactions' "$ADDRESS_REVIEW_BOT_REGISTRY" ||
-   ! file_contains 'find any major issues' "$ADDRESS_REVIEW_BOT_REGISTRY" ||
+   ! file_contains "Didn't find any major issues" "$ADDRESS_REVIEW_BOT_REGISTRY" ||
    ! file_contains 'Reviewed commit:' "$ADDRESS_REVIEW_BOT_REGISTRY" ||
    ! file_contains 'CODEX_CLEAN_RESULT_BODY' "$ADDRESS_REVIEW_BOT_REGISTRY" ||
-   ! file_contains 'contains("find any major issues")' "$ADDRESS_REVIEW_BOT_REGISTRY" ||
+   ! file_contains 'test("Didn[\u0027’]t find any major issues")' "$ADDRESS_REVIEW_BOT_REGISTRY" ||
    ! file_contains 'independently from the persistent summary' "$ADDRESS_REVIEW_BOT_REGISTRY" ||
    ! file_contains 'CODEX_REACTION_APPROVED' "$ADDRESS_REVIEW_BOT_REGISTRY" ||
    ! file_contains 'CODEX_CLEAN_RESULT_APPROVED' "$ADDRESS_REVIEW_BOT_REGISTRY" ||
@@ -200,7 +200,7 @@ codex_connector_approved() {
   reviewed_commit=$(sed -n 's/.*Reviewed commit:[[:space:]]*`\{0,1\}\([0-9a-fA-F]\{7,40\}\).*/\1/p' <<< "$clean_result_body" | head -1)
   reaction_approved=$(jq -r 'any(.[]; .content == "+1" and .user.login == "chatgpt-codex-connector[bot]")' <<< "$reactions")
   clean_result_approved=false
-  if grep -Fq 'find any major issues' <<< "$clean_result_body"; then
+  if grep -Eq "Didn['’]t find any major issues" <<< "$clean_result_body"; then
     clean_result_approved=true
   fi
 
@@ -215,11 +215,13 @@ CODEX_TEST_HEAD="0123456789abcdef0123456789abcdef01234567"
 CODEX_SUMMARY=$'<!-- codex-pull-request-review-summary -->\n| Code Review | Complete | `0123456` |'
 CODEX_CLEAN_RESULT=$'Codex Review: Didn\'t find any major issues.\nReviewed commit: `0123456`'
 CODEX_WRONG_HEAD_RESULT=$'Codex Review: Didn’t find any major issues.\nReviewed commit: `abcdef0`'
+CODEX_NON_CLEAN_RESULT=$'Codex Review: Did find any major issues.\nReviewed commit: `0123456`'
 CODEX_COMBINED_SUMMARY=$'<!-- codex-pull-request-review-summary -->\nDidn’t find any major issues\nReviewed commit: `0123456`'
 CODEX_NO_REACTIONS='[]'
 CODEX_PLUS_ONE='[{"content":"+1","user":{"login":"chatgpt-codex-connector[bot]"}}]'
 if ! codex_connector_approved "$CODEX_SUMMARY" "$CODEX_CLEAN_RESULT" "$CODEX_NO_REACTIONS" "$CODEX_TEST_HEAD" 0 ||
    codex_connector_approved "$CODEX_SUMMARY" "$CODEX_WRONG_HEAD_RESULT" "$CODEX_NO_REACTIONS" "$CODEX_TEST_HEAD" 0 ||
+   codex_connector_approved "$CODEX_SUMMARY" "$CODEX_NON_CLEAN_RESULT" "$CODEX_NO_REACTIONS" "$CODEX_TEST_HEAD" 0 ||
    codex_connector_approved "$CODEX_SUMMARY" "$CODEX_CLEAN_RESULT" "$CODEX_NO_REACTIONS" "$CODEX_TEST_HEAD" 1 ||
    ! codex_connector_approved "$CODEX_SUMMARY" "" "$CODEX_PLUS_ONE" "$CODEX_TEST_HEAD" 0 ||
    codex_connector_approved "$CODEX_COMBINED_SUMMARY" "" "$CODEX_NO_REACTIONS" "$CODEX_TEST_HEAD" 0; then

--- a/scripts/test-commands.sh
+++ b/scripts/test-commands.sh
@@ -161,12 +161,17 @@ file_contains() {
 ADDRESS_REVIEW_BOT_REGISTRY="$ROOT_DIR/plugins/go-workflow/skills/address-review/bot-registry.md"
 ADDRESS_REVIEW_DISCOVERY="$ROOT_DIR/plugins/go-workflow/skills/address-review/setup-and-discovery.md"
 GO_WORKFLOW_README="$ROOT_DIR/plugins/go-workflow/README.md"
-CODEX_CONNECTOR_REGISTRY_ROW='| `chatgpt-codex-connector[bot]` | Current-head `codex-pull-request-review-summary` issue comment has a connector-authored `+1` reaction and no unresolved inline comments from the connector | Current-head summary has unresolved inline comments from the connector | `@codex review` |'
+CODEX_CONNECTOR_REGISTRY_ROW='| `chatgpt-codex-connector[bot]` | Current-head `codex-pull-request-review-summary` issue comment has either a connector-authored `+1` reaction or a clean-result comment, and no unresolved inline comments from the connector | Current-head summary has unresolved inline comments from the connector | `@codex review` |'
 
 echo -n "Address-review registers current-head Codex connector re-review... "
 if ! file_contains "$CODEX_CONNECTOR_REGISTRY_ROW" "$ADDRESS_REVIEW_BOT_REGISTRY" ||
    ! file_contains 'PR_HEAD_SHA' "$ADDRESS_REVIEW_BOT_REGISTRY" ||
    ! file_contains 'repos/$REPO_SLUG/issues/comments/$COMMENT_ID/reactions' "$ADDRESS_REVIEW_BOT_REGISTRY" ||
+   ! file_contains 'Didn’t find any major issues' "$ADDRESS_REVIEW_BOT_REGISTRY" ||
+   ! file_contains 'Reviewed commit:' "$ADDRESS_REVIEW_BOT_REGISTRY" ||
+   ! file_contains 'CODEX_REACTION_APPROVED' "$ADDRESS_REVIEW_BOT_REGISTRY" ||
+   ! file_contains 'CODEX_CLEAN_RESULT_APPROVED' "$ADDRESS_REVIEW_BOT_REGISTRY" ||
+   ! file_contains '[ "$CODEX_UNRESOLVED_THREADS" -eq 0 ]' "$ADDRESS_REVIEW_BOT_REGISTRY" ||
    ! file_contains 'ISSUE_COMMENT_AUTHORS' "$ADDRESS_REVIEW_DISCOVERY" ||
    ! file_contains 'chatgpt-codex-connector[bot]' "$ADDRESS_REVIEW_DISCOVERY" ||
    ! file_contains 'chatgpt-codex-connector' "$ADDRESS_REVIEW_DISCOVERY" ||
@@ -175,6 +180,43 @@ if ! file_contains "$CODEX_CONNECTOR_REGISTRY_ROW" "$ADDRESS_REVIEW_BOT_REGISTRY
    ! file_contains '`chatgpt-codex-connector[bot]`' "$GO_WORKFLOW_README" ||
    ! file_contains 'Manual re-request through GitHub Reviewers' "$GO_WORKFLOW_README"; then
   echo "FAIL (Codex connector detection, trigger, or signal contract missing)"
+  ERRORS=$((ERRORS + 1))
+else
+  echo "OK"
+fi
+
+codex_connector_approved() {
+  local summary_body="$1"
+  local reactions="$2"
+  local head_sha="$3"
+  local unresolved_threads="$4"
+  local reviewed_commit reaction_approved clean_result_approved
+
+  reviewed_commit=$(sed -n 's/.*Reviewed commit:[[:space:]]*`\{0,1\}\([0-9a-fA-F]\{7,40\}\).*/\1/p' <<< "$summary_body" | head -1)
+  reaction_approved=$(jq -r 'any(.[]; .content == "+1" and .user.login == "chatgpt-codex-connector[bot]")' <<< "$reactions")
+  clean_result_approved=false
+  if grep -Fq 'Didn’t find any major issues' <<< "$summary_body"; then
+    clean_result_approved=true
+  fi
+
+  [ -n "$reviewed_commit" ] &&
+    [[ "$head_sha" == "$reviewed_commit"* ]] &&
+    [ "$unresolved_threads" -eq 0 ] &&
+    { [ "$reaction_approved" = true ] || [ "$clean_result_approved" = true ]; }
+}
+
+echo -n "Codex connector approval requires a clean current-head result... "
+CODEX_TEST_HEAD="0123456789abcdef0123456789abcdef01234567"
+CODEX_CLEAN_SUMMARY=$'<!-- codex-pull-request-review-summary -->\nDidn’t find any major issues\nReviewed commit: `0123456`'
+CODEX_WRONG_HEAD_SUMMARY=$'<!-- codex-pull-request-review-summary -->\nDidn’t find any major issues\nReviewed commit: `abcdef0`'
+CODEX_REACTION_SUMMARY=$'<!-- codex-pull-request-review-summary -->\nReviewed commit: `0123456`'
+CODEX_NO_REACTIONS='[]'
+CODEX_PLUS_ONE='[{"content":"+1","user":{"login":"chatgpt-codex-connector[bot]"}}]'
+if ! codex_connector_approved "$CODEX_CLEAN_SUMMARY" "$CODEX_NO_REACTIONS" "$CODEX_TEST_HEAD" 0 ||
+   codex_connector_approved "$CODEX_WRONG_HEAD_SUMMARY" "$CODEX_NO_REACTIONS" "$CODEX_TEST_HEAD" 0 ||
+   codex_connector_approved "$CODEX_CLEAN_SUMMARY" "$CODEX_NO_REACTIONS" "$CODEX_TEST_HEAD" 1 ||
+   ! codex_connector_approved "$CODEX_REACTION_SUMMARY" "$CODEX_PLUS_ONE" "$CODEX_TEST_HEAD" 0; then
+  echo "FAIL (clean-result, wrong-head, unresolved-thread, or reaction path regressed)"
   ERRORS=$((ERRORS + 1))
 else
   echo "OK"

--- a/scripts/test-commands.sh
+++ b/scripts/test-commands.sh
@@ -170,6 +170,7 @@ if ! file_contains "$CODEX_CONNECTOR_REGISTRY_ROW" "$ADDRESS_REVIEW_BOT_REGISTRY
    ! file_contains "Didn't find any major issues" "$ADDRESS_REVIEW_BOT_REGISTRY" ||
    ! file_contains 'Reviewed commit:' "$ADDRESS_REVIEW_BOT_REGISTRY" ||
    ! file_contains 'CODEX_CLEAN_RESULT_BODY' "$ADDRESS_REVIEW_BOT_REGISTRY" ||
+   ! file_contains 'contains("codex-pull-request-review-summary")) | not' "$ADDRESS_REVIEW_BOT_REGISTRY" ||
    ! file_contains '| select(.body | test("Didn[' "$ADDRESS_REVIEW_BOT_REGISTRY" ||
    ! file_contains 't find any major issues"))' "$ADDRESS_REVIEW_BOT_REGISTRY" ||
    ! file_contains 'independently from the persistent summary' "$ADDRESS_REVIEW_BOT_REGISTRY" ||
@@ -191,12 +192,18 @@ fi
 
 codex_connector_approved() {
   local summary_body="$1"
-  local clean_result_body="$2"
+  local issue_comments="$2"
   local reactions="$3"
   local head_sha="$4"
   local unresolved_threads="$5"
-  local summary_commit reviewed_commit reaction_approved clean_result_approved
+  local clean_result_body summary_commit reviewed_commit reaction_approved clean_result_approved
 
+  clean_result_body=$(jq -r '[
+    .[]
+    | select(.user.login == "chatgpt-codex-connector[bot]")
+    | select((.body | contains("codex-pull-request-review-summary")) | not)
+    | select(.body | test("Didn[\u0027’]t find any major issues"))
+  ] | sort_by(.created_at) | last.body // ""' <<< "$issue_comments")
   summary_commit=$(sed -n 's/.*`\([0-9a-fA-F]\{7,40\}\)`.*/\1/p' <<< "$summary_body" | head -1)
   reviewed_commit=$(sed -n 's/.*Reviewed commit:[[:space:]]*`\{0,1\}\([0-9a-fA-F]\{7,40\}\).*/\1/p' <<< "$clean_result_body" | head -1)
   reaction_approved=$(jq -r 'any(.[]; .content == "+1" and .user.login == "chatgpt-codex-connector[bot]")' <<< "$reactions")
@@ -218,14 +225,19 @@ CODEX_CLEAN_RESULT=$'Codex Review: Didn\'t find any major issues.\nReviewed comm
 CODEX_WRONG_HEAD_RESULT=$'Codex Review: Didn’t find any major issues.\nReviewed commit: `abcdef0`'
 CODEX_NON_CLEAN_RESULT=$'Codex Review: Did find any major issues.\nReviewed commit: `0123456`'
 CODEX_COMBINED_SUMMARY=$'<!-- codex-pull-request-review-summary -->\nDidn’t find any major issues\nReviewed commit: `0123456`'
+CODEX_CLEAN_COMMENTS=$(jq -nc --arg body "$CODEX_CLEAN_RESULT" '[{user:{login:"chatgpt-codex-connector[bot]"},body:$body,created_at:"2026-09-01T00:00:01Z"}]')
+CODEX_WRONG_HEAD_COMMENTS=$(jq -nc --arg body "$CODEX_WRONG_HEAD_RESULT" '[{user:{login:"chatgpt-codex-connector[bot]"},body:$body,created_at:"2026-09-01T00:00:01Z"}]')
+CODEX_NON_CLEAN_COMMENTS=$(jq -nc --arg body "$CODEX_NON_CLEAN_RESULT" '[{user:{login:"chatgpt-codex-connector[bot]"},body:$body,created_at:"2026-09-01T00:00:01Z"}]')
+CODEX_COMBINED_SUMMARY_COMMENTS=$(jq -nc --arg body "$CODEX_COMBINED_SUMMARY" '[{user:{login:"chatgpt-codex-connector[bot]"},body:$body,created_at:"2026-09-01T00:00:01Z"}]')
+CODEX_NO_COMMENTS='[]'
 CODEX_NO_REACTIONS='[]'
 CODEX_PLUS_ONE='[{"content":"+1","user":{"login":"chatgpt-codex-connector[bot]"}}]'
-if ! codex_connector_approved "$CODEX_SUMMARY" "$CODEX_CLEAN_RESULT" "$CODEX_NO_REACTIONS" "$CODEX_TEST_HEAD" 0 ||
-   codex_connector_approved "$CODEX_SUMMARY" "$CODEX_WRONG_HEAD_RESULT" "$CODEX_NO_REACTIONS" "$CODEX_TEST_HEAD" 0 ||
-   codex_connector_approved "$CODEX_SUMMARY" "$CODEX_NON_CLEAN_RESULT" "$CODEX_NO_REACTIONS" "$CODEX_TEST_HEAD" 0 ||
-   codex_connector_approved "$CODEX_SUMMARY" "$CODEX_CLEAN_RESULT" "$CODEX_NO_REACTIONS" "$CODEX_TEST_HEAD" 1 ||
-   ! codex_connector_approved "$CODEX_SUMMARY" "" "$CODEX_PLUS_ONE" "$CODEX_TEST_HEAD" 0 ||
-   codex_connector_approved "$CODEX_COMBINED_SUMMARY" "" "$CODEX_NO_REACTIONS" "$CODEX_TEST_HEAD" 0; then
+if ! codex_connector_approved "$CODEX_SUMMARY" "$CODEX_CLEAN_COMMENTS" "$CODEX_NO_REACTIONS" "$CODEX_TEST_HEAD" 0 ||
+   codex_connector_approved "$CODEX_SUMMARY" "$CODEX_WRONG_HEAD_COMMENTS" "$CODEX_NO_REACTIONS" "$CODEX_TEST_HEAD" 0 ||
+   codex_connector_approved "$CODEX_SUMMARY" "$CODEX_NON_CLEAN_COMMENTS" "$CODEX_NO_REACTIONS" "$CODEX_TEST_HEAD" 0 ||
+   codex_connector_approved "$CODEX_SUMMARY" "$CODEX_CLEAN_COMMENTS" "$CODEX_NO_REACTIONS" "$CODEX_TEST_HEAD" 1 ||
+   ! codex_connector_approved "$CODEX_SUMMARY" "$CODEX_NO_COMMENTS" "$CODEX_PLUS_ONE" "$CODEX_TEST_HEAD" 0 ||
+   codex_connector_approved "$CODEX_COMBINED_SUMMARY" "$CODEX_COMBINED_SUMMARY_COMMENTS" "$CODEX_NO_REACTIONS" "$CODEX_TEST_HEAD" 0; then
   echo "FAIL (separate clean-result, wrong-head, unresolved-thread, reaction, or combined-body path regressed)"
   ERRORS=$((ERRORS + 1))
 else

--- a/scripts/test-commands.sh
+++ b/scripts/test-commands.sh
@@ -161,15 +161,16 @@ file_contains() {
 ADDRESS_REVIEW_BOT_REGISTRY="$ROOT_DIR/plugins/go-workflow/skills/address-review/bot-registry.md"
 ADDRESS_REVIEW_DISCOVERY="$ROOT_DIR/plugins/go-workflow/skills/address-review/setup-and-discovery.md"
 GO_WORKFLOW_README="$ROOT_DIR/plugins/go-workflow/README.md"
-CODEX_CONNECTOR_REGISTRY_ROW='| `chatgpt-codex-connector[bot]` | Current-head `codex-pull-request-review-summary` issue comment has either a connector-authored `+1` reaction or a clean-result comment, and no unresolved inline comments from the connector | Current-head summary has unresolved inline comments from the connector | `@codex review` |'
+CODEX_CONNECTOR_REGISTRY_ROW='| `chatgpt-codex-connector[bot]` | Connector-authored `+1` reaction on the current-head `codex-pull-request-review-summary`, or a separate connector-authored clean-result comment with matching `Reviewed commit:` evidence; either requires no unresolved inline comments from the connector | Current-head summary has unresolved inline comments from the connector | `@codex review` |'
 
 echo -n "Address-review registers current-head Codex connector re-review... "
 if ! file_contains "$CODEX_CONNECTOR_REGISTRY_ROW" "$ADDRESS_REVIEW_BOT_REGISTRY" ||
    ! file_contains 'PR_HEAD_SHA' "$ADDRESS_REVIEW_BOT_REGISTRY" ||
    ! file_contains 'repos/$REPO_SLUG/issues/comments/$COMMENT_ID/reactions' "$ADDRESS_REVIEW_BOT_REGISTRY" ||
-   ! file_contains 'Didn’t find any major issues' "$ADDRESS_REVIEW_BOT_REGISTRY" ||
+   ! file_contains 'find any major issues' "$ADDRESS_REVIEW_BOT_REGISTRY" ||
    ! file_contains 'Reviewed commit:' "$ADDRESS_REVIEW_BOT_REGISTRY" ||
    ! file_contains 'CODEX_CLEAN_RESULT_BODY' "$ADDRESS_REVIEW_BOT_REGISTRY" ||
+   ! file_contains 'contains("find any major issues")' "$ADDRESS_REVIEW_BOT_REGISTRY" ||
    ! file_contains 'independently from the persistent summary' "$ADDRESS_REVIEW_BOT_REGISTRY" ||
    ! file_contains 'CODEX_REACTION_APPROVED' "$ADDRESS_REVIEW_BOT_REGISTRY" ||
    ! file_contains 'CODEX_CLEAN_RESULT_APPROVED' "$ADDRESS_REVIEW_BOT_REGISTRY" ||
@@ -199,7 +200,7 @@ codex_connector_approved() {
   reviewed_commit=$(sed -n 's/.*Reviewed commit:[[:space:]]*`\{0,1\}\([0-9a-fA-F]\{7,40\}\).*/\1/p' <<< "$clean_result_body" | head -1)
   reaction_approved=$(jq -r 'any(.[]; .content == "+1" and .user.login == "chatgpt-codex-connector[bot]")' <<< "$reactions")
   clean_result_approved=false
-  if grep -Fq 'Didn’t find any major issues' <<< "$clean_result_body"; then
+  if grep -Fq 'find any major issues' <<< "$clean_result_body"; then
     clean_result_approved=true
   fi
 
@@ -212,8 +213,8 @@ codex_connector_approved() {
 echo -n "Codex connector approval requires a clean current-head result... "
 CODEX_TEST_HEAD="0123456789abcdef0123456789abcdef01234567"
 CODEX_SUMMARY=$'<!-- codex-pull-request-review-summary -->\n| Code Review | Complete | `0123456` |'
-CODEX_CLEAN_RESULT=$'Didn’t find any major issues\nReviewed commit: `0123456`'
-CODEX_WRONG_HEAD_RESULT=$'Didn’t find any major issues\nReviewed commit: `abcdef0`'
+CODEX_CLEAN_RESULT=$'Codex Review: Didn\'t find any major issues.\nReviewed commit: `0123456`'
+CODEX_WRONG_HEAD_RESULT=$'Codex Review: Didn’t find any major issues.\nReviewed commit: `abcdef0`'
 CODEX_COMBINED_SUMMARY=$'<!-- codex-pull-request-review-summary -->\nDidn’t find any major issues\nReviewed commit: `0123456`'
 CODEX_NO_REACTIONS='[]'
 CODEX_PLUS_ONE='[{"content":"+1","user":{"login":"chatgpt-codex-connector[bot]"}}]'


### PR DESCRIPTION
## Summary

- recognize Codex connector clean-result comments as an approval signal
- require `Reviewed commit:` evidence to match the current pull request head
- preserve connector-authored `+1` approvals and the zero-unresolved-thread requirement
- cover clean-result, wrong-head, unresolved-finding, and reaction approval paths

## Test Plan

- `bash -n scripts/test-commands.sh`
- focused connector approval fixture checks
- authoritative Detent validation gate with Detent-local Go caches

Fixes #363
