### PR TITLE
fix(gopher-guides): retry lost lock publish

### DIFF
--- a/plugins/gopher-guides/scripts/cache-lock.sh
+++ b/plugins/gopher-guides/scripts/cache-lock.sh
@@ -94,17 +94,15 @@ owner_identity=$(process_identity "$$")
 attempt=0
 while true; do
   if mkdir "$LOCK_DIRECTORY" 2>/dev/null; then
-    if ! printf '%s\n' "$owner_identity" > "$OWNER_FILE"; then
-      rmdir "$LOCK_DIRECTORY" 2>/dev/null || true
-      exit 1
+    if printf '%s\n' "$owner_identity" 2>/dev/null > "$OWNER_FILE"; then
+      shopt -s nullglob
+      owner_files=("$LOCK_DIRECTORY"/owner.*)
+      shopt -u nullglob
+      if [ "${#owner_files[@]}" -eq 1 ] && [ "${owner_files[0]}" = "$OWNER_FILE" ]; then
+        break
+      fi
+      release_directory_lock
     fi
-    shopt -s nullglob
-    owner_files=("$LOCK_DIRECTORY"/owner.*)
-    shopt -u nullglob
-    if [ "${#owner_files[@]}" -eq 1 ] && [ "${owner_files[0]}" = "$OWNER_FILE" ]; then
-      break
-    fi
-    release_directory_lock
   else
     reclaim_portable_lock
   fi

