### PR TITLE
chore(ci): pin patched Go toolchain

### DIFF
--- a/.github/workflows/agent-skills-ci.yml
+++ b/.github/workflows/agent-skills-ci.yml
@@ -85,13 +85,18 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: '1.22'
+          go-version: '1.26.7'
+      - name: Install govulncheck
+        run: go install golang.org/x/vuln/cmd/govulncheck@v1.7.0
       - name: Build demo repo
         working-directory: agent-skills/examples/demo-repo
         run: go build ./...
       - name: Test demo repo
         working-directory: agent-skills/examples/demo-repo
         run: go test ./...
+      - name: Scan demo repo for vulnerabilities
+        working-directory: agent-skills/examples/demo-repo
+        run: govulncheck ./...
 
   test-scripts-no-key:
     name: Test scripts without API key
@@ -101,7 +106,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: '1.22'
+          go-version: '1.26.7'
       - name: Install Go tools
         run: |
           go install honnef.co/go/tools/cmd/staticcheck@latest
@@ -259,7 +264,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: '1.22'
+          go-version: '1.26.7'
       - name: Install Go tools
         run: |
           go install honnef.co/go/tools/cmd/staticcheck@latest
@@ -300,7 +305,7 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
       - uses: actions/setup-go@v5
         with:
-          go-version: '1.25'
+          go-version: '1.26.7'
       - name: Install Go tools
         run: |
           go install honnef.co/go/tools/cmd/staticcheck@latest

--- a/agent-skills/tests/run-tests.sh
+++ b/agent-skills/tests/run-tests.sh
@@ -142,6 +142,36 @@ else
     fail "install.sh: still references old .github/skills/ path"
 fi
 
+header "CI Workflow Validation"
+
+CI_WORKFLOW="${AGENT_SKILLS_CI_WORKFLOW:-$ROOT_DIR/../.github/workflows/agent-skills-ci.yml}"
+SETUP_GO_COUNT=$(rg -c 'uses: actions/setup-go@v5' "$CI_WORKFLOW" || true)
+PINNED_GO_COUNT=$(rg -c "go-version: '1\.26\.7'" "$CI_WORKFLOW" || true)
+
+if [[ "$SETUP_GO_COUNT" -gt 0 && "$PINNED_GO_COUNT" == "$SETUP_GO_COUNT" ]]; then
+    pass "agent-skills CI: all setup-go steps use Go 1.26.7"
+else
+    fail "agent-skills CI: expected every setup-go step pinned to Go 1.26.7 (found $SETUP_GO_COUNT steps, $PINNED_GO_COUNT pins)"
+fi
+
+DEMO_JOB=$(sed -n '/^  test-demo-repo:/,/^  [a-z][a-z-]*:$/p' "$CI_WORKFLOW")
+VULN_SCAN_STEP_COUNT=$(rg -c '^      - name: Scan demo repo for vulnerabilities$' <<< "$DEMO_JOB" || true)
+VULN_SCAN_STEP=$(awk '
+    capture && (/^      - / || /^  [^ ]/) { exit }
+    /^      - name: Scan demo repo for vulnerabilities$/ { capture = 1 }
+    capture { print }
+' <<< "$DEMO_JOB")
+if rg -q 'go install golang.org/x/vuln/cmd/govulncheck@v1\.7\.0' <<< "$DEMO_JOB" && \
+   [[ "$VULN_SCAN_STEP_COUNT" == "1" ]] && \
+   rg -q '^        working-directory: agent-skills/examples/demo-repo$' <<< "$VULN_SCAN_STEP" && \
+   rg -q '^        run: govulncheck \./\.\.\.$' <<< "$VULN_SCAN_STEP" && \
+   ! rg -q '^[[:space:]]+continue-on-error:' <<< "$VULN_SCAN_STEP" && \
+   ! rg -q '\|\|[[:space:]]*true' <<< "$VULN_SCAN_STEP"; then
+    pass "agent-skills CI: demo repo has a hard govulncheck scan"
+else
+    fail "agent-skills CI: demo repo missing hard govulncheck scan"
+fi
+
 # ── Demo Repo Validation ────────────────────────────────────────────
 
 header "Demo Repo Validation"


### PR DESCRIPTION
## Summary

- pin every Agent Skills CI Go runner to Go 1.26.7
- add a hard govulncheck v1.7.0 scan for the demo module
- add regression checks for the toolchain pins and vulnerability gate

## Validation

- Agent Skills test suite: 38/38 passed
- Go 1.26.7 build and tests passed
- govulncheck v1.7.0: no vulnerabilities found
- ShellCheck, YAML parsing, and actionlint passed

Closes #342