### PR TITLE
fix(build): avoid Bash 5.3 Gemini hangs

### DIFF
--- a/plugins/go-workflow/lib/github-rest.sh
+++ b/plugins/go-workflow/lib/github-rest.sh
@@ -25,7 +25,7 @@ github_current_pr() {
   fi
 
   pages=$(gh api --paginate --slurp "repos/{owner}/{repo}/commits/$head_sha/pulls?per_page=100") || return
-  jq -cer --arg branch "$branch" --arg head_sha "$head_sha" '
+  printf '%s\n' "$pages" | jq -cer --arg branch "$branch" --arg head_sha "$head_sha" '
     [
       .[][]
       | select(.state == "open")
@@ -39,7 +39,7 @@ github_current_pr() {
       else
         error("multiple open pull requests match the current branch and head")
       end
-  ' <<< "$pages"
+  '
 }
 
 github_pr_reviews() {
@@ -47,7 +47,7 @@ github_pr_reviews() {
   local pages
 
   pages=$(gh api --paginate --slurp "repos/{owner}/{repo}/pulls/$pr_number/reviews?per_page=100") || return
-  jq -c '[.[][]]' <<< "$pages"
+  printf '%s\n' "$pages" | jq -c '[.[][]]'
 }
 
 github_check_snapshot() {
@@ -138,7 +138,7 @@ github_watch_pr_checks() {
   if ! pr_json=$(github_pr "$pr_number"); then
     return "$GITHUB_CHECKS_API_ERROR"
   fi
-  current_sha=$(jq -er '.head.sha' <<< "$pr_json") || return "$GITHUB_CHECKS_API_ERROR"
+  current_sha=$(printf '%s\n' "$pr_json" | jq -er '.head.sha') || return "$GITHUB_CHECKS_API_ERROR"
 
   if [ -n "$expected_sha" ] && [ "$current_sha" != "$expected_sha" ]; then
     return "$GITHUB_CHECKS_HEAD_SHIFT"
@@ -149,7 +149,7 @@ github_watch_pr_checks() {
     if ! snapshot=$(github_check_snapshot "$expected_sha"); then
       return "$GITHUB_CHECKS_API_ERROR"
     fi
-    item_count=$(jq '.items | length' <<< "$snapshot") || return "$GITHUB_CHECKS_API_ERROR"
+    item_count=$(printf '%s\n' "$snapshot" | jq '.items | length') || return "$GITHUB_CHECKS_API_ERROR"
     if [ "$item_count" -gt 0 ]; then
       registered=true
       break
@@ -165,8 +165,8 @@ github_watch_pr_checks() {
   fi
 
   while true; do
-    pending_count=$(jq '[.items[] | select(.terminal == false)] | length' <<< "$snapshot") || return "$GITHUB_CHECKS_API_ERROR"
-    signature=$(jq -r '[.items[] | "\(.id):\(.source_id)"] | sort | join("|")' <<< "$snapshot") || return "$GITHUB_CHECKS_API_ERROR"
+    pending_count=$(printf '%s\n' "$snapshot" | jq '[.items[] | select(.terminal == false)] | length') || return "$GITHUB_CHECKS_API_ERROR"
+    signature=$(printf '%s\n' "$snapshot" | jq -r '[.items[] | "\(.id):\(.source_id)"] | sort | join("|")') || return "$GITHUB_CHECKS_API_ERROR"
 
     if [ "$pending_count" -eq 0 ]; then
       if [ "$signature" = "$stable_signature" ]; then
@@ -187,12 +187,12 @@ github_watch_pr_checks() {
       if ! pr_json=$(github_pr "$pr_number"); then
         return "$GITHUB_CHECKS_API_ERROR"
       fi
-      current_sha=$(jq -er '.head.sha' <<< "$pr_json") || return "$GITHUB_CHECKS_API_ERROR"
+      current_sha=$(printf '%s\n' "$pr_json" | jq -er '.head.sha') || return "$GITHUB_CHECKS_API_ERROR"
       if [ "$current_sha" != "$expected_sha" ]; then
         return "$GITHUB_CHECKS_HEAD_SHIFT"
       fi
 
-      pending_checks=$(jq -r '.items[] | select(.terminal == false) | "\(.name): \(.state)"' <<< "$snapshot") || return "$GITHUB_CHECKS_API_ERROR"
+      pending_checks=$(printf '%s\n' "$snapshot" | jq -r '.items[] | select(.terminal == false) | "\(.name): \(.state)"') || return "$GITHUB_CHECKS_API_ERROR"
       printf 'Timed out waiting for PR #%s checks at %s to reach a stable terminal state after %s polls.\n' \
         "$pr_number" "$expected_sha" "$terminal_attempts" >&2
       if [ -n "$pending_checks" ]; then
@@ -213,13 +213,13 @@ github_watch_pr_checks() {
   if ! pr_json=$(github_pr "$pr_number"); then
     return "$GITHUB_CHECKS_API_ERROR"
   fi
-  current_sha=$(jq -er '.head.sha' <<< "$pr_json") || return "$GITHUB_CHECKS_API_ERROR"
+  current_sha=$(printf '%s\n' "$pr_json" | jq -er '.head.sha') || return "$GITHUB_CHECKS_API_ERROR"
   if [ "$current_sha" != "$expected_sha" ]; then
     return "$GITHUB_CHECKS_HEAD_SHIFT"
   fi
 
   printf '%s\n' "$snapshot"
-  failure_count=$(jq '[.items[] | select(.terminal and (.successful | not))] | length' <<< "$snapshot") || return "$GITHUB_CHECKS_API_ERROR"
+  failure_count=$(printf '%s\n' "$snapshot" | jq '[.items[] | select(.terminal and (.successful | not))] | length') || return "$GITHUB_CHECKS_API_ERROR"
   if [ "$failure_count" -gt 0 ]; then
     return "$GITHUB_CHECKS_FAILED"
   fi

--- a/scripts/build-universal.sh
+++ b/scripts/build-universal.sh
@@ -400,10 +400,10 @@ extract_frontmatter_value() {
     local key="$2"
 
     printf '%s\n' "$frontmatter" | awk -v key="$key" '
-        index($0, key ":") == 1 {
+        !found && index($0, key ":") == 1 {
             sub("^[^:]*:[[:space:]]*", "")
             print
-            exit
+            found = 1
         }
     '
 }

--- a/scripts/build-universal.sh
+++ b/scripts/build-universal.sh
@@ -320,17 +320,16 @@ generate_gemini_extension_json() {
         mcp_servers=$(jq -c '.' "$mcp_json")
     fi
 
-    cat << EOF
-{
-  "name": "gopher-ai-$plugin_name",
-  "version": "$VERSION",
-  "description": "$description",
-  "contextFileName": "GEMINI.md",
-  "mcpServers": $mcp_servers,
-  "excludeTools": [],
-  "settings": []
-}
-EOF
+    printf '%s\n' \
+        '{' \
+        "  \"name\": \"gopher-ai-$plugin_name\"," \
+        "  \"version\": \"$VERSION\"," \
+        "  \"description\": \"$description\"," \
+        '  "contextFileName": "GEMINI.md",' \
+        "  \"mcpServers\": $mcp_servers," \
+        '  "excludeTools": [],' \
+        '  "settings": []' \
+        '}'
 }
 
 generate_gemini_md() {
@@ -339,28 +338,25 @@ generate_gemini_md() {
 
     marketplace_desc=$(jq -r --arg name "$plugin_name" '.plugins[] | select(.name == $name) | .description // ""' "$ROOT_DIR/.claude-plugin/marketplace.json")
 
-    cat << EOF
-# Gopher AI: $plugin_name
-
-$marketplace_desc
-
-## About
-
-This extension is part of the gopher-ai toolkit for Go developers, created by [Gopher Guides](https://gopherguides.com).
-
-## Skills
-
-Skills in this extension activate automatically based on context. Check the \`skills/\` directory for available skills.
-
-## Commands
-
-Commands are available in the \`commands/\` directory. Each command is defined as a TOML file.
-
-## Links
-
-- [Gopher Guides Training](https://gopherguides.com)
-- [GitHub Repository](https://github.com/gopherguides/gopher-ai)
-EOF
+    printf '# Gopher AI: %s\n\n' "$plugin_name"
+    printf '%s\n\n' "$marketplace_desc"
+    printf '%s\n' \
+        '## About' \
+        '' \
+        'This extension is part of the gopher-ai toolkit for Go developers, created by [Gopher Guides](https://gopherguides.com).' \
+        '' \
+        '## Skills' \
+        '' \
+        "Skills in this extension activate automatically based on context. Check the \`skills/\` directory for available skills." \
+        '' \
+        '## Commands' \
+        '' \
+        "Commands are available in the \`commands/\` directory. Each command is defined as a TOML file." \
+        '' \
+        '## Links' \
+        '' \
+        '- [Gopher Guides Training](https://gopherguides.com)' \
+        '- [GitHub Repository](https://github.com/gopherguides/gopher-ai)'
 }
 
 convert_command_to_toml() {
@@ -393,11 +389,8 @@ convert_command_to_toml() {
     body=${body//\$ARGUMENTS/\{\{args\}\}}
     body=$(convert_gemini_prompt_body "$body")
 
-    cat << EOF
-# Generated from $cmd_name.md
-# gopher-ai v$VERSION
-description = "$description"
-EOF
+    printf '# Generated from %s.md\n# gopher-ai v%s\ndescription = "%s"\n' \
+        "$cmd_name" "$VERSION" "$description"
 
     emit_toml_multiline_string "prompt" "$body"
 }
@@ -406,13 +399,13 @@ extract_frontmatter_value() {
     local frontmatter="$1"
     local key="$2"
 
-    awk -v key="$key" '
+    printf '%s\n' "$frontmatter" | awk -v key="$key" '
         index($0, key ":") == 1 {
             sub("^[^:]*:[[:space:]]*", "")
             print
             exit
         }
-    ' <<< "$frontmatter"
+    '
 }
 
 strip_wrapping_quotes() {
@@ -467,7 +460,7 @@ emit_toml_multiline_string() {
 convert_gemini_prompt_body() {
     local value="$1"
 
-    awk '
+    printf '%s\n' "$value" | awk '
         function convert_inline(line,    out, i, c, cmd, escaped) {
             out = ""
             i = 1
@@ -521,7 +514,7 @@ convert_gemini_prompt_body() {
             }
             print line
         }
-    ' <<< "$value"
+    '
 }
 
 create_archive() {

--- a/scripts/test-github-rest.sh
+++ b/scripts/test-github-rest.sh
@@ -50,6 +50,10 @@ if [ ! -f "$REST_LIB" ]; then
   exit 1
 fi
 
+if rg -q '<<<' "$REST_LIB"; then
+  fail "GitHub REST helpers feed JSON through Bash here-strings"
+fi
+
 source "$REST_LIB"
 
 current_pr=$(

--- a/scripts/test-installation.sh
+++ b/scripts/test-installation.sh
@@ -39,6 +39,21 @@ else
   echo "OK"
 fi
 
+echo -n "Gemini frontmatter parsing drains large inputs... "
+FRONTMATTER_EXTRACTOR=$(sed -n '/^extract_frontmatter_value()/,/^}/p' "$ROOT_DIR/scripts/build-universal.sh")
+eval "$FRONTMATTER_EXTRACTOR"
+LARGE_FRONTMATTER=$(awk 'BEGIN {
+  print "description: expected"
+  for (i = 0; i < 20000; i++) print "padding-key: padding-value"
+}')
+if EXTRACTED_DESCRIPTION=$(extract_frontmatter_value "$LARGE_FRONTMATTER" description) &&
+   [ "$EXTRACTED_DESCRIPTION" = "expected" ]; then
+  echo "OK"
+else
+  echo "FAIL"
+  ERRORS=$((ERRORS + 1))
+fi
+
 if [ -x /opt/homebrew/bin/bash ] &&
    /opt/homebrew/bin/bash --version | sed -n '1p' | rg -q 'version 5\.3\.' &&
    command -v gtimeout >/dev/null 2>&1; then

--- a/scripts/test-installation.sh
+++ b/scripts/test-installation.sh
@@ -30,6 +30,31 @@ line_absence_status() {
 
 echo "=== Plugin Installation Tests ==="
 
+echo -n "Gemini generation avoids heredoc and here-string I/O... "
+GEMINI_GENERATORS=$(sed -n '/^generate_gemini_extension_json()/,/^create_archive()/p' "$ROOT_DIR/scripts/build-universal.sh")
+if printf '%s\n' "$GEMINI_GENERATORS" | rg -q '<<<|<<[[:space:]]*[[:alnum:]'\''"]'; then
+  echo "FAIL"
+  ERRORS=$((ERRORS + 1))
+else
+  echo "OK"
+fi
+
+if [ -x /opt/homebrew/bin/bash ] &&
+   /opt/homebrew/bin/bash --version | sed -n '1p' | rg -q 'version 5\.3\.' &&
+   command -v gtimeout >/dev/null 2>&1; then
+  echo -n "Universal build completes under Bash 5.3... "
+  BASH_53_LOG=$(mktemp "${TMPDIR:-${TMP:-${TEMP:-/tmp}}}/gopher-ai-bash-53-build.XXXXXX")
+  if gtimeout 30 /opt/homebrew/bin/bash "$ROOT_DIR/scripts/build-universal.sh" >"$BASH_53_LOG" 2>&1; then
+    echo "OK"
+  else
+    BASH_53_STATUS=$?
+    echo "FAIL (status $BASH_53_STATUS)"
+    sed -n '1,120p' "$BASH_53_LOG"
+    ERRORS=$((ERRORS + 1))
+  fi
+  rm -f "$BASH_53_LOG"
+fi
+
 # Test 1: marketplace.json exists and is valid JSON
 echo -n "marketplace.json is valid JSON... "
 if ! jq . "$MARKETPLACE" >/dev/null 2>&1; then


### PR DESCRIPTION
## Summary

- replace Gemini generation heredocs and here-strings with streamed `printf` output
- stream GitHub REST watcher JSON into `jq` without Bash here-strings
- add bounded Bash 5.3 and structural regression coverage

## Test plan

- Homebrew Bash 5.3.9 clean-fixture universal build
- `scripts/test-github-rest.sh` under Bash 5.3.9
- full `scripts/test-installation.sh` from a clean fixture
- authoritative Detent `gate.run` validation

Fixes #339