--- a/scripts/test-hooks.sh
+++ b/scripts/test-hooks.sh
@@ -130,7 +130,8 @@ run_runtime_location_tests() {
   local cache_compatibility_work cache_compatibility_xdg cache_compatibility_target cache_compatibility_legacy
   local cache_compatibility_default_output cache_compatibility_legacy_output
   local cache_legacy_file cache_unrelated_file legacy_unrelated_file
-  local cache_lock_portable_cache cache_lock_smoke cache_lock_smoke_output
+  local cache_lock_portable_cache cache_lock_publish_bin cache_lock_publish_marker
+  local cache_lock_publish_output cache_lock_smoke cache_lock_smoke_output
   local cache_lock_portable_orphan_output
   local cache_lock_portable_output cache_lock_portable_reused_output
   local cache_clear_race cache_clear_race_bin cache_clear_race_output cache_clear_race_ready
@@ -138,7 +139,7 @@ run_runtime_location_tests() {
   local cache_clear_output_file cache_clear_pid clear_attempt
   local clear_cache_command default_clear_output expected_default_clear_output override_clear_output
   local default_cache_valid=false override_cache_valid=false compatibility_cache_valid=false
-  local cache_lock_smoke_valid=false cache_lock_portable_orphan_valid=false
+  local cache_lock_publish_valid=false cache_lock_smoke_valid=false cache_lock_portable_orphan_valid=false
   local cache_lock_portable_reused_valid=false cache_lock_portable_valid=false
   local cache_clear_race_cleared=false cache_clear_race_valid=false cache_clear_race_status=true
   local corrupt_cache_valid=false parallel_cache_valid=false parallel_status=true writer writer_pid
@@ -165,6 +166,8 @@ run_runtime_location_tests() {
   legacy_unrelated_file="$cache_fixture/work/.claude/settings.json"
   cache_lock_smoke="$cache_fixture/native-lock/cache.lock"
   cache_lock_portable_cache="$cache_fixture/native-lock/portable-cache.json"
+  cache_lock_publish_bin="$cache_fixture/publish-bin"
+  cache_lock_publish_marker="$cache_fixture/publish-stolen"
   cache_clear_race="$cache_fixture/clear-race/cache.json"
   cache_clear_race_bin="$cache_fixture/clear-race-bin"
   cache_clear_race_ready="$cache_fixture/clear-race-ready"
@@ -174,6 +177,7 @@ run_runtime_location_tests() {
   clear_cache_command=$(sed -n 's/^!`\(.*\)`$/\1/p' "$clear_cache")
 
   mkdir -p "$cache_home" "$cache_bin" "$cache_identity_bin" "$cache_parallel_bin" "$cache_parallel_barrier" \
+    "$cache_lock_publish_bin" \
     "$cache_fixture/work" "$cache_clear_race_bin" \
     "$(dirname "$cache_corrupt")" "$(dirname "$cache_compatibility_legacy")" \
     "$(dirname "$cache_lock_smoke")" "$(dirname "$cache_clear_race")"
@@ -203,6 +207,17 @@ run_runtime_location_tests() {
     'printf '\''%s\n'\'' '\''{"result":"ok"}'\''' \
     > "$cache_clear_race_bin/curl"
   chmod +x "$cache_clear_race_bin/curl"
+  printf '%s\n' \
+    '#!/bin/sh' \
+    'if [ "$#" -eq 1 ] && [ "$1" = "$CACHE_TEST_LOCK_DIRECTORY" ] && [ ! -e "$CACHE_TEST_STOLEN" ]; then' \
+    '  "$CACHE_TEST_REAL_MKDIR" "$1" || exit $?' \
+    '  "$CACHE_TEST_REAL_RMDIR" "$1" || exit $?' \
+    '  : > "$CACHE_TEST_STOLEN"' \
+    '  exit 0' \
+    'fi' \
+    'exec "$CACHE_TEST_REAL_MKDIR" "$@"' \
+    > "$cache_lock_publish_bin/mkdir"
+  chmod +x "$cache_lock_publish_bin/mkdir"
 
   "$cache_lock" "$cache_lock_smoke" sh -c 'exit 0'
   if cache_lock_smoke_output=$("$cache_lock" "$cache_lock_smoke" sh -c 'printf native-lock') &&
@@ -216,6 +231,20 @@ run_runtime_location_tests() {
      [ ! -e "$cache_lock_portable_cache" ] &&
      [ ! -d "${cache_lock_smoke}.directory" ]; then
     cache_lock_portable_valid=true
+  fi
+  printf '%s\n' '{"old":true}' > "$cache_lock_portable_cache"
+  if cache_lock_publish_output=$(PATH="$cache_lock_publish_bin:$PATH" \
+       CACHE_TEST_LOCK_DIRECTORY="${cache_lock_smoke}.directory" \
+       CACHE_TEST_STOLEN="$cache_lock_publish_marker" \
+       CACHE_TEST_REAL_MKDIR="$(command -v mkdir)" \
+       CACHE_TEST_REAL_RMDIR="$(command -v rmdir)" \
+       GOPHER_GUIDES_CACHE_LOCK_FORCE_PORTABLE=true \
+       "$cache_lock" "$cache_lock_smoke" "$cache_mutate" clear "$cache_lock_portable_cache") &&
+     [ -z "$cache_lock_publish_output" ] &&
+     [ -e "$cache_lock_publish_marker" ] &&
+     [ ! -e "$cache_lock_portable_cache" ] &&
+     [ ! -d "${cache_lock_smoke}.directory" ]; then
+    cache_lock_publish_valid=true
   fi
   mkdir "${cache_lock_smoke}.directory"
   printf '%s\n' stale > "${cache_lock_smoke}.directory/owner.99999999.1"
@@ -398,6 +427,7 @@ run_runtime_location_tests() {
      [ "$cache_lock_portable_orphan_valid" = true ] &&
      [ "$cache_lock_portable_reused_valid" = true ] &&
      [ "$cache_lock_portable_valid" = true ] &&
+     [ "$cache_lock_publish_valid" = true ] &&
      [ "$default_cache_valid" = true ] &&
      [ "$override_cache_valid" = true ] &&
      [ "$compatibility_cache_valid" = true ] &&


### PR DESCRIPTION
Closes #384

## Summary

- retry portable cache-lock acquisition when the lock directory disappears before owner publication
- avoid removing a lock directory that may already belong to a contender
- add a deterministic regression for the acquisition/publication interleaving

## Verification

- `GOPHER_AI_HOOK_TEST_FOCUS=runtime-locations ./scripts/test-hooks.sh` (5 consecutive runs)
- `./scripts/test-hooks.sh`
- `./scripts/test-installation.sh`
- `./scripts/test-commands.sh`
- `./scripts/test-worktree-create.sh`
- `./scripts/test-ship-e2e-gate.sh`
- `./scripts/check-shared-sync.sh`
- `shellcheck -e SC1090,SC1091,SC2016 plugins/gopher-guides/scripts/cache-lock.sh scripts/test-hooks.sh`

The local real-Codex lifecycle smoke was intentionally blocked by its active-session safety guard; CI runs that test in a clean process environment.