### PR TITLE
fix(test): preserve composition cleanup target

### DIFF
--- a/scripts/test-commands.sh
+++ b/scripts/test-commands.sh
@@ -405,10 +405,10 @@ if ! validate_composition_contract "$ROOT_DIR"; then
 elif ! (
   source "$ROOT_DIR/plugins/go-workflow/lib/loop-state.sh"
   COMPOSITION_ROOT=$(mktemp -d "${TMPDIR:-/tmp}/gopher-ai-composition-state.XXXXXX") || exit 1
-  COMPOSITION_CLEANUP_ROOT=$COMPOSITION_ROOT
+  COMPOSITION_CLEANUP_ROOT=$(cd "$COMPOSITION_ROOT" && pwd -P) || exit 1
   trap 'rm -rf "$COMPOSITION_CLEANUP_ROOT"' EXIT
-  cd "$COMPOSITION_ROOT" || exit 1
-  COMPOSITION_ROOT=$(pwd -P) || exit 1
+  cd "$COMPOSITION_CLEANUP_ROOT" || exit 1
+  COMPOSITION_ROOT=$COMPOSITION_CLEANUP_ROOT
   [ "$(resolve_loop_owner_root)" = "$COMPOSITION_ROOT" ]
   mkdir -p "$COMPOSITION_ROOT/.local/state"
   STATE_FILE="$COMPOSITION_ROOT/.local/state/complete-issue-302.loop.local.json"

--- a/scripts/test-commands.sh
+++ b/scripts/test-commands.sh
@@ -404,10 +404,11 @@ if ! validate_composition_contract "$ROOT_DIR"; then
   COMPOSITION_FAILURE="composition contract is incomplete"
 elif ! (
   source "$ROOT_DIR/plugins/go-workflow/lib/loop-state.sh"
-  COMPOSITION_ROOT=$(mktemp -d "${TMPDIR:-/tmp}/gopher-ai-composition-state.XXXXXX")
-  trap 'rm -rf "$COMPOSITION_ROOT"' EXIT
-  cd "$COMPOSITION_ROOT"
-  COMPOSITION_ROOT=$(pwd -P)
+  COMPOSITION_ROOT=$(mktemp -d "${TMPDIR:-/tmp}/gopher-ai-composition-state.XXXXXX") || exit 1
+  COMPOSITION_CLEANUP_ROOT=$COMPOSITION_ROOT
+  trap 'rm -rf "$COMPOSITION_CLEANUP_ROOT"' EXIT
+  cd "$COMPOSITION_ROOT" || exit 1
+  COMPOSITION_ROOT=$(pwd -P) || exit 1
   [ "$(resolve_loop_owner_root)" = "$COMPOSITION_ROOT" ]
   mkdir -p "$COMPOSITION_ROOT/.local/state"
   STATE_FILE="$COMPOSITION_ROOT/.local/state/complete-issue-302.loop.local.json"


### PR DESCRIPTION
## Summary

- abort explicitly when the composition fixture cannot create or enter its temporary directory
- keep the original disposable path in a separate cleanup-only variable
- canonicalize the ownership path without changing the cleanup target

## Test Plan

- `TMPDIR=/tmp/ /bin/bash ./scripts/test-commands.sh`
- `shellcheck agent-skills/scripts/*.sh`
- `git diff --check`

Fixes #379