### PR TITLE
test(detent): isolate composition fixtures

### DIFF
--- a/scripts/test-commands.sh
+++ b/scripts/test-commands.sh
@@ -407,6 +407,7 @@ elif ! (
   COMPOSITION_ROOT=$(mktemp -d "${TMPDIR:-/tmp}/gopher-ai-composition-state.XXXXXX")
   trap 'rm -rf "$COMPOSITION_ROOT"' EXIT
   cd "$COMPOSITION_ROOT"
+  COMPOSITION_ROOT=$(pwd -P)
   [ "$(resolve_loop_owner_root)" = "$COMPOSITION_ROOT" ]
   mkdir -p "$COMPOSITION_ROOT/.local/state"
   STATE_FILE="$COMPOSITION_ROOT/.local/state/complete-issue-302.loop.local.json"

--- a/scripts/test-commands.sh
+++ b/scripts/test-commands.sh
@@ -4,6 +4,12 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+FIXTURE_TMP_BASE="${TMPDIR:-${TMP:-${TEMP:-/tmp}}}"
+case "$FIXTURE_TMP_BASE/" in
+  "$ROOT_DIR/"*)
+    export GIT_CEILING_DIRECTORIES="$FIXTURE_TMP_BASE${GIT_CEILING_DIRECTORIES:+:$GIT_CEILING_DIRECTORIES}"
+    ;;
+esac
 
 ERRORS=0
 
@@ -400,6 +406,8 @@ elif ! (
   source "$ROOT_DIR/plugins/go-workflow/lib/loop-state.sh"
   COMPOSITION_ROOT=$(mktemp -d "${TMPDIR:-/tmp}/gopher-ai-composition-state.XXXXXX")
   trap 'rm -rf "$COMPOSITION_ROOT"' EXIT
+  cd "$COMPOSITION_ROOT"
+  [ "$(resolve_loop_owner_root)" = "$COMPOSITION_ROOT" ]
   mkdir -p "$COMPOSITION_ROOT/.local/state"
   STATE_FILE="$COMPOSITION_ROOT/.local/state/complete-issue-302.loop.local.json"
   printf '%s\n' '{"schema_version":2,"owner_workflow":"complete-issue","loop_name":"complete-issue-302","completion_promise":"COMPLETE","terminal_promises":["COMPLETE","INCOMPLETE"],"phase":"implementing","components":{}}' > "$STATE_FILE"


### PR DESCRIPTION
## Summary

- isolate command-test fixtures from an enclosing Detent worktree when the temporary base is repository-local
- run the composed-workflow state contract from its disposable fixture and assert that fixture owns loop state
- prevent composition validation from writing debug logs to the primary checkout

## Test Plan

- `env -u GIT_CEILING_DIRECTORIES GOCACHE="$PWD/.detent/tmp/go-build" GOMODCACHE="$PWD/.detent/tmp/go-mod" GOPATH="$PWD/.detent/tmp/go-path" ./scripts/test-commands.sh`
- authoritative `gate.run` command after rebasing onto current main (with the environment-only sandbox identity workaround tracked by #374)

Fixes #345
