### PR TITLE
fix(go-web): resolve conversion plugin root

### DIFF
--- a/plugins/go-web/commands/convert-to-go-project.md
+++ b/plugins/go-web/commands/convert-to-go-project.md
@@ -6,5 +6,9 @@ allowed-tools: ["Bash(*setup-loop.sh*)", "Bash(go:*)", "Bash(git:*)", "Bash(npm:
 
 # Convert to Go Project
 
+Bind the injected `$ARGUMENTS` value to `SKILL_ARGS` without evaluating or re-tokenizing it.
+
+Bind `<PLUGIN_ROOT>` in the shared workflow to `${CLAUDE_PLUGIN_ROOT}`.
+
 Read `${CLAUDE_PLUGIN_ROOT}/references/convert-to-go-project.md` completely and follow it,
-passing `$ARGUMENTS` as the optional target directory.
+passing `SKILL_ARGS` as the optional target directory.

--- a/plugins/go-web/references/convert-to-go-project.md
+++ b/plugins/go-web/references/convert-to-go-project.md
@@ -1,12 +1,24 @@
 # Convert to Go Project
 
+## Plugin Resource Contract
+
+The caller must bind `<PLUGIN_ROOT>` to the concrete absolute path of the `go-web` plugin
+directory before reading resources or running commands. Do not treat `<PLUGIN_ROOT>` as a
+literal path.
+
+## Invocation Argument Contract
+
+`SKILL_ARGS` must already contain the optional target directory supplied through the active
+surface. Preserve it literally, trim only surrounding whitespace, and never evaluate it as
+shell code or read it from an environment variable.
+
 ## Cross-Platform Interaction
 
 When the workflow needs a user choice, use the active surface's native structured-input
 mechanism when available. Otherwise, ask the user directly and stop before any mutation that
 depends on the answer.
 
-**If `$ARGUMENTS` is empty or not provided:**
+**If `$SKILL_ARGS` is empty or not provided:**
 
 This command converts an existing project to the Go + Templ + HTMX + Tailwind stack.
 
@@ -37,20 +49,21 @@ Proceed to analyze the current directory.
 
 ---
 
-**If `$ARGUMENTS` is provided:**
+**If `$SKILL_ARGS` is provided:**
 
-Convert the project at `$ARGUMENTS` (or current directory if `.`) to the Go stack.
+Convert the project at `$SKILL_ARGS` (or current directory if `.`) to the Go stack.
 
-## Loop Initialization
+## Persistent Loop Protocol
 
-Initialize persistent loop to ensure conversion completes fully:
+On Claude Code, initialize the persistent loop to ensure conversion completes fully.
+On Codex, skip loop initialization and complete the workflow in the current invocation.
 
 ```bash
-if [ ! -x "${CLAUDE_PLUGIN_ROOT}/scripts/setup-loop.sh" ]; then
+if [ ! -x "<PLUGIN_ROOT>/scripts/setup-loop.sh" ]; then
   echo "ERROR: Plugin cache stale. Run /gopher-ai-refresh (or refresh-plugins.sh) and restart the active agent."
   exit 1
 else
-  "${CLAUDE_PLUGIN_ROOT}/scripts/setup-loop.sh" "convert-to-go-project" "COMPLETE"
+  "<PLUGIN_ROOT>/scripts/setup-loop.sh" "convert-to-go-project" "COMPLETE"
 fi
 ```
 
@@ -271,22 +284,22 @@ After selecting a deployment platform that runs the app as a server (Railway, Fl
 
 ## Step 3: Migration Strategy
 
-Framework-specific migration guides live in `${CLAUDE_PLUGIN_ROOT}/references/migrations/`.
+Framework-specific migration guides live in `<PLUGIN_ROOT>/references/migrations/`.
 After detecting the source framework (Step 1), read ONLY the matching guide:
 
 | Detected framework | Migration guide to read |
 |---|---|
-| Express.js / Fastify / other Node HTTP | `${CLAUDE_PLUGIN_ROOT}/references/migrations/express.md` |
-| Django / Flask / FastAPI | `${CLAUDE_PLUGIN_ROOT}/references/migrations/django-flask.md` |
-| Laravel / other PHP | `${CLAUDE_PLUGIN_ROOT}/references/migrations/laravel.md` |
-| Next.js / React SPA | `${CLAUDE_PLUGIN_ROOT}/references/migrations/nextjs.md` |
+| Express.js / Fastify / other Node HTTP | `<PLUGIN_ROOT>/references/migrations/express.md` |
+| Django / Flask / FastAPI | `<PLUGIN_ROOT>/references/migrations/django-flask.md` |
+| Laravel / other PHP | `<PLUGIN_ROOT>/references/migrations/laravel.md` |
+| Next.js / React SPA | `<PLUGIN_ROOT>/references/migrations/nextjs.md` |
 
 Each guide covers route mapping, middleware and template conversion, ORM-to-sqlc query
 migration, and that framework's meta/SEO migration patterns.
 
 If the source project uses jQuery, React state, or other client-side JavaScript for UI
 interactivity (dropdowns, modals, sidebars, tabs), also read
-`${CLAUDE_PLUGIN_ROOT}/references/migrations/client-side-templui.md` for templUI conversion
+`<PLUGIN_ROOT>/references/migrations/client-side-templui.md` for templUI conversion
 patterns (including the critical rules for templ interpolation inside JavaScript).
 
 If the detected framework has no guide, follow the "Unsupported Framework" flow in the Error
@@ -326,8 +339,8 @@ Add Go files to the project. Create the same structure as `/create-go-project`:
 ### Template Library
 
 All static file templates live in the plugin template library at
-`${CLAUDE_PLUGIN_ROOT}/templates/`. The manifest listing every template and its target path is
-`${CLAUDE_PLUGIN_ROOT}/templates/README.md`.
+`<PLUGIN_ROOT>/templates/`. The manifest listing every template and its target path is
+`<PLUGIN_ROOT>/templates/README.md`.
 
 **How to use a template:** Read the template file, replace every occurrence of the placeholder
 `{{PROJECT_NAME}}` with the project/module name chosen for the conversion, and Write the result
@@ -347,7 +360,7 @@ File Creation Order above. `<db>` is the selected database: `postgres`, `sqlite`
 When merging into an existing project, append to (rather than overwrite) files that already
 exist, such as `.gitignore` and `package.json`.
 
-| Template (`${CLAUDE_PLUGIN_ROOT}/templates/`) | Target in project | Notes |
+| Template (`<PLUGIN_ROOT>/templates/`) | Target in project | Notes |
 |---|---|---|
 | core/go.mod | go.mod | Add the database driver and service SDK requires (see below) |
 | core/gitignore | .gitignore | Append entries if a .gitignore already exists |
@@ -398,7 +411,7 @@ touch data/.gitkeep
 **If using templUI components:** install the CLI
 (`go install github.com/templui/templui@latest && templui add sidebar button card icon`),
 uncomment `e.Static("/assets", "assets")` in `internal/handler/handler.go`, and apply the
-`<head>` changes from `${CLAUDE_PLUGIN_ROOT}/templates/templ/base-templui-head.templ` to
+`<head>` changes from `<PLUGIN_ROOT>/templates/templ/base-templui-head.templ` to
 `templates/layouts/base.templ` (component Script() templates are required — see the
 client-side-templui migration guide).
 
@@ -415,16 +428,16 @@ ls -la .github/workflows/ .gitlab-ci.yml Jenkinsfile .circleci/ 2>/dev/null
 
 **If no CI exists:** Create the following files:
 
-| Template (`${CLAUDE_PLUGIN_ROOT}/templates/`) | Target in project | Notes |
+| Template (`<PLUGIN_ROOT>/templates/`) | Target in project | Notes |
 |---|---|---|
 | ci/ci.yml | .github/workflows/ci.yml | Keep ONLY the `sqlc-vet` job variant for the selected database; delete the other two commented variants |
 | ci/dependabot.yml | .github/dependabot.yml | Only if no dependabot config exists |
 
 ### Clerk Integration Files (if selected)
 
-If the user selected Clerk, read `${CLAUDE_PLUGIN_ROOT}/references/clerk-integration.md` and
+If the user selected Clerk, read `<PLUGIN_ROOT>/references/clerk-integration.md` and
 follow it completely. It covers the CRITICAL Clerk CDN rules, the file templates under
-`${CLAUDE_PLUGIN_ROOT}/templates/auth/`, and the required updates to `.envrc`, config,
+`<PLUGIN_ROOT>/templates/auth/`, and the required updates to `.envrc`, config,
 middleware/CSP, layouts, and routes. If Clerk was NOT selected, skip this entirely and do not
 read that file.
 
@@ -435,8 +448,8 @@ Based on the deployment platform and build method selected, load ONLY the matchi
 | Selection | Action |
 |---|---|
 | Vercel + Neon | Create `vercel.json`, `api/index.go`, and a `public/` directory |
-| Nixpacks (Railway, Coolify, Dokploy, self-hosted) | Read `${CLAUDE_PLUGIN_ROOT}/references/deployment/nixpacks.md` |
-| Dockerfile (Fly.io, self-hosted, or user preference) | Read `${CLAUDE_PLUGIN_ROOT}/references/deployment/dockerfile.md` |
+| Nixpacks (Railway, Coolify, Dokploy, self-hosted) | Read `<PLUGIN_ROOT>/references/deployment/nixpacks.md` |
+| Dockerfile (Fly.io, self-hosted, or user preference) | Read `<PLUGIN_ROOT>/references/deployment/dockerfile.md` |
 | Plain binary (self-hosted, no containers) | No additional files — the Makefile already covers `make dev`, `make build`, and `make run`; deploy the binary directly (systemd, supervisor, or a shell script) |
 
 ### Project Documentation
@@ -455,7 +468,7 @@ Check for these files first:
 **If any exist:** Preserve the existing file. Inform the user: "Found existing AI context file: [filename]. Preserving it."
 
 **If none exist:** Create a `CLAUDE.md` in the project root following the content guide in
-`${CLAUDE_PLUGIN_ROOT}/templates/docs/claude-md-guide.md` (adjust the project name).
+`<PLUGIN_ROOT>/templates/docs/claude-md-guide.md` (adjust the project name).
 
 ### SEO and Meta Tag Migration
 
@@ -466,7 +479,7 @@ The supporting files are already created from the template library in the Core F
 `templates/layouts/meta.templ`.
 
 Before converting any templates, read
-`${CLAUDE_PLUGIN_ROOT}/references/migrations/seo-preservation.md` for the metadata detection
+`<PLUGIN_ROOT>/references/migrations/seo-preservation.md` for the metadata detection
 commands, extraction checklist, site-wide config migration, OG image preservation, the per-page
 migration pattern, and the preserved-metadata report format. Framework-specific meta migration
 examples are in the framework guide you already loaded in Step 3.
@@ -594,7 +607,7 @@ After planning, execute the conversion:
 For each converted handler, create `internal/handler/<entity>_test.go` using `testutil.NewTestDB`
 and `testutil.NewTestConfig` with echo's `httptest` pattern. For a complete worked example
 (handler + list/create/validation tests), read
-`${CLAUDE_PLUGIN_ROOT}/references/crud-implementation-example.md` and adapt it to the converted
+`<PLUGIN_ROOT>/references/crud-implementation-example.md` and adapt it to the converted
 entities.
 
 **Test at least:**
@@ -725,7 +738,9 @@ Which approach fits your needs?
 
 ## Completion Criteria
 
-**DO NOT output `<done>COMPLETE</done>` until ALL of these conditions are TRUE:**
+On Claude Code, do not output `<done>COMPLETE</done>` until all of these conditions are true.
+On Codex, do not emit a completion marker; return the final summary only after all criteria are
+true.
 
 1. Go project structure is created alongside existing files
 2. All migrations are created from existing schema
@@ -736,7 +751,7 @@ Which approach fits your needs?
 7. `go test ./...` passes
 8. Server starts and responds to requests
 
-**When ALL criteria are met, output exactly:**
+**On Claude Code, when all criteria are met, output exactly:**
 
 ```
 <done>COMPLETE</done>

--- a/plugins/go-web/skills/convert-to-go-project/SKILL.md
+++ b/plugins/go-web/skills/convert-to-go-project/SKILL.md
@@ -6,5 +6,19 @@ argument-hint: "[target-directory]"
 
 # Convert to Go Project
 
-Read `${CLAUDE_PLUGIN_ROOT}/references/convert-to-go-project.md` completely and follow it,
-passing `$ARGUMENTS` as the optional target directory.
+## Invocation Argument Binding
+
+Bind the optional target directory to `SKILL_ARGS` before reading the shared workflow. For an
+explicit Codex invocation, use only the text following the exact qualified
+`$go-web:convert-to-go-project` token. Otherwise, derive the target directory from the
+activating request. Preserve the text literally, trim only surrounding whitespace, and never
+evaluate it as shell code or read it from an environment variable.
+
+## Plugin Resource Resolution
+
+`<PLUGIN_ROOT>` denotes the absolute path to the `go-web` plugin directory. Resolve it before
+reading any shared resource: start from the absolute path of this selected `SKILL.md` and
+ascend two directories (`skills/convert-to-go-project` to the plugin root).
+
+Read `<PLUGIN_ROOT>/references/convert-to-go-project.md` completely and follow it with
+`SKILL_ARGS` as the optional target directory.

--- a/plugins/go-workflow/hooks/legacy-skill-hashes.txt
+++ b/plugins/go-workflow/hooks/legacy-skill-hashes.txt
@@ -7,7 +7,7 @@
 # this prevents accepting a hash from skill A as proof of ownership for skill B.
 # DO NOT EDIT BY HAND — re-run the regen script after finalizing SKILL.md changes.
 #
-# Total entries: 336
+# Total entries: 337
 002bd0c3859a936f2bbfa90a8c967db4d141b99a741e4c23f0d5bec397a2d3fc complete-issue
 017e2d820506e7bef4a89a4d65839150db1ffdc124852a43dc916023e6d37e16 review-deep
 0232ae1141f76c0ba40045649179a566080de9fc717c6cb08c3961b827fe3e88 create-pr
@@ -81,6 +81,7 @@
 3fc0ab46af997a873358572307050f2dd0db622932552436b36ec0b4226b04fe address-review
 407b55dc982e18732824871d2f15ab0c1e816ea584e461429bac5e97bb940c1a ship
 409a09c10de7cbb72b46b5048dc28a6b175fcc76b9fcabc3c83364c804cfd4af complete-issue
+40dc25cc8228806930264e9b5f3443983b5dbf4c1253768a99ca9b9afdfb16b3 convert-to-go-project
 40ee12850668ef98e3f1e2bb7dc7c04961c99ad11cf575168a2b61c76fe16573 systematic-debugging
 4147ca72d20d9829c6f85ceca86607ab28d2b39652873bd51443ea995179efd2 commit
 4249d27e94b944fc3245b595f27b996ac3e555e61853509a23dc0ab8486fa47b validate-skills

--- a/scripts/legacy-skill-hashes.txt
+++ b/scripts/legacy-skill-hashes.txt
@@ -7,7 +7,7 @@
 # this prevents accepting a hash from skill A as proof of ownership for skill B.
 # DO NOT EDIT BY HAND — re-run the regen script after finalizing SKILL.md changes.
 #
-# Total entries: 336
+# Total entries: 337
 002bd0c3859a936f2bbfa90a8c967db4d141b99a741e4c23f0d5bec397a2d3fc complete-issue
 017e2d820506e7bef4a89a4d65839150db1ffdc124852a43dc916023e6d37e16 review-deep
 0232ae1141f76c0ba40045649179a566080de9fc717c6cb08c3961b827fe3e88 create-pr
@@ -81,6 +81,7 @@
 3fc0ab46af997a873358572307050f2dd0db622932552436b36ec0b4226b04fe address-review
 407b55dc982e18732824871d2f15ab0c1e816ea584e461429bac5e97bb940c1a ship
 409a09c10de7cbb72b46b5048dc28a6b175fcc76b9fcabc3c83364c804cfd4af complete-issue
+40dc25cc8228806930264e9b5f3443983b5dbf4c1253768a99ca9b9afdfb16b3 convert-to-go-project
 40ee12850668ef98e3f1e2bb7dc7c04961c99ad11cf575168a2b61c76fe16573 systematic-debugging
 4147ca72d20d9829c6f85ceca86607ab28d2b39652873bd51443ea995179efd2 commit
 4249d27e94b944fc3245b595f27b996ac3e555e61853509a23dc0ab8486fa47b validate-skills

--- a/scripts/probe-codex-skill-resources.sh
+++ b/scripts/probe-codex-skill-resources.sh
@@ -26,6 +26,7 @@ TIMEOUT_MARKER="$PROBE_DIR/timeout"
 mkdir -p "$PROBE_DIR/.agents/skills"
 ln -s "$ROOT_DIR/plugins/go-workflow/skills/commit" "$PROBE_DIR/.agents/skills/commit"
 ln -s "$ROOT_DIR/plugins/gopher-guides/skills/gopher-guides" "$PROBE_DIR/.agents/skills/gopher-guides"
+ln -s "$ROOT_DIR/plugins/go-web/skills/convert-to-go-project" "$PROBE_DIR/.agents/skills/convert-to-go-project"
 
 env -u PLUGIN_ROOT -u PLUGIN_DATA -u CLAUDE_PLUGIN_ROOT -u CLAUDE_PLUGIN_DATA -u GOPHER_GUIDES_API_KEY codex exec \
   --cd "$PROBE_DIR" \
@@ -35,7 +36,7 @@ env -u PLUGIN_ROOT -u PLUGIN_DATA -u CLAUDE_PLUGIN_ROOT -u CLAUDE_PLUGIN_DATA -u
   --sandbox read-only \
   --output-last-message "$LAST_MESSAGE" \
   - >"$EVENT_LOG" 2>&1 <<'PROMPT' &
-Invoke `$commit` and `$gopher-guides` for this read-only resource-resolution probe. Do not edit files, use the network, call an API, or request credentials.
+Invoke `$commit`, `$gopher-guides`, and `$convert-to-go-project` for this read-only resource-resolution probe. Do not edit files, use the network, call an API, or request credentials.
 
 For each selected skill, use the absolute selected `SKILL.md` path exposed by Codex and follow its Plugin Resource Resolution contract. Do not use or infer any plugin-root environment variable.
 
@@ -43,15 +44,18 @@ Use read-only shell commands to perform these checks:
 
 1. Derive the go-workflow plugin root, require that it is non-empty and absolute, and read the first line of `<PLUGIN_ROOT>/lib/driver-interaction.md`. Require that the file is readable.
 2. Derive the gopher-guides plugin root, require that it is non-empty and absolute, and require that `<PLUGIN_ROOT>/scripts/cache-api.sh` is executable.
-3. Invoke that cache wrapper with no arguments. Require a non-zero status and the exact stderr text `Usage: cache-api.sh <endpoint> <json-data>`.
-4. Invoke it with `practices` and `{"topic":"resource probe"}` while `GOPHER_GUIDES_API_KEY` is unset. Require a non-zero status and the exact stderr text `Error: GOPHER_GUIDES_API_KEY is not set`.
+3. Derive the go-web plugin root, require that it is non-empty and absolute, and read the first line of `<PLUGIN_ROOT>/references/convert-to-go-project.md`. Require the exact text `# Convert to Go Project`.
+4. Invoke the cache wrapper with no arguments. Require a non-zero status and the exact stderr text `Usage: cache-api.sh <endpoint> <json-data>`.
+5. Invoke it with `practices` and `{"topic":"resource probe"}` while `GOPHER_GUIDES_API_KEY` is unset. Require a non-zero status and the exact stderr text `Error: GOPHER_GUIDES_API_KEY is not set`.
 
-Only after all checks pass, respond with exactly these four plain-text lines, replacing each root placeholder with the concrete absolute root:
+Only after all checks pass, respond with exactly these six plain-text lines, replacing each root placeholder with the concrete absolute root:
 
 GO_WORKFLOW_PLUGIN_ROOT=<absolute-root>
 GO_WORKFLOW_RESOURCE=readable
 GOPHER_GUIDES_PLUGIN_ROOT=<absolute-root>
 GOPHER_GUIDES_USAGE=Usage: cache-api.sh <endpoint> <json-data>
+GO_WEB_PLUGIN_ROOT=<absolute-root>
+GO_WEB_CONVERSION_RESOURCE=# Convert to Go Project
 PROMPT
 PROBE_PID=$!
 
@@ -84,6 +88,7 @@ fi
 
 GO_WORKFLOW_PLUGIN_ROOT=$(sed -n 's/^GO_WORKFLOW_PLUGIN_ROOT=//p' "$LAST_MESSAGE")
 GOPHER_GUIDES_PLUGIN_ROOT=$(sed -n 's/^GOPHER_GUIDES_PLUGIN_ROOT=//p' "$LAST_MESSAGE")
+GO_WEB_PLUGIN_ROOT=$(sed -n 's/^GO_WEB_PLUGIN_ROOT=//p' "$LAST_MESSAGE")
 
 case "$GO_WORKFLOW_PLUGIN_ROOT" in
   /*) ;;
@@ -98,6 +103,15 @@ case "$GOPHER_GUIDES_PLUGIN_ROOT" in
   /*) ;;
   *)
     printf 'FAIL: missing absolute gopher-guides root evidence\n' >&2
+    sed -n '1,160p' "$EVENT_LOG" >&2
+    exit 1
+    ;;
+esac
+
+case "$GO_WEB_PLUGIN_ROOT" in
+  /*) ;;
+  *)
+    printf 'FAIL: missing absolute go-web root evidence\n' >&2
     sed -n '1,160p' "$EVENT_LOG" >&2
     exit 1
     ;;
@@ -119,6 +133,14 @@ test "$GOPHER_GUIDES_PLUGIN_ROOT" = "$ROOT_DIR/plugins/gopher-guides" || {
   printf 'FAIL: gopher-guides probe resolved a different installation\n' >&2
   exit 1
 }
+test -r "$GO_WEB_PLUGIN_ROOT/references/convert-to-go-project.md" || {
+  printf 'FAIL: resolved go-web conversion workflow is not readable\n' >&2
+  exit 1
+}
+test "$GO_WEB_PLUGIN_ROOT" = "$ROOT_DIR/plugins/go-web" || {
+  printf 'FAIL: go-web probe resolved a different installation\n' >&2
+  exit 1
+}
 rg -Fxq 'GO_WORKFLOW_RESOURCE=readable' "$LAST_MESSAGE" || {
   printf 'FAIL: missing go-workflow resource evidence\n' >&2
   exit 1
@@ -127,7 +149,12 @@ rg -Fxq 'GOPHER_GUIDES_USAGE=Usage: cache-api.sh <endpoint> <json-data>' "$LAST_
   printf 'FAIL: missing gopher-guides usage evidence\n' >&2
   exit 1
 }
+rg -Fxq 'GO_WEB_CONVERSION_RESOURCE=# Convert to Go Project' "$LAST_MESSAGE" || {
+  printf 'FAIL: missing go-web conversion resource evidence\n' >&2
+  exit 1
+}
 
 printf 'Codex skill resource probe passed\n'
 printf '  go-workflow: %s\n' "$GO_WORKFLOW_PLUGIN_ROOT/lib/driver-interaction.md"
 printf '  gopher-guides: %s\n' "$GOPHER_GUIDES_PLUGIN_ROOT/scripts/cache-api.sh"
+printf '  go-web: %s\n' "$GO_WEB_PLUGIN_ROOT/references/convert-to-go-project.md"

--- a/scripts/test-commands.sh
+++ b/scripts/test-commands.sh
@@ -299,6 +299,8 @@ elif ! file_contains 'codex exec' "$CODEX_RESOURCE_PROBE" ||
      ! file_contains 'env -u PLUGIN_ROOT -u PLUGIN_DATA -u CLAUDE_PLUGIN_ROOT -u CLAUDE_PLUGIN_DATA' "$CODEX_RESOURCE_PROBE" ||
      ! file_contains 'GO_WORKFLOW_PLUGIN_ROOT=' "$CODEX_RESOURCE_PROBE" ||
      ! file_contains 'GOPHER_GUIDES_PLUGIN_ROOT=' "$CODEX_RESOURCE_PROBE" ||
+     ! file_contains 'GO_WEB_PLUGIN_ROOT=' "$CODEX_RESOURCE_PROBE" ||
+     ! file_contains 'references/convert-to-go-project.md' "$CODEX_RESOURCE_PROBE" ||
      ! file_contains 'scripts/cache-api.sh' "$CODEX_RESOURCE_PROBE" ||
      ! file_contains 'Usage: cache-api.sh <endpoint> <json-data>' "$CODEX_RESOURCE_PROBE"; then
   echo "FAIL (live Codex resource probe lacks required safety or evidence checks)"

--- a/scripts/test-go-web-templates.sh
+++ b/scripts/test-go-web-templates.sh
@@ -8,7 +8,8 @@ TEMPLATE_DIR="$ROOT_DIR/plugins/go-web/templates"
 CONVERSION_COMMAND="$ROOT_DIR/plugins/go-web/commands/convert-to-go-project.md"
 CONVERSION_SKILL="$ROOT_DIR/plugins/go-web/skills/convert-to-go-project/SKILL.md"
 CONVERSION_WORKFLOW="$ROOT_DIR/plugins/go-web/references/convert-to-go-project.md"
-CONVERSION_WORKFLOW_ROUTE='Read `${CLAUDE_PLUGIN_ROOT}/references/convert-to-go-project.md`'
+CONVERSION_COMMAND_WORKFLOW_ROUTE='Read `${CLAUDE_PLUGIN_ROOT}/references/convert-to-go-project.md`'
+CONVERSION_SKILL_WORKFLOW_ROUTE='Read `<PLUGIN_ROOT>/references/convert-to-go-project.md`'
 CREATE_COMMAND="$ROOT_DIR/plugins/go-web/commands/create-go-project.md"
 CREATE_SKILL="$ROOT_DIR/plugins/go-web/skills/create-go-project/SKILL.md"
 CREATE_WORKFLOW="$ROOT_DIR/plugins/go-web/references/create-go-project.md"
@@ -415,40 +416,54 @@ if [ ! -f "$CONVERSION_WORKFLOW" ]; then
   fail "missing shared convert-to-go-project workflow"
 else
   require_literal "$CONVERSION_WORKFLOW" \
-    '| Express.js / Fastify / other Node HTTP | `${CLAUDE_PLUGIN_ROOT}/references/migrations/express.md` |' \
+    '| Express.js / Fastify / other Node HTTP | `<PLUGIN_ROOT>/references/migrations/express.md` |' \
     "shared conversion workflow must route Node HTTP frameworks to the Express migration guide"
   require_literal "$CONVERSION_WORKFLOW" \
-    '| Django / Flask / FastAPI | `${CLAUDE_PLUGIN_ROOT}/references/migrations/django-flask.md` |' \
+    '| Django / Flask / FastAPI | `<PLUGIN_ROOT>/references/migrations/django-flask.md` |' \
     "shared conversion workflow must route Python frameworks to the Django and Flask migration guide"
   require_literal "$CONVERSION_WORKFLOW" \
-    '| Laravel / other PHP | `${CLAUDE_PLUGIN_ROOT}/references/migrations/laravel.md` |' \
+    '| Laravel / other PHP | `<PLUGIN_ROOT>/references/migrations/laravel.md` |' \
     "shared conversion workflow must route PHP frameworks to the Laravel migration guide"
   require_literal "$CONVERSION_WORKFLOW" \
-    '| Next.js / React SPA | `${CLAUDE_PLUGIN_ROOT}/references/migrations/nextjs.md` |' \
+    '| Next.js / React SPA | `<PLUGIN_ROOT>/references/migrations/nextjs.md` |' \
     "shared conversion workflow must route React frameworks to the Next.js migration guide"
   require_literal "$CONVERSION_WORKFLOW" \
     '| `go.mod` | Go (existing) | Already Go - extend rather than convert |' \
     "shared conversion workflow must extend existing Go projects rather than replace them"
   require_literal "$CONVERSION_WORKFLOW" \
-    '`${CLAUDE_PLUGIN_ROOT}/references/migrations/client-side-templui.md`' \
+    '`<PLUGIN_ROOT>/references/migrations/client-side-templui.md`' \
     "shared conversion workflow must route client-side interactivity to the templUI migration guide"
-  require_literal "$CONVERSION_WORKFLOW" '`${CLAUDE_PLUGIN_ROOT}/templates/`' \
+  require_literal "$CONVERSION_WORKFLOW" '`<PLUGIN_ROOT>/templates/`' \
     "shared conversion workflow must use the plugin template library"
-  require_literal "$CONVERSION_WORKFLOW" '`${CLAUDE_PLUGIN_ROOT}/templates/README.md`' \
+  require_literal "$CONVERSION_WORKFLOW" '`<PLUGIN_ROOT>/templates/README.md`' \
     "shared conversion workflow must use the plugin template manifest"
+  reject_literal "$CONVERSION_WORKFLOW" '${CLAUDE_PLUGIN_ROOT}' \
+    "shared conversion workflow must not depend on a Claude-only plugin root"
+  require_literal "$CONVERSION_WORKFLOW" 'On Codex, skip loop initialization' \
+    "shared conversion workflow must not initialize Claude loop state on Codex"
+  require_literal "$CONVERSION_WORKFLOW" 'On Codex, do not emit a completion marker' \
+    "shared conversion workflow must not emit Claude completion markers on Codex"
   require_literal "$CONVERSION_WORKFLOW" "app/testutil.<db>.go" \
     "shared conversion workflow must select the database-specific test helper"
   reject_literal "$CONVERSION_WORKFLOW" "app/testutil.go" \
     "shared conversion workflow must not select the generic SQLite helper"
 fi
 
-require_literal "$CONVERSION_COMMAND" "$CONVERSION_WORKFLOW_ROUTE" \
+require_literal "$CONVERSION_COMMAND" "$CONVERSION_COMMAND_WORKFLOW_ROUTE" \
   "convert-to-go-project command must route to the shared conversion workflow"
+require_literal "$CONVERSION_COMMAND" 'Bind the injected `$ARGUMENTS` value to `SKILL_ARGS`' \
+  "convert-to-go-project command must bind Claude arguments to the portable contract"
+require_literal "$CONVERSION_COMMAND" 'Bind `<PLUGIN_ROOT>` in the shared workflow to `${CLAUDE_PLUGIN_ROOT}`' \
+  "convert-to-go-project command must bind the portable plugin root on Claude"
 
 if [ ! -f "$CONVERSION_SKILL" ]; then
   fail "missing convert-to-go-project Codex skill"
 else
-  require_literal "$CONVERSION_SKILL" "$CONVERSION_WORKFLOW_ROUTE" \
+  require_literal "$CONVERSION_SKILL" 'ascend two directories' \
+    "convert-to-go-project skill must resolve its concrete plugin root on Codex"
+  require_literal "$CONVERSION_SKILL" 'Bind the optional target directory to `SKILL_ARGS`' \
+    "convert-to-go-project skill must bind Codex arguments to the portable contract"
+  require_literal "$CONVERSION_SKILL" "$CONVERSION_SKILL_WORKFLOW_ROUTE" \
     "convert-to-go-project skill must route to the shared conversion workflow"
 fi
 


### PR DESCRIPTION
## Summary

- derive the Codex go-web plugin root from the selected absolute `SKILL.md` path
- use a portable `<PLUGIN_ROOT>` contract in the shared conversion workflow and bind it explicitly on Claude
- keep Claude-only loop lifecycle markers off the Codex execution path
- extend static and live clean-home Codex resource-resolution coverage

## Test Plan

- `./scripts/test-go-web-templates.sh`
- `./scripts/test-commands.sh`
- `shellcheck scripts/probe-codex-skill-resources.sh`
- complete repository gate from `detent.yaml`
- live clean-home `scripts/probe-codex-skill-resources.sh`

Fixes #371