### PR TITLE
fix(workflow): enforce stop-hook session ownership

### DIFF
--- a/plugins/go-dev/scripts/setup-loop.sh
+++ b/plugins/go-dev/scripts/setup-loop.sh
@@ -19,6 +19,11 @@ fi
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 source "$SCRIPT_DIR/../lib/loop-state.sh"
 
+new_loop_instance_id() {
+  local created_at="$1"
+  printf '%s-%s-%s%s\n' "$created_at" "$$" "$RANDOM" "$RANDOM"
+}
+
 SAFE_LOOP_NAME=$(printf '%s\n' "$LOOP_NAME" | sed 's/[^a-zA-Z0-9_-]/-/g')
 OWNER_STATE_DIR=$(loop_state_directory)
 mkdir -p "$OWNER_STATE_DIR"
@@ -87,7 +92,19 @@ if [ -f "$STATE_FILE" ]; then
       "$LOOP_NAME" >&2
     exit 1
   fi
-  printf "Loop already active: %s\n" "$LOOP_NAME"
+  STORED_SESSION_ID=$(jq -r '.session_id // empty' "$STATE_FILE")
+  STORED_LOOP_INSTANCE_ID=$(jq -r '.loop_instance_id // empty' "$STATE_FILE")
+  if [ -z "$STORED_SESSION_ID" ] && [ -z "$STORED_LOOP_INSTANCE_ID" ]; then
+    LEGACY_STARTED_AT=$(jq -r '.started_at // empty' "$STATE_FILE")
+    if [ -z "$LEGACY_STARTED_AT" ]; then
+      LEGACY_STARTED_AT=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+    fi
+    STORED_LOOP_INSTANCE_ID=$(new_loop_instance_id "$LEGACY_STARTED_AT")
+    set_loop_field "$STATE_FILE" "loop_instance_id" "$STORED_LOOP_INSTANCE_ID" '[]'
+    printf 'Loop initialized: %s [%s]\n' "$LOOP_NAME" "$STORED_LOOP_INSTANCE_ID"
+  else
+    printf "Loop already active: %s\n" "$LOOP_NAME"
+  fi
   exit 0
 fi
 
@@ -101,7 +118,7 @@ SESSION_ID="${CLAUDE_SESSION_ID:-}"
 WORKTREE_PATH=$(resolve_loop_worktree_root)
 SESSION_WORKTREE_PATH="$WORKTREE_PATH"
 STARTED_AT=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
-LOOP_INSTANCE_ID="${STARTED_AT}-$$-${RANDOM}${RANDOM}"
+LOOP_INSTANCE_ID=$(new_loop_instance_id "$STARTED_AT")
 
 MAX_ITER_JSON="null"
 if [ -n "$MAX_ITERATIONS" ]; then

--- a/plugins/go-dev/scripts/setup-loop.sh
+++ b/plugins/go-dev/scripts/setup-loop.sh
@@ -100,6 +100,8 @@ fi
 SESSION_ID="${CLAUDE_SESSION_ID:-}"
 WORKTREE_PATH=$(resolve_loop_worktree_root)
 SESSION_WORKTREE_PATH="$WORKTREE_PATH"
+STARTED_AT=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+LOOP_INSTANCE_ID="${STARTED_AT}-$$-${RANDOM}${RANDOM}"
 
 MAX_ITER_JSON="null"
 if [ -n "$MAX_ITERATIONS" ]; then
@@ -131,7 +133,8 @@ jq -n \
   --arg completion_promise "$COMPLETION_PROMISE" \
   --argjson terminal_promises "$TERMINAL_PROMISES_JSON" \
   --arg phase "$INITIAL_PHASE" \
-  --arg started_at "$(date -u +"%Y-%m-%dT%H:%M:%SZ")" \
+  --arg started_at "$STARTED_AT" \
+  --arg loop_instance_id "$LOOP_INSTANCE_ID" \
   --arg session_id "$SESSION_ID" \
   --arg session_worktree_path "$SESSION_WORKTREE_PATH" \
   --arg worktree_path "$WORKTREE_PATH" \
@@ -147,6 +150,7 @@ jq -n \
     phase: $phase,
     bot_review_baseline: "",
     started_at: $started_at,
+    loop_instance_id: $loop_instance_id,
     session_id: $session_id,
     session_worktree_path: $session_worktree_path,
     worktree_path: $worktree_path,
@@ -156,5 +160,5 @@ jq -n \
     components: {}
   }' > "$TMP_FILE" && mv "$TMP_FILE" "$STATE_FILE"
 
-printf 'Loop initialized: %s\n' "$LOOP_NAME"
+printf 'Loop initialized: %s [%s]\n' "$LOOP_NAME" "$LOOP_INSTANCE_ID"
 printf 'Output <done>%s</done> when all completion criteria are met.\n' "$COMPLETION_PROMISE"

--- a/plugins/go-dev/scripts/setup-loop.sh
+++ b/plugins/go-dev/scripts/setup-loop.sh
@@ -95,16 +95,11 @@ if [ -f "$STATE_FILE" ]; then
   STORED_SESSION_ID=$(jq -r '.session_id // empty' "$STATE_FILE")
   STORED_LOOP_INSTANCE_ID=$(jq -r '.loop_instance_id // empty' "$STATE_FILE")
   if [ -z "$STORED_SESSION_ID" ] && [ -z "$STORED_LOOP_INSTANCE_ID" ]; then
-    LEGACY_STARTED_AT=$(jq -r '.started_at // empty' "$STATE_FILE")
-    if [ -z "$LEGACY_STARTED_AT" ]; then
-      LEGACY_STARTED_AT=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
-    fi
-    STORED_LOOP_INSTANCE_ID=$(new_loop_instance_id "$LEGACY_STARTED_AT")
-    set_loop_field "$STATE_FILE" "loop_instance_id" "$STORED_LOOP_INSTANCE_ID" '[]'
-    printf 'Loop initialized: %s [%s]\n' "$LOOP_NAME" "$STORED_LOOP_INSTANCE_ID"
-  else
-    printf "Loop already active: %s\n" "$LOOP_NAME"
+    printf "Error: cannot safely re-enter legacy ownerless loop '%s'; cancel it and restart.\n" \
+      "$LOOP_NAME" >&2
+    exit 1
   fi
+  printf "Loop already active: %s\n" "$LOOP_NAME"
   exit 0
 fi
 

--- a/plugins/go-web/scripts/setup-loop.sh
+++ b/plugins/go-web/scripts/setup-loop.sh
@@ -19,6 +19,11 @@ fi
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 source "$SCRIPT_DIR/../lib/loop-state.sh"
 
+new_loop_instance_id() {
+  local created_at="$1"
+  printf '%s-%s-%s%s\n' "$created_at" "$$" "$RANDOM" "$RANDOM"
+}
+
 SAFE_LOOP_NAME=$(printf '%s\n' "$LOOP_NAME" | sed 's/[^a-zA-Z0-9_-]/-/g')
 OWNER_STATE_DIR=$(loop_state_directory)
 mkdir -p "$OWNER_STATE_DIR"
@@ -87,7 +92,19 @@ if [ -f "$STATE_FILE" ]; then
       "$LOOP_NAME" >&2
     exit 1
   fi
-  printf "Loop already active: %s\n" "$LOOP_NAME"
+  STORED_SESSION_ID=$(jq -r '.session_id // empty' "$STATE_FILE")
+  STORED_LOOP_INSTANCE_ID=$(jq -r '.loop_instance_id // empty' "$STATE_FILE")
+  if [ -z "$STORED_SESSION_ID" ] && [ -z "$STORED_LOOP_INSTANCE_ID" ]; then
+    LEGACY_STARTED_AT=$(jq -r '.started_at // empty' "$STATE_FILE")
+    if [ -z "$LEGACY_STARTED_AT" ]; then
+      LEGACY_STARTED_AT=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+    fi
+    STORED_LOOP_INSTANCE_ID=$(new_loop_instance_id "$LEGACY_STARTED_AT")
+    set_loop_field "$STATE_FILE" "loop_instance_id" "$STORED_LOOP_INSTANCE_ID" '[]'
+    printf 'Loop initialized: %s [%s]\n' "$LOOP_NAME" "$STORED_LOOP_INSTANCE_ID"
+  else
+    printf "Loop already active: %s\n" "$LOOP_NAME"
+  fi
   exit 0
 fi
 
@@ -101,7 +118,7 @@ SESSION_ID="${CLAUDE_SESSION_ID:-}"
 WORKTREE_PATH=$(resolve_loop_worktree_root)
 SESSION_WORKTREE_PATH="$WORKTREE_PATH"
 STARTED_AT=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
-LOOP_INSTANCE_ID="${STARTED_AT}-$$-${RANDOM}${RANDOM}"
+LOOP_INSTANCE_ID=$(new_loop_instance_id "$STARTED_AT")
 
 MAX_ITER_JSON="null"
 if [ -n "$MAX_ITERATIONS" ]; then

--- a/plugins/go-web/scripts/setup-loop.sh
+++ b/plugins/go-web/scripts/setup-loop.sh
@@ -100,6 +100,8 @@ fi
 SESSION_ID="${CLAUDE_SESSION_ID:-}"
 WORKTREE_PATH=$(resolve_loop_worktree_root)
 SESSION_WORKTREE_PATH="$WORKTREE_PATH"
+STARTED_AT=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+LOOP_INSTANCE_ID="${STARTED_AT}-$$-${RANDOM}${RANDOM}"
 
 MAX_ITER_JSON="null"
 if [ -n "$MAX_ITERATIONS" ]; then
@@ -131,7 +133,8 @@ jq -n \
   --arg completion_promise "$COMPLETION_PROMISE" \
   --argjson terminal_promises "$TERMINAL_PROMISES_JSON" \
   --arg phase "$INITIAL_PHASE" \
-  --arg started_at "$(date -u +"%Y-%m-%dT%H:%M:%SZ")" \
+  --arg started_at "$STARTED_AT" \
+  --arg loop_instance_id "$LOOP_INSTANCE_ID" \
   --arg session_id "$SESSION_ID" \
   --arg session_worktree_path "$SESSION_WORKTREE_PATH" \
   --arg worktree_path "$WORKTREE_PATH" \
@@ -147,6 +150,7 @@ jq -n \
     phase: $phase,
     bot_review_baseline: "",
     started_at: $started_at,
+    loop_instance_id: $loop_instance_id,
     session_id: $session_id,
     session_worktree_path: $session_worktree_path,
     worktree_path: $worktree_path,
@@ -156,5 +160,5 @@ jq -n \
     components: {}
   }' > "$TMP_FILE" && mv "$TMP_FILE" "$STATE_FILE"
 
-printf 'Loop initialized: %s\n' "$LOOP_NAME"
+printf 'Loop initialized: %s [%s]\n' "$LOOP_NAME" "$LOOP_INSTANCE_ID"
 printf 'Output <done>%s</done> when all completion criteria are met.\n' "$COMPLETION_PROMISE"

--- a/plugins/go-web/scripts/setup-loop.sh
+++ b/plugins/go-web/scripts/setup-loop.sh
@@ -95,16 +95,11 @@ if [ -f "$STATE_FILE" ]; then
   STORED_SESSION_ID=$(jq -r '.session_id // empty' "$STATE_FILE")
   STORED_LOOP_INSTANCE_ID=$(jq -r '.loop_instance_id // empty' "$STATE_FILE")
   if [ -z "$STORED_SESSION_ID" ] && [ -z "$STORED_LOOP_INSTANCE_ID" ]; then
-    LEGACY_STARTED_AT=$(jq -r '.started_at // empty' "$STATE_FILE")
-    if [ -z "$LEGACY_STARTED_AT" ]; then
-      LEGACY_STARTED_AT=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
-    fi
-    STORED_LOOP_INSTANCE_ID=$(new_loop_instance_id "$LEGACY_STARTED_AT")
-    set_loop_field "$STATE_FILE" "loop_instance_id" "$STORED_LOOP_INSTANCE_ID" '[]'
-    printf 'Loop initialized: %s [%s]\n' "$LOOP_NAME" "$STORED_LOOP_INSTANCE_ID"
-  else
-    printf "Loop already active: %s\n" "$LOOP_NAME"
+    printf "Error: cannot safely re-enter legacy ownerless loop '%s'; cancel it and restart.\n" \
+      "$LOOP_NAME" >&2
+    exit 1
   fi
+  printf "Loop already active: %s\n" "$LOOP_NAME"
   exit 0
 fi
 

--- a/plugins/go-workflow/hooks/stop-hook.sh
+++ b/plugins/go-workflow/hooks/stop-hook.sh
@@ -69,6 +69,21 @@ block_stop() {
     '{"decision": "block", "reason": $reason, "systemMessage": $msg}'
 }
 
+transcript_proves_loop_initialization() {
+  local state_file="$1"
+  local loop_name
+
+  [ -n "$CURRENT_SESSION_ID" ] &&
+    [ -n "$TRANSCRIPT_PATH" ] &&
+    [ -f "$TRANSCRIPT_PATH" ] || return 1
+
+  loop_name=$(jq -r '.loop_name // empty' "$state_file" 2>/dev/null)
+  [ -n "$loop_name" ] || return 1
+
+  grep -Fq -- "Loop initialized: $loop_name\\n" "$TRANSCRIPT_PATH" ||
+    grep -Fq -- "Loop initialized: $loop_name\"" "$TRANSCRIPT_PATH"
+}
+
 session_owns_loop_state() {
   local state_file="$1"
   local stored_session_id
@@ -85,9 +100,12 @@ session_owns_loop_state() {
     [ "$stored_session_worktree_path" = "$CURRENT_WORKTREE_PATH" ] || return 1
   fi
 
-  [ -n "$stored_session_id" ] &&
-    [ -n "$CURRENT_SESSION_ID" ] &&
-    [ "$stored_session_id" = "$CURRENT_SESSION_ID" ]
+  if [ -n "$stored_session_id" ]; then
+    [ -n "$CURRENT_SESSION_ID" ] && [ "$stored_session_id" = "$CURRENT_SESSION_ID" ]
+    return
+  fi
+
+  transcript_proves_loop_initialization "$state_file"
 }
 
 state_is_stale_for_transcript() {
@@ -362,17 +380,17 @@ STATE_FILES=$(find_active_loops)
 OWNED_STATE_FILES=""
 while IFS= read -r CANDIDATE_STATE_FILE; do
   [ -n "$CANDIDATE_STATE_FILE" ] || continue
+  if state_has_stale_worktree "$CANDIDATE_STATE_FILE"; then
+    loop_log "stop-hook: pruning stale loop state '$CANDIDATE_STATE_FILE'"
+    cleanup_loop "$CANDIDATE_STATE_FILE"
+    continue
+  fi
   if state_has_explicit_session_mismatch "$CANDIDATE_STATE_FILE"; then
     loop_log "stop-hook: current session does not own loop state '$CANDIDATE_STATE_FILE', skipping"
     continue
   fi
   if state_is_stale_for_transcript "$CANDIDATE_STATE_FILE"; then
     loop_log "stop-hook: pruning timestamp-stale loop state '$CANDIDATE_STATE_FILE'"
-    cleanup_loop "$CANDIDATE_STATE_FILE"
-    continue
-  fi
-  if state_has_stale_worktree "$CANDIDATE_STATE_FILE"; then
-    loop_log "stop-hook: pruning stale loop state '$CANDIDATE_STATE_FILE'"
     cleanup_loop "$CANDIDATE_STATE_FILE"
     continue
   fi
@@ -441,6 +459,11 @@ if ! read_loop_state "$STATE_FILE" '[]' 2>/dev/null; then
   exit 0
 fi
 
+STORED_SESSION_ID=$(jq -r '.session_id // empty' "$STATE_FILE")
+if [ -z "$STORED_SESSION_ID" ] && [ -n "$CURRENT_SESSION_ID" ]; then
+  set_loop_field "$STATE_FILE" "session_id" "$CURRENT_SESSION_ID" '[]'
+  loop_log "stop-hook: claimed loop state '$STATE_FILE' for session '$CURRENT_SESSION_ID'"
+fi
 STORED_SESSION_WORKTREE_PATH=$(jq -r '.session_worktree_path // empty' "$STATE_FILE")
 if [ -z "$STORED_SESSION_WORKTREE_PATH" ]; then
   set_loop_field "$STATE_FILE" "session_worktree_path" "$CURRENT_WORKTREE_PATH" '[]'

--- a/plugins/go-workflow/hooks/stop-hook.sh
+++ b/plugins/go-workflow/hooks/stop-hook.sh
@@ -113,6 +113,16 @@ state_is_stale_for_transcript() {
     [ "$transcript_birth" -gt "$loop_epoch" ]
 }
 
+state_has_explicit_session_mismatch() {
+  local state_file="$1"
+  local stored_session_id
+
+  stored_session_id=$(jq -r '.session_id // empty' "$state_file" 2>/dev/null)
+  [ -n "$stored_session_id" ] &&
+    [ -n "$CURRENT_SESSION_ID" ] &&
+    [ "$stored_session_id" != "$CURRENT_SESSION_ID" ]
+}
+
 state_has_stale_worktree() {
   local state_file="$1"
   local field
@@ -352,6 +362,10 @@ STATE_FILES=$(find_active_loops)
 OWNED_STATE_FILES=""
 while IFS= read -r CANDIDATE_STATE_FILE; do
   [ -n "$CANDIDATE_STATE_FILE" ] || continue
+  if state_has_explicit_session_mismatch "$CANDIDATE_STATE_FILE"; then
+    loop_log "stop-hook: current session does not own loop state '$CANDIDATE_STATE_FILE', skipping"
+    continue
+  fi
   if state_is_stale_for_transcript "$CANDIDATE_STATE_FILE"; then
     loop_log "stop-hook: pruning timestamp-stale loop state '$CANDIDATE_STATE_FILE'"
     cleanup_loop "$CANDIDATE_STATE_FILE"

--- a/plugins/go-workflow/hooks/stop-hook.sh
+++ b/plugins/go-workflow/hooks/stop-hook.sh
@@ -17,6 +17,10 @@ set -euo pipefail
 HOOK_INPUT=$(cat)
 
 # Extract transcript path from hook input
+STOP_HOOK_ACTIVE=$(echo "$HOOK_INPUT" | jq -r '.stop_hook_active // false' 2>/dev/null)
+if [ "$STOP_HOOK_ACTIVE" = "true" ]; then
+  exit 0
+fi
 TRANSCRIPT_PATH=$(echo "$HOOK_INPUT" | jq -r '.transcript_path // empty' 2>/dev/null)
 CURRENT_SESSION_ID=$(echo "$HOOK_INPUT" | jq -r '.session_id // empty' 2>/dev/null)
 HOOK_CWD=$(echo "$HOOK_INPUT" | jq -r '.cwd // empty' 2>/dev/null)
@@ -65,26 +69,15 @@ block_stop() {
     '{"decision": "block", "reason": $reason, "systemMessage": $msg}'
 }
 
-transcript_owns_loop() {
-  local loop_name="$1"
-
-  [ -n "$loop_name" ] &&
-    [ -n "$TRANSCRIPT_PATH" ] &&
-    [ -f "$TRANSCRIPT_PATH" ] &&
-    grep -Fq -- "Loop initialized: $loop_name" "$TRANSCRIPT_PATH"
-}
-
 session_owns_loop_state() {
   local state_file="$1"
   local stored_session_id
   local stored_session_worktree_path
-  local loop_name
 
   [ -f "$state_file" ] && [ -r "$state_file" ] && jq empty "$state_file" 2>/dev/null || return 1
 
   stored_session_id=$(jq -r '.session_id // empty' "$state_file" 2>/dev/null)
   stored_session_worktree_path=$(jq -r '.session_worktree_path // empty' "$state_file" 2>/dev/null)
-  loop_name=$(jq -r '.loop_name // empty' "$state_file" 2>/dev/null)
 
   if [ -n "$stored_session_worktree_path" ]; then
     [ -d "$stored_session_worktree_path" ] || return 1
@@ -92,12 +85,32 @@ session_owns_loop_state() {
     [ "$stored_session_worktree_path" = "$CURRENT_WORKTREE_PATH" ] || return 1
   fi
 
-  if [ -n "$stored_session_id" ]; then
-    [ -n "$CURRENT_SESSION_ID" ] && [ "$stored_session_id" = "$CURRENT_SESSION_ID" ]
-    return
+  [ -n "$stored_session_id" ] &&
+    [ -n "$CURRENT_SESSION_ID" ] &&
+    [ "$stored_session_id" = "$CURRENT_SESSION_ID" ]
+}
+
+state_is_stale_for_transcript() {
+  local state_file="$1"
+  local started_at
+  local transcript_birth
+  local loop_epoch
+
+  [ -n "$TRANSCRIPT_PATH" ] && [ -f "$TRANSCRIPT_PATH" ] || return 1
+  started_at=$(jq -r '.started_at // empty' "$state_file" 2>/dev/null)
+  [ -n "$started_at" ] || return 1
+
+  if [[ "${OSTYPE:-}" == "darwin"* ]]; then
+    transcript_birth=$(stat -f %B "$TRANSCRIPT_PATH" 2>/dev/null || echo "0")
+    loop_epoch=$(date -j -f "%Y-%m-%dT%H:%M:%SZ" "$started_at" +%s 2>/dev/null || echo "0")
+  else
+    transcript_birth=$(stat -c %W "$TRANSCRIPT_PATH" 2>/dev/null || echo "0")
+    loop_epoch=$(date -d "$started_at" +%s 2>/dev/null || echo "0")
   fi
 
-  transcript_owns_loop "$loop_name"
+  [ "$loop_epoch" -gt 0 ] &&
+    [ "$transcript_birth" -gt 0 ] &&
+    [ "$transcript_birth" -gt "$loop_epoch" ]
 }
 
 state_has_stale_worktree() {
@@ -339,6 +352,11 @@ STATE_FILES=$(find_active_loops)
 OWNED_STATE_FILES=""
 while IFS= read -r CANDIDATE_STATE_FILE; do
   [ -n "$CANDIDATE_STATE_FILE" ] || continue
+  if state_is_stale_for_transcript "$CANDIDATE_STATE_FILE"; then
+    loop_log "stop-hook: pruning timestamp-stale loop state '$CANDIDATE_STATE_FILE'"
+    cleanup_loop "$CANDIDATE_STATE_FILE"
+    continue
+  fi
   if state_has_stale_worktree "$CANDIDATE_STATE_FILE"; then
     loop_log "stop-hook: pruning stale loop state '$CANDIDATE_STATE_FILE'"
     cleanup_loop "$CANDIDATE_STATE_FILE"
@@ -409,11 +427,6 @@ if ! read_loop_state "$STATE_FILE" '[]' 2>/dev/null; then
   exit 0
 fi
 
-STORED_SESSION_ID=$(jq -r '.session_id // empty' "$STATE_FILE")
-if [ -z "$STORED_SESSION_ID" ] && [ -n "$CURRENT_SESSION_ID" ]; then
-  set_loop_field "$STATE_FILE" "session_id" "$CURRENT_SESSION_ID" '[]'
-  loop_log "stop-hook: claimed loop state '$STATE_FILE' for session '$CURRENT_SESSION_ID'"
-fi
 STORED_SESSION_WORKTREE_PATH=$(jq -r '.session_worktree_path // empty' "$STATE_FILE")
 if [ -z "$STORED_SESSION_WORKTREE_PATH" ]; then
   set_loop_field "$STATE_FILE" "session_worktree_path" "$CURRENT_WORKTREE_PATH" '[]'

--- a/plugins/go-workflow/hooks/stop-hook.sh
+++ b/plugins/go-workflow/hooks/stop-hook.sh
@@ -115,8 +115,15 @@ state_is_stale_for_transcript() {
   local started_at
   local transcript_birth
   local loop_epoch
+  local loop_instance_id
+  local stored_session_id
 
   [ -n "$TRANSCRIPT_PATH" ] && [ -f "$TRANSCRIPT_PATH" ] || return 1
+  stored_session_id=$(jq -r '.session_id // empty' "$state_file" 2>/dev/null)
+  loop_instance_id=$(jq -r '.loop_instance_id // empty' "$state_file" 2>/dev/null)
+  if [ -z "$stored_session_id" ] && [ -n "$loop_instance_id" ]; then
+    return 1
+  fi
   started_at=$(jq -r '.started_at // empty' "$state_file" 2>/dev/null)
   [ -n "$started_at" ] || return 1
 

--- a/plugins/go-workflow/hooks/stop-hook.sh
+++ b/plugins/go-workflow/hooks/stop-hook.sh
@@ -71,6 +71,7 @@ block_stop() {
 
 transcript_proves_loop_initialization() {
   local state_file="$1"
+  local loop_instance_id
   local loop_name
 
   [ -n "$CURRENT_SESSION_ID" ] &&
@@ -78,10 +79,11 @@ transcript_proves_loop_initialization() {
     [ -f "$TRANSCRIPT_PATH" ] || return 1
 
   loop_name=$(jq -r '.loop_name // empty' "$state_file" 2>/dev/null)
-  [ -n "$loop_name" ] || return 1
+  loop_instance_id=$(jq -r '.loop_instance_id // empty' "$state_file" 2>/dev/null)
+  [ -n "$loop_name" ] && [ -n "$loop_instance_id" ] || return 1
 
-  grep -Fq -- "Loop initialized: $loop_name\\n" "$TRANSCRIPT_PATH" ||
-    grep -Fq -- "Loop initialized: $loop_name\"" "$TRANSCRIPT_PATH"
+  grep -Fq -- "Loop initialized: $loop_name [$loop_instance_id]\\n" "$TRANSCRIPT_PATH" ||
+    grep -Fq -- "Loop initialized: $loop_name [$loop_instance_id]\"" "$TRANSCRIPT_PATH"
 }
 
 session_owns_loop_state() {

--- a/plugins/go-workflow/scripts/setup-loop.sh
+++ b/plugins/go-workflow/scripts/setup-loop.sh
@@ -19,6 +19,11 @@ fi
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 source "$SCRIPT_DIR/../lib/loop-state.sh"
 
+new_loop_instance_id() {
+  local created_at="$1"
+  printf '%s-%s-%s%s\n' "$created_at" "$$" "$RANDOM" "$RANDOM"
+}
+
 SAFE_LOOP_NAME=$(printf '%s\n' "$LOOP_NAME" | sed 's/[^a-zA-Z0-9_-]/-/g')
 OWNER_STATE_DIR=$(loop_state_directory)
 mkdir -p "$OWNER_STATE_DIR"
@@ -87,7 +92,19 @@ if [ -f "$STATE_FILE" ]; then
       "$LOOP_NAME" >&2
     exit 1
   fi
-  printf "Loop already active: %s\n" "$LOOP_NAME"
+  STORED_SESSION_ID=$(jq -r '.session_id // empty' "$STATE_FILE")
+  STORED_LOOP_INSTANCE_ID=$(jq -r '.loop_instance_id // empty' "$STATE_FILE")
+  if [ -z "$STORED_SESSION_ID" ] && [ -z "$STORED_LOOP_INSTANCE_ID" ]; then
+    LEGACY_STARTED_AT=$(jq -r '.started_at // empty' "$STATE_FILE")
+    if [ -z "$LEGACY_STARTED_AT" ]; then
+      LEGACY_STARTED_AT=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+    fi
+    STORED_LOOP_INSTANCE_ID=$(new_loop_instance_id "$LEGACY_STARTED_AT")
+    set_loop_field "$STATE_FILE" "loop_instance_id" "$STORED_LOOP_INSTANCE_ID" '[]'
+    printf 'Loop initialized: %s [%s]\n' "$LOOP_NAME" "$STORED_LOOP_INSTANCE_ID"
+  else
+    printf "Loop already active: %s\n" "$LOOP_NAME"
+  fi
   exit 0
 fi
 
@@ -101,7 +118,7 @@ SESSION_ID="${CLAUDE_SESSION_ID:-}"
 WORKTREE_PATH=$(resolve_loop_worktree_root)
 SESSION_WORKTREE_PATH="$WORKTREE_PATH"
 STARTED_AT=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
-LOOP_INSTANCE_ID="${STARTED_AT}-$$-${RANDOM}${RANDOM}"
+LOOP_INSTANCE_ID=$(new_loop_instance_id "$STARTED_AT")
 
 MAX_ITER_JSON="null"
 if [ -n "$MAX_ITERATIONS" ]; then

--- a/plugins/go-workflow/scripts/setup-loop.sh
+++ b/plugins/go-workflow/scripts/setup-loop.sh
@@ -100,6 +100,8 @@ fi
 SESSION_ID="${CLAUDE_SESSION_ID:-}"
 WORKTREE_PATH=$(resolve_loop_worktree_root)
 SESSION_WORKTREE_PATH="$WORKTREE_PATH"
+STARTED_AT=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+LOOP_INSTANCE_ID="${STARTED_AT}-$$-${RANDOM}${RANDOM}"
 
 MAX_ITER_JSON="null"
 if [ -n "$MAX_ITERATIONS" ]; then
@@ -131,7 +133,8 @@ jq -n \
   --arg completion_promise "$COMPLETION_PROMISE" \
   --argjson terminal_promises "$TERMINAL_PROMISES_JSON" \
   --arg phase "$INITIAL_PHASE" \
-  --arg started_at "$(date -u +"%Y-%m-%dT%H:%M:%SZ")" \
+  --arg started_at "$STARTED_AT" \
+  --arg loop_instance_id "$LOOP_INSTANCE_ID" \
   --arg session_id "$SESSION_ID" \
   --arg session_worktree_path "$SESSION_WORKTREE_PATH" \
   --arg worktree_path "$WORKTREE_PATH" \
@@ -147,6 +150,7 @@ jq -n \
     phase: $phase,
     bot_review_baseline: "",
     started_at: $started_at,
+    loop_instance_id: $loop_instance_id,
     session_id: $session_id,
     session_worktree_path: $session_worktree_path,
     worktree_path: $worktree_path,
@@ -156,5 +160,5 @@ jq -n \
     components: {}
   }' > "$TMP_FILE" && mv "$TMP_FILE" "$STATE_FILE"
 
-printf 'Loop initialized: %s\n' "$LOOP_NAME"
+printf 'Loop initialized: %s [%s]\n' "$LOOP_NAME" "$LOOP_INSTANCE_ID"
 printf 'Output <done>%s</done> when all completion criteria are met.\n' "$COMPLETION_PROMISE"

--- a/plugins/go-workflow/scripts/setup-loop.sh
+++ b/plugins/go-workflow/scripts/setup-loop.sh
@@ -95,16 +95,11 @@ if [ -f "$STATE_FILE" ]; then
   STORED_SESSION_ID=$(jq -r '.session_id // empty' "$STATE_FILE")
   STORED_LOOP_INSTANCE_ID=$(jq -r '.loop_instance_id // empty' "$STATE_FILE")
   if [ -z "$STORED_SESSION_ID" ] && [ -z "$STORED_LOOP_INSTANCE_ID" ]; then
-    LEGACY_STARTED_AT=$(jq -r '.started_at // empty' "$STATE_FILE")
-    if [ -z "$LEGACY_STARTED_AT" ]; then
-      LEGACY_STARTED_AT=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
-    fi
-    STORED_LOOP_INSTANCE_ID=$(new_loop_instance_id "$LEGACY_STARTED_AT")
-    set_loop_field "$STATE_FILE" "loop_instance_id" "$STORED_LOOP_INSTANCE_ID" '[]'
-    printf 'Loop initialized: %s [%s]\n' "$LOOP_NAME" "$STORED_LOOP_INSTANCE_ID"
-  else
-    printf "Loop already active: %s\n" "$LOOP_NAME"
+    printf "Error: cannot safely re-enter legacy ownerless loop '%s'; cancel it and restart.\n" \
+      "$LOOP_NAME" >&2
+    exit 1
   fi
+  printf "Loop already active: %s\n" "$LOOP_NAME"
   exit 0
 fi
 

--- a/plugins/llm-tools/scripts/setup-loop.sh
+++ b/plugins/llm-tools/scripts/setup-loop.sh
@@ -19,6 +19,11 @@ fi
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 source "$SCRIPT_DIR/../lib/loop-state.sh"
 
+new_loop_instance_id() {
+  local created_at="$1"
+  printf '%s-%s-%s%s\n' "$created_at" "$$" "$RANDOM" "$RANDOM"
+}
+
 SAFE_LOOP_NAME=$(printf '%s\n' "$LOOP_NAME" | sed 's/[^a-zA-Z0-9_-]/-/g')
 OWNER_STATE_DIR=$(loop_state_directory)
 mkdir -p "$OWNER_STATE_DIR"
@@ -87,7 +92,19 @@ if [ -f "$STATE_FILE" ]; then
       "$LOOP_NAME" >&2
     exit 1
   fi
-  printf "Loop already active: %s\n" "$LOOP_NAME"
+  STORED_SESSION_ID=$(jq -r '.session_id // empty' "$STATE_FILE")
+  STORED_LOOP_INSTANCE_ID=$(jq -r '.loop_instance_id // empty' "$STATE_FILE")
+  if [ -z "$STORED_SESSION_ID" ] && [ -z "$STORED_LOOP_INSTANCE_ID" ]; then
+    LEGACY_STARTED_AT=$(jq -r '.started_at // empty' "$STATE_FILE")
+    if [ -z "$LEGACY_STARTED_AT" ]; then
+      LEGACY_STARTED_AT=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+    fi
+    STORED_LOOP_INSTANCE_ID=$(new_loop_instance_id "$LEGACY_STARTED_AT")
+    set_loop_field "$STATE_FILE" "loop_instance_id" "$STORED_LOOP_INSTANCE_ID" '[]'
+    printf 'Loop initialized: %s [%s]\n' "$LOOP_NAME" "$STORED_LOOP_INSTANCE_ID"
+  else
+    printf "Loop already active: %s\n" "$LOOP_NAME"
+  fi
   exit 0
 fi
 
@@ -101,7 +118,7 @@ SESSION_ID="${CLAUDE_SESSION_ID:-}"
 WORKTREE_PATH=$(resolve_loop_worktree_root)
 SESSION_WORKTREE_PATH="$WORKTREE_PATH"
 STARTED_AT=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
-LOOP_INSTANCE_ID="${STARTED_AT}-$$-${RANDOM}${RANDOM}"
+LOOP_INSTANCE_ID=$(new_loop_instance_id "$STARTED_AT")
 
 MAX_ITER_JSON="null"
 if [ -n "$MAX_ITERATIONS" ]; then

--- a/plugins/llm-tools/scripts/setup-loop.sh
+++ b/plugins/llm-tools/scripts/setup-loop.sh
@@ -100,6 +100,8 @@ fi
 SESSION_ID="${CLAUDE_SESSION_ID:-}"
 WORKTREE_PATH=$(resolve_loop_worktree_root)
 SESSION_WORKTREE_PATH="$WORKTREE_PATH"
+STARTED_AT=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+LOOP_INSTANCE_ID="${STARTED_AT}-$$-${RANDOM}${RANDOM}"
 
 MAX_ITER_JSON="null"
 if [ -n "$MAX_ITERATIONS" ]; then
@@ -131,7 +133,8 @@ jq -n \
   --arg completion_promise "$COMPLETION_PROMISE" \
   --argjson terminal_promises "$TERMINAL_PROMISES_JSON" \
   --arg phase "$INITIAL_PHASE" \
-  --arg started_at "$(date -u +"%Y-%m-%dT%H:%M:%SZ")" \
+  --arg started_at "$STARTED_AT" \
+  --arg loop_instance_id "$LOOP_INSTANCE_ID" \
   --arg session_id "$SESSION_ID" \
   --arg session_worktree_path "$SESSION_WORKTREE_PATH" \
   --arg worktree_path "$WORKTREE_PATH" \
@@ -147,6 +150,7 @@ jq -n \
     phase: $phase,
     bot_review_baseline: "",
     started_at: $started_at,
+    loop_instance_id: $loop_instance_id,
     session_id: $session_id,
     session_worktree_path: $session_worktree_path,
     worktree_path: $worktree_path,
@@ -156,5 +160,5 @@ jq -n \
     components: {}
   }' > "$TMP_FILE" && mv "$TMP_FILE" "$STATE_FILE"
 
-printf 'Loop initialized: %s\n' "$LOOP_NAME"
+printf 'Loop initialized: %s [%s]\n' "$LOOP_NAME" "$LOOP_INSTANCE_ID"
 printf 'Output <done>%s</done> when all completion criteria are met.\n' "$COMPLETION_PROMISE"

--- a/plugins/llm-tools/scripts/setup-loop.sh
+++ b/plugins/llm-tools/scripts/setup-loop.sh
@@ -95,16 +95,11 @@ if [ -f "$STATE_FILE" ]; then
   STORED_SESSION_ID=$(jq -r '.session_id // empty' "$STATE_FILE")
   STORED_LOOP_INSTANCE_ID=$(jq -r '.loop_instance_id // empty' "$STATE_FILE")
   if [ -z "$STORED_SESSION_ID" ] && [ -z "$STORED_LOOP_INSTANCE_ID" ]; then
-    LEGACY_STARTED_AT=$(jq -r '.started_at // empty' "$STATE_FILE")
-    if [ -z "$LEGACY_STARTED_AT" ]; then
-      LEGACY_STARTED_AT=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
-    fi
-    STORED_LOOP_INSTANCE_ID=$(new_loop_instance_id "$LEGACY_STARTED_AT")
-    set_loop_field "$STATE_FILE" "loop_instance_id" "$STORED_LOOP_INSTANCE_ID" '[]'
-    printf 'Loop initialized: %s [%s]\n' "$LOOP_NAME" "$STORED_LOOP_INSTANCE_ID"
-  else
-    printf "Loop already active: %s\n" "$LOOP_NAME"
+    printf "Error: cannot safely re-enter legacy ownerless loop '%s'; cancel it and restart.\n" \
+      "$LOOP_NAME" >&2
+    exit 1
   fi
+  printf "Loop already active: %s\n" "$LOOP_NAME"
   exit 0
 fi
 

--- a/plugins/tailwind/scripts/setup-loop.sh
+++ b/plugins/tailwind/scripts/setup-loop.sh
@@ -19,6 +19,11 @@ fi
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 source "$SCRIPT_DIR/../lib/loop-state.sh"
 
+new_loop_instance_id() {
+  local created_at="$1"
+  printf '%s-%s-%s%s\n' "$created_at" "$$" "$RANDOM" "$RANDOM"
+}
+
 SAFE_LOOP_NAME=$(printf '%s\n' "$LOOP_NAME" | sed 's/[^a-zA-Z0-9_-]/-/g')
 OWNER_STATE_DIR=$(loop_state_directory)
 mkdir -p "$OWNER_STATE_DIR"
@@ -87,7 +92,19 @@ if [ -f "$STATE_FILE" ]; then
       "$LOOP_NAME" >&2
     exit 1
   fi
-  printf "Loop already active: %s\n" "$LOOP_NAME"
+  STORED_SESSION_ID=$(jq -r '.session_id // empty' "$STATE_FILE")
+  STORED_LOOP_INSTANCE_ID=$(jq -r '.loop_instance_id // empty' "$STATE_FILE")
+  if [ -z "$STORED_SESSION_ID" ] && [ -z "$STORED_LOOP_INSTANCE_ID" ]; then
+    LEGACY_STARTED_AT=$(jq -r '.started_at // empty' "$STATE_FILE")
+    if [ -z "$LEGACY_STARTED_AT" ]; then
+      LEGACY_STARTED_AT=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+    fi
+    STORED_LOOP_INSTANCE_ID=$(new_loop_instance_id "$LEGACY_STARTED_AT")
+    set_loop_field "$STATE_FILE" "loop_instance_id" "$STORED_LOOP_INSTANCE_ID" '[]'
+    printf 'Loop initialized: %s [%s]\n' "$LOOP_NAME" "$STORED_LOOP_INSTANCE_ID"
+  else
+    printf "Loop already active: %s\n" "$LOOP_NAME"
+  fi
   exit 0
 fi
 
@@ -101,7 +118,7 @@ SESSION_ID="${CLAUDE_SESSION_ID:-}"
 WORKTREE_PATH=$(resolve_loop_worktree_root)
 SESSION_WORKTREE_PATH="$WORKTREE_PATH"
 STARTED_AT=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
-LOOP_INSTANCE_ID="${STARTED_AT}-$$-${RANDOM}${RANDOM}"
+LOOP_INSTANCE_ID=$(new_loop_instance_id "$STARTED_AT")
 
 MAX_ITER_JSON="null"
 if [ -n "$MAX_ITERATIONS" ]; then

--- a/plugins/tailwind/scripts/setup-loop.sh
+++ b/plugins/tailwind/scripts/setup-loop.sh
@@ -100,6 +100,8 @@ fi
 SESSION_ID="${CLAUDE_SESSION_ID:-}"
 WORKTREE_PATH=$(resolve_loop_worktree_root)
 SESSION_WORKTREE_PATH="$WORKTREE_PATH"
+STARTED_AT=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+LOOP_INSTANCE_ID="${STARTED_AT}-$$-${RANDOM}${RANDOM}"
 
 MAX_ITER_JSON="null"
 if [ -n "$MAX_ITERATIONS" ]; then
@@ -131,7 +133,8 @@ jq -n \
   --arg completion_promise "$COMPLETION_PROMISE" \
   --argjson terminal_promises "$TERMINAL_PROMISES_JSON" \
   --arg phase "$INITIAL_PHASE" \
-  --arg started_at "$(date -u +"%Y-%m-%dT%H:%M:%SZ")" \
+  --arg started_at "$STARTED_AT" \
+  --arg loop_instance_id "$LOOP_INSTANCE_ID" \
   --arg session_id "$SESSION_ID" \
   --arg session_worktree_path "$SESSION_WORKTREE_PATH" \
   --arg worktree_path "$WORKTREE_PATH" \
@@ -147,6 +150,7 @@ jq -n \
     phase: $phase,
     bot_review_baseline: "",
     started_at: $started_at,
+    loop_instance_id: $loop_instance_id,
     session_id: $session_id,
     session_worktree_path: $session_worktree_path,
     worktree_path: $worktree_path,
@@ -156,5 +160,5 @@ jq -n \
     components: {}
   }' > "$TMP_FILE" && mv "$TMP_FILE" "$STATE_FILE"
 
-printf 'Loop initialized: %s\n' "$LOOP_NAME"
+printf 'Loop initialized: %s [%s]\n' "$LOOP_NAME" "$LOOP_INSTANCE_ID"
 printf 'Output <done>%s</done> when all completion criteria are met.\n' "$COMPLETION_PROMISE"

--- a/plugins/tailwind/scripts/setup-loop.sh
+++ b/plugins/tailwind/scripts/setup-loop.sh
@@ -95,16 +95,11 @@ if [ -f "$STATE_FILE" ]; then
   STORED_SESSION_ID=$(jq -r '.session_id // empty' "$STATE_FILE")
   STORED_LOOP_INSTANCE_ID=$(jq -r '.loop_instance_id // empty' "$STATE_FILE")
   if [ -z "$STORED_SESSION_ID" ] && [ -z "$STORED_LOOP_INSTANCE_ID" ]; then
-    LEGACY_STARTED_AT=$(jq -r '.started_at // empty' "$STATE_FILE")
-    if [ -z "$LEGACY_STARTED_AT" ]; then
-      LEGACY_STARTED_AT=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
-    fi
-    STORED_LOOP_INSTANCE_ID=$(new_loop_instance_id "$LEGACY_STARTED_AT")
-    set_loop_field "$STATE_FILE" "loop_instance_id" "$STORED_LOOP_INSTANCE_ID" '[]'
-    printf 'Loop initialized: %s [%s]\n' "$LOOP_NAME" "$STORED_LOOP_INSTANCE_ID"
-  else
-    printf "Loop already active: %s\n" "$LOOP_NAME"
+    printf "Error: cannot safely re-enter legacy ownerless loop '%s'; cancel it and restart.\n" \
+      "$LOOP_NAME" >&2
+    exit 1
   fi
+  printf "Loop already active: %s\n" "$LOOP_NAME"
   exit 0
 fi
 

--- a/scripts/test-hooks.sh
+++ b/scripts/test-hooks.sh
@@ -1058,12 +1058,17 @@ else
   ERRORS=$((ERRORS + 1))
 fi
 
-echo -n "  Stop hook never claims an empty session ID from transcript evidence... "
+echo -n "  Stop hook claims ownerless state from exact transcript initialization evidence... "
 OWNER_CLAIM_ROOT=$(mktemp -d "$HOOK_TMP_BASE/gopher-ai-stop-hook-owner-claim.XXXXXX")
 OWNER_CLAIM_STATE="$OWNER_CLAIM_ROOT/.local/state/ship.loop.local.json"
 OWNER_CLAIM_TRANSCRIPT="$OWNER_CLAIM_ROOT/transcript.jsonl"
 mkdir -p "$(dirname "$OWNER_CLAIM_STATE")"
-printf '%s\n' '{"schema_version":2,"owner_workflow":"ship","loop_name":"ship","iteration":1,"max_iterations":50,"completion_promise":"SHIPPED","terminal_promises":["SHIPPED","INCOMPLETE"],"components":{},"phase":"ci-watch","original_prompt":"ship","session_id":""}' > "$OWNER_CLAIM_STATE"
+printf '%s\n' '{"role":"assistant","message":{"content":[]}}' > "$OWNER_CLAIM_TRANSCRIPT"
+(
+  cd "$OWNER_CLAIM_ROOT"
+  env -u CLAUDE_SESSION_ID "$ROOT_DIR/shared/scripts/setup-loop.sh" \
+    "ship" "SHIPPED" 50 "ci-watch" '{}' >/dev/null
+)
 printf '%s\n' '{"role":"user","message":{"content":[{"type":"tool_result","content":"Loop initialized: ship\nOutput <done>SHIPPED</done> when all completion criteria are met."}]}}' > "$OWNER_CLAIM_TRANSCRIPT"
 OWNER_CLAIM_BEFORE=$(cksum "$OWNER_CLAIM_STATE")
 OWNER_CLAIM_OUTPUT=$(
@@ -1071,8 +1076,30 @@ OWNER_CLAIM_OUTPUT=$(
   jq -n --arg transcript "$OWNER_CLAIM_TRANSCRIPT" --arg session "owner-session" \
     '{transcript_path: $transcript, session_id: $session}' | "$CORE_STOP_HOOK"
 )
-if [ -z "$OWNER_CLAIM_OUTPUT" ] &&
-   [ "$OWNER_CLAIM_BEFORE" = "$(cksum "$OWNER_CLAIM_STATE")" ]; then
+if printf '%s\n' "$OWNER_CLAIM_OUTPUT" | jq -e '.decision == "block"' >/dev/null 2>&1 &&
+   jq -e '.iteration == 2 and .session_id == "owner-session"' "$OWNER_CLAIM_STATE" >/dev/null 2>&1 &&
+   [ "$OWNER_CLAIM_BEFORE" != "$(cksum "$OWNER_CLAIM_STATE")" ]; then
+  echo "OK"
+else
+  echo "FAIL"
+  ERRORS=$((ERRORS + 1))
+fi
+
+echo -n "  Stop hook ignores ownerless state without transcript initialization evidence... "
+UNCLAIMED_ROOT=$(mktemp -d "$HOOK_TMP_BASE/gopher-ai-stop-hook-unclaimed.XXXXXX")
+UNCLAIMED_STATE="$UNCLAIMED_ROOT/.local/state/ship.loop.local.json"
+UNCLAIMED_TRANSCRIPT="$UNCLAIMED_ROOT/transcript.jsonl"
+mkdir -p "$(dirname "$UNCLAIMED_STATE")"
+printf '%s\n' '{"schema_version":2,"owner_workflow":"ship","loop_name":"ship","iteration":1,"max_iterations":50,"completion_promise":"SHIPPED","terminal_promises":["SHIPPED","INCOMPLETE"],"components":{},"phase":"ci-watch","original_prompt":"ship","session_id":""}' > "$UNCLAIMED_STATE"
+printf '%s\n' '{"role":"assistant","message":{"content":[{"type":"text","text":"Unrelated session output."}]}}' > "$UNCLAIMED_TRANSCRIPT"
+UNCLAIMED_BEFORE=$(cksum "$UNCLAIMED_STATE")
+UNCLAIMED_OUTPUT=$(
+  cd "$UNCLAIMED_ROOT"
+  jq -n --arg transcript "$UNCLAIMED_TRANSCRIPT" --arg session "foreign-session" \
+    '{transcript_path: $transcript, session_id: $session}' | "$CORE_STOP_HOOK"
+)
+if [ -z "$UNCLAIMED_OUTPUT" ] &&
+   [ "$UNCLAIMED_BEFORE" = "$(cksum "$UNCLAIMED_STATE")" ]; then
   echo "OK"
 else
   echo "FAIL"
@@ -1279,6 +1306,29 @@ STALE_WORKTREE_OUTPUT=$(
     '{transcript_path: $transcript, session_id: $session}' | "$CORE_STOP_HOOK"
 )
 if [ -z "$STALE_WORKTREE_OUTPUT" ] && [ ! -e "$STALE_WORKTREE_STATE" ]; then
+  echo "OK"
+else
+  echo "FAIL"
+  ERRORS=$((ERRORS + 1))
+fi
+
+echo -n "  Stop hook prunes foreign state whose worktree no longer exists... "
+FOREIGN_STALE_WORKTREE_ROOT=$(mktemp -d "$HOOK_TMP_BASE/gopher-ai-stop-hook-foreign-stale-worktree.XXXXXX")
+FOREIGN_STALE_WORKTREE_STATE="$FOREIGN_STALE_WORKTREE_ROOT/.local/state/ship.loop.local.json"
+FOREIGN_STALE_WORKTREE_TRANSCRIPT="$FOREIGN_STALE_WORKTREE_ROOT/transcript.jsonl"
+mkdir -p "$(dirname "$FOREIGN_STALE_WORKTREE_STATE")"
+jq -n \
+  --arg owner "$FOREIGN_STALE_WORKTREE_ROOT" \
+  --arg missing "$FOREIGN_STALE_WORKTREE_ROOT/missing-worktree" \
+  '{schema_version:2,owner_workflow:"ship",loop_name:"ship",iteration:1,max_iterations:50,completion_promise:"SHIPPED",terminal_promises:["SHIPPED","INCOMPLETE"],components:{},phase:"pushing",original_prompt:"ship",session_id:"owner-session",session_worktree_path:$owner,worktree_path:$missing}' \
+  > "$FOREIGN_STALE_WORKTREE_STATE"
+printf '%s\n' '{"role":"assistant","message":{"content":[{"type":"text","text":"Unrelated session output."}]}}' > "$FOREIGN_STALE_WORKTREE_TRANSCRIPT"
+FOREIGN_STALE_WORKTREE_OUTPUT=$(
+  cd "$FOREIGN_STALE_WORKTREE_ROOT"
+  jq -n --arg transcript "$FOREIGN_STALE_WORKTREE_TRANSCRIPT" --arg session "foreign-session" \
+    '{transcript_path: $transcript, session_id: $session}' | "$CORE_STOP_HOOK"
+)
+if [ -z "$FOREIGN_STALE_WORKTREE_OUTPUT" ] && [ ! -e "$FOREIGN_STALE_WORKTREE_STATE" ]; then
   echo "OK"
 else
   echo "FAIL"

--- a/scripts/test-hooks.sh
+++ b/scripts/test-hooks.sh
@@ -1041,7 +1041,7 @@ FOREIGN_SESSION_ROOT=$(mktemp -d "$HOOK_TMP_BASE/gopher-ai-stop-hook-foreign-ses
 FOREIGN_SESSION_STATE="$FOREIGN_SESSION_ROOT/.local/state/ship.loop.local.json"
 FOREIGN_SESSION_TRANSCRIPT="$FOREIGN_SESSION_ROOT/foreign-session.jsonl"
 mkdir -p "$(dirname "$FOREIGN_SESSION_STATE")"
-printf '%s\n' '{"schema_version":2,"owner_workflow":"ship","loop_name":"ship","iteration":4,"max_iterations":50,"completion_promise":"SHIPPED","terminal_promises":["SHIPPED","INCOMPLETE"],"components":{},"phase":"ci-watch","original_prompt":"ship","session_id":"owner-session"}' > "$FOREIGN_SESSION_STATE"
+printf '%s\n' '{"schema_version":2,"owner_workflow":"ship","loop_name":"ship","iteration":4,"max_iterations":50,"completion_promise":"SHIPPED","terminal_promises":["SHIPPED","INCOMPLETE"],"components":{},"phase":"ci-watch","original_prompt":"ship","started_at":"2000-01-01T00:00:00Z","session_id":"owner-session"}' > "$FOREIGN_SESSION_STATE"
 printf '%s\n' '{"role":"assistant","message":{"content":[{"type":"text","text":"Unrelated session output."}]}}' > "$FOREIGN_SESSION_TRANSCRIPT"
 FOREIGN_SESSION_BEFORE=$(cksum "$FOREIGN_SESSION_STATE")
 FOREIGN_SESSION_OUTPUT=$(

--- a/scripts/test-hooks.sh
+++ b/scripts/test-hooks.sh
@@ -1064,21 +1064,53 @@ OWNER_CLAIM_STATE="$OWNER_CLAIM_ROOT/.local/state/ship.loop.local.json"
 OWNER_CLAIM_TRANSCRIPT="$OWNER_CLAIM_ROOT/transcript.jsonl"
 mkdir -p "$(dirname "$OWNER_CLAIM_STATE")"
 printf '%s\n' '{"role":"assistant","message":{"content":[]}}' > "$OWNER_CLAIM_TRANSCRIPT"
-(
+OWNER_CLAIM_SETUP_OUTPUT=$(
   cd "$OWNER_CLAIM_ROOT"
   env -u CLAUDE_SESSION_ID "$ROOT_DIR/shared/scripts/setup-loop.sh" \
-    "ship" "SHIPPED" 50 "ci-watch" '{}' >/dev/null
+    "ship" "SHIPPED" 50 "ci-watch" '{}'
 )
-printf '%s\n' '{"role":"user","message":{"content":[{"type":"tool_result","content":"Loop initialized: ship\nOutput <done>SHIPPED</done> when all completion criteria are met."}]}}' > "$OWNER_CLAIM_TRANSCRIPT"
+OWNER_CLAIM_INSTANCE=$(jq -r '.loop_instance_id // empty' "$OWNER_CLAIM_STATE")
+jq -n --arg content "$OWNER_CLAIM_SETUP_OUTPUT" \
+  '{role:"user",message:{content:[{type:"tool_result",content:$content}]}}' \
+  > "$OWNER_CLAIM_TRANSCRIPT"
 OWNER_CLAIM_BEFORE=$(cksum "$OWNER_CLAIM_STATE")
 OWNER_CLAIM_OUTPUT=$(
   cd "$OWNER_CLAIM_ROOT"
   jq -n --arg transcript "$OWNER_CLAIM_TRANSCRIPT" --arg session "owner-session" \
     '{transcript_path: $transcript, session_id: $session}' | "$CORE_STOP_HOOK"
 )
-if printf '%s\n' "$OWNER_CLAIM_OUTPUT" | jq -e '.decision == "block"' >/dev/null 2>&1 &&
+if [ -n "$OWNER_CLAIM_INSTANCE" ] &&
+   printf '%s\n' "$OWNER_CLAIM_SETUP_OUTPUT" | grep -Fq "Loop initialized: ship [$OWNER_CLAIM_INSTANCE]" &&
+   printf '%s\n' "$OWNER_CLAIM_OUTPUT" | jq -e '.decision == "block"' >/dev/null 2>&1 &&
    jq -e '.iteration == 2 and .session_id == "owner-session"' "$OWNER_CLAIM_STATE" >/dev/null 2>&1 &&
    [ "$OWNER_CLAIM_BEFORE" != "$(cksum "$OWNER_CLAIM_STATE")" ]; then
+  echo "OK"
+else
+  echo "FAIL"
+  ERRORS=$((ERRORS + 1))
+fi
+
+echo -n "  Stop hook rejects historical name-only evidence for a new ownerless instance... "
+HISTORICAL_ROOT=$(mktemp -d "$HOOK_TMP_BASE/gopher-ai-stop-hook-historical.XXXXXX")
+HISTORICAL_STATE="$HISTORICAL_ROOT/.local/state/ship.loop.local.json"
+HISTORICAL_TRANSCRIPT="$HISTORICAL_ROOT/transcript.jsonl"
+mkdir -p "$(dirname "$HISTORICAL_STATE")"
+printf '%s\n' \
+  '{"role":"user","message":{"content":[{"type":"tool_result","content":"Loop initialized: ship\nOutput <done>SHIPPED</done> when all completion criteria are met."}]}}' \
+  '{"role":"assistant","message":{"content":[{"type":"text","text":"<done>SHIPPED</done>"}]}}' \
+  > "$HISTORICAL_TRANSCRIPT"
+jq -n --arg started_at "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+  '{schema_version:2,owner_workflow:"ship",loop_name:"ship",loop_instance_id:"current-instance",iteration:1,max_iterations:50,completion_promise:"SHIPPED",terminal_promises:["SHIPPED","INCOMPLETE"],components:{},phase:"ci-watch",original_prompt:"ship",started_at:$started_at,session_id:""}' \
+  > "$HISTORICAL_STATE"
+HISTORICAL_BEFORE=$(cksum "$HISTORICAL_STATE")
+HISTORICAL_OUTPUT=$(
+  cd "$HISTORICAL_ROOT"
+  jq -n --arg transcript "$HISTORICAL_TRANSCRIPT" --arg session "foreign-session" \
+    '{transcript_path: $transcript, session_id: $session}' | "$CORE_STOP_HOOK"
+)
+if [ -z "$HISTORICAL_OUTPUT" ] &&
+   [ -e "$HISTORICAL_STATE" ] &&
+   [ "$HISTORICAL_BEFORE" = "$(cksum "$HISTORICAL_STATE")" ]; then
   echo "OK"
 else
   echo "FAIL"

--- a/scripts/test-hooks.sh
+++ b/scripts/test-hooks.sh
@@ -1058,6 +1058,28 @@ else
   ERRORS=$((ERRORS + 1))
 fi
 
+echo -n "  Stop hook preserves fresh ownerless state for a later foreign transcript... "
+FOREIGN_OWNERLESS_ROOT=$(mktemp -d "$HOOK_TMP_BASE/gopher-ai-stop-hook-foreign-ownerless.XXXXXX")
+FOREIGN_OWNERLESS_STATE="$FOREIGN_OWNERLESS_ROOT/.local/state/ship.loop.local.json"
+FOREIGN_OWNERLESS_TRANSCRIPT="$FOREIGN_OWNERLESS_ROOT/foreign-session.jsonl"
+mkdir -p "$(dirname "$FOREIGN_OWNERLESS_STATE")"
+printf '%s\n' '{"schema_version":2,"owner_workflow":"ship","loop_name":"ship","loop_instance_id":"owner-instance","iteration":4,"max_iterations":50,"completion_promise":"SHIPPED","terminal_promises":["SHIPPED","INCOMPLETE"],"components":{},"phase":"ci-watch","original_prompt":"ship","started_at":"2000-01-01T00:00:00Z","session_id":""}' > "$FOREIGN_OWNERLESS_STATE"
+printf '%s\n' '{"role":"assistant","message":{"content":[{"type":"text","text":"Unrelated session output."}]}}' > "$FOREIGN_OWNERLESS_TRANSCRIPT"
+FOREIGN_OWNERLESS_BEFORE=$(cksum "$FOREIGN_OWNERLESS_STATE")
+FOREIGN_OWNERLESS_OUTPUT=$(
+  cd "$FOREIGN_OWNERLESS_ROOT"
+  jq -n --arg transcript "$FOREIGN_OWNERLESS_TRANSCRIPT" --arg session "foreign-session" \
+    '{transcript_path: $transcript, session_id: $session}' | "$CORE_STOP_HOOK"
+)
+if [ -z "$FOREIGN_OWNERLESS_OUTPUT" ] &&
+   [ -e "$FOREIGN_OWNERLESS_STATE" ] &&
+   [ "$FOREIGN_OWNERLESS_BEFORE" = "$(cksum "$FOREIGN_OWNERLESS_STATE")" ]; then
+  echo "OK"
+else
+  echo "FAIL"
+  ERRORS=$((ERRORS + 1))
+fi
+
 echo -n "  Stop hook claims ownerless state from exact transcript initialization evidence... "
 OWNER_CLAIM_ROOT=$(mktemp -d "$HOOK_TMP_BASE/gopher-ai-stop-hook-owner-claim.XXXXXX")
 OWNER_CLAIM_STATE="$OWNER_CLAIM_ROOT/.local/state/ship.loop.local.json"

--- a/scripts/test-hooks.sh
+++ b/scripts/test-hooks.sh
@@ -786,7 +786,7 @@ STOP_HOOK_ROOT=$(mktemp -d "$HOOK_TMP_BASE/gopher-ai-stop-hook.XXXXXX")
 STOP_HOOK_STATE="$STOP_HOOK_ROOT/.local/state/ship.loop.local.json"
 STOP_HOOK_TRANSCRIPT="$STOP_HOOK_ROOT/transcript.jsonl"
 mkdir -p "$(dirname "$STOP_HOOK_STATE")"
-printf '%s\n' '{"loop_name":"ship","iteration":1,"max_iterations":50,"completion_promise":"SHIPPED","phase":"pushing","original_prompt":"ship","session_id":"","awaiting_driver_input":false,"driver_input_reason":""}' > "$STOP_HOOK_STATE"
+printf '%s\n' '{"loop_name":"ship","iteration":1,"max_iterations":50,"completion_promise":"SHIPPED","phase":"pushing","original_prompt":"ship","session_id":"owner-session","awaiting_driver_input":false,"driver_input_reason":""}' > "$STOP_HOOK_STATE"
 printf '%s\n' '{"role":"user","message":{"content":[{"type":"tool_result","content":"Loop initialized: ship"}]}}' > "$STOP_HOOK_TRANSCRIPT"
 
 if (
@@ -795,7 +795,7 @@ if (
   pause_loop_for_driver "$STOP_HOOK_STATE" "dirty-tree-decision"
   "$ROOT_DIR/plugins/go-workflow/scripts/setup-loop.sh" \
     "ship" "SHIPPED" 50 "" '{}' >/dev/null
-  PAUSED_OUTPUT=$(jq -n --arg transcript "$STOP_HOOK_TRANSCRIPT" '{transcript_path: $transcript}' | bash "$ROOT_DIR/plugins/go-workflow/hooks/stop-hook.sh")
+  PAUSED_OUTPUT=$(jq -n --arg transcript "$STOP_HOOK_TRANSCRIPT" --arg session "owner-session" '{transcript_path: $transcript, session_id: $session}' | bash "$ROOT_DIR/plugins/go-workflow/hooks/stop-hook.sh")
   [ -z "$PAUSED_OUTPUT" ]
   jq -e '
     .iteration == 1 and
@@ -804,7 +804,7 @@ if (
     .driver_input_reason == "dirty-tree-decision"
   ' "$STOP_HOOK_STATE" >/dev/null
   resume_loop_after_driver "$STOP_HOOK_STATE"
-  RESUMED_OUTPUT=$(jq -n --arg transcript "$STOP_HOOK_TRANSCRIPT" '{transcript_path: $transcript}' | bash "$ROOT_DIR/plugins/go-workflow/hooks/stop-hook.sh")
+  RESUMED_OUTPUT=$(jq -n --arg transcript "$STOP_HOOK_TRANSCRIPT" --arg session "owner-session" '{transcript_path: $transcript, session_id: $session}' | bash "$ROOT_DIR/plugins/go-workflow/hooks/stop-hook.sh")
   printf '%s\n' "$RESUMED_OUTPUT" | jq -e '.decision == "block"' >/dev/null
   jq -e '
     .iteration == 2 and
@@ -943,20 +943,20 @@ if (
   cd "$STOP_HOOK_REASON_ROOT"
   REASON_FAILURES=0
   for STATE_JSON in \
-    '{"loop_name":"start-issue-302","iteration":1,"max_iterations":50,"completion_promise":"COMPLETE","phase":"","original_prompt":"","session_id":"","awaiting_driver_input":false,"driver_input_reason":""}' \
-    '{"loop_name":"start-issue-302","iteration":1,"max_iterations":50,"completion_promise":"COMPLETE","phase":"","session_id":"","awaiting_driver_input":false,"driver_input_reason":""}' \
-    '{"loop_name":"start-issue-302","iteration":1,"max_iterations":50,"completion_promise":"COMPLETE","phase":"","original_prompt":"   ","session_id":"","awaiting_driver_input":false,"driver_input_reason":""}' \
-    '{"loop_name":"start-issue-302","iteration":1,"max_iterations":50,"completion_promise":"COMPLETE","phase":"custom","phase_messages":{"custom":"   "},"original_prompt":"Continue issue 302.","session_id":"","awaiting_driver_input":false,"driver_input_reason":""}'
+    '{"loop_name":"start-issue-302","iteration":1,"max_iterations":50,"completion_promise":"COMPLETE","phase":"","original_prompt":"","session_id":"owner-session","awaiting_driver_input":false,"driver_input_reason":""}' \
+    '{"loop_name":"start-issue-302","iteration":1,"max_iterations":50,"completion_promise":"COMPLETE","phase":"","session_id":"owner-session","awaiting_driver_input":false,"driver_input_reason":""}' \
+    '{"loop_name":"start-issue-302","iteration":1,"max_iterations":50,"completion_promise":"COMPLETE","phase":"","original_prompt":"   ","session_id":"owner-session","awaiting_driver_input":false,"driver_input_reason":""}' \
+    '{"loop_name":"start-issue-302","iteration":1,"max_iterations":50,"completion_promise":"COMPLETE","phase":"custom","phase_messages":{"custom":"   "},"original_prompt":"Continue issue 302.","session_id":"owner-session","awaiting_driver_input":false,"driver_input_reason":""}'
   do
     printf '%s\n' "$STATE_JSON" > "$STOP_HOOK_REASON_STATE"
-    STOP_OUTPUT=$(jq -n --arg transcript "$STOP_HOOK_REASON_TRANSCRIPT" '{transcript_path: $transcript}' | bash "$ROOT_DIR/plugins/go-workflow/hooks/stop-hook.sh")
+    STOP_OUTPUT=$(jq -n --arg transcript "$STOP_HOOK_REASON_TRANSCRIPT" --arg session "owner-session" '{transcript_path: $transcript, session_id: $session}' | bash "$ROOT_DIR/plugins/go-workflow/hooks/stop-hook.sh")
     if ! printf '%s\n' "$STOP_OUTPUT" | has_nonempty_block_reason; then
       REASON_FAILURES=$((REASON_FAILURES + 1))
     fi
   done
 
-  printf '%s\n' '{"loop_name":"start-issue-302","iteration":1,"max_iterations":50,"completion_promise":"COMPLETE","phase":"","original_prompt":"Continue issue 302.","session_id":"","awaiting_driver_input":false,"driver_input_reason":""}' > "$STOP_HOOK_REASON_STATE"
-  STOP_OUTPUT=$(jq -n --arg transcript "$STOP_HOOK_REASON_TRANSCRIPT" '{transcript_path: $transcript}' | bash "$ROOT_DIR/plugins/go-workflow/hooks/stop-hook.sh")
+  printf '%s\n' '{"loop_name":"start-issue-302","iteration":1,"max_iterations":50,"completion_promise":"COMPLETE","phase":"","original_prompt":"Continue issue 302.","session_id":"owner-session","awaiting_driver_input":false,"driver_input_reason":""}' > "$STOP_HOOK_REASON_STATE"
+  STOP_OUTPUT=$(jq -n --arg transcript "$STOP_HOOK_REASON_TRANSCRIPT" --arg session "owner-session" '{transcript_path: $transcript, session_id: $session}' | bash "$ROOT_DIR/plugins/go-workflow/hooks/stop-hook.sh")
   if ! printf '%s\n' "$STOP_OUTPUT" | jq -e '.reason == "Continue issue 302."' >/dev/null; then
     REASON_FAILURES=$((REASON_FAILURES + 1))
   fi
@@ -977,13 +977,13 @@ sed \
   -e 's/^  REASON="Continue working on the task\."$/  REASON=""/' \
   -e 's/^    reason="Loop execution is blocked by invalid state\."$/    reason=""/' \
   "$REASON_MUTATION_ROOT/hooks/stop-hook.sh" > "$REASON_MUTATION_ROOT/hooks/stop-hook-mutated.sh"
-printf '%s\n' '{"loop_name":"start-issue-302","iteration":1,"max_iterations":50,"completion_promise":"COMPLETE","phase":"","original_prompt":"","session_id":""}' \
+printf '%s\n' '{"loop_name":"start-issue-302","iteration":1,"max_iterations":50,"completion_promise":"COMPLETE","phase":"","original_prompt":"","session_id":"owner-session"}' \
   > "$REASON_MUTATION_ROOT/.local/state/start-issue-302.loop.local.json"
 printf '%s\n' '{"role":"user","message":{"content":[{"type":"tool_result","content":"Loop initialized: start-issue-302"}]}}' \
   > "$REASON_MUTATION_ROOT/transcript.jsonl"
 MUTATED_REASON_OUTPUT=$(
   cd "$REASON_MUTATION_ROOT"
-  jq -n --arg transcript "$REASON_MUTATION_ROOT/transcript.jsonl" '{transcript_path: $transcript}' | bash hooks/stop-hook-mutated.sh
+  jq -n --arg transcript "$REASON_MUTATION_ROOT/transcript.jsonl" --arg session "owner-session" '{transcript_path: $transcript, session_id: $session}' | bash hooks/stop-hook-mutated.sh
 )
 if grep -F -q 'REASON=""' "$REASON_MUTATION_ROOT/hooks/stop-hook-mutated.sh" &&
    ! printf '%s\n' "$MUTATED_REASON_OUTPUT" | has_nonempty_block_reason; then
@@ -996,21 +996,40 @@ fi
 CORE_STOP_HOOK="$ROOT_DIR/shared/hooks/stop-hook.sh"
 CORE_LOOP_LIB="$ROOT_DIR/shared/lib/loop-state.sh"
 
-echo -n "  Stop hook ignores a foreign transcript when legacy state has no session ID... "
+echo -n "  Stop hook exits immediately when stop_hook_active is true... "
+ACTIVE_STOP_ROOT=$(mktemp -d "$HOOK_TMP_BASE/gopher-ai-stop-hook-active.XXXXXX")
+ACTIVE_STOP_STATE="$ACTIVE_STOP_ROOT/.local/state/ship.loop.local.json"
+ACTIVE_STOP_TRANSCRIPT="$ACTIVE_STOP_ROOT/owner-session.jsonl"
+mkdir -p "$(dirname "$ACTIVE_STOP_STATE")"
+printf '%s\n' '{"schema_version":2,"owner_workflow":"ship","loop_name":"ship","iteration":1,"max_iterations":50,"completion_promise":"SHIPPED","terminal_promises":["SHIPPED","INCOMPLETE"],"components":{},"phase":"ci-watch","original_prompt":"ship","session_id":"owner-session"}' > "$ACTIVE_STOP_STATE"
+printf '%s\n' '{"role":"user","message":{"content":[{"type":"tool_result","content":"Loop initialized: ship"}]}}' > "$ACTIVE_STOP_TRANSCRIPT"
+ACTIVE_STOP_BEFORE=$(cksum "$ACTIVE_STOP_STATE")
+ACTIVE_STOP_OUTPUT=$(
+  cd "$ACTIVE_STOP_ROOT"
+  jq -n --arg transcript "$ACTIVE_STOP_TRANSCRIPT" --arg session "owner-session" \
+    '{transcript_path: $transcript, session_id: $session, stop_hook_active: true}' | "$CORE_STOP_HOOK"
+)
+if [ -z "$ACTIVE_STOP_OUTPUT" ] &&
+   [ "$ACTIVE_STOP_BEFORE" = "$(cksum "$ACTIVE_STOP_STATE")" ]; then
+  echo "OK"
+else
+  echo "FAIL"
+  ERRORS=$((ERRORS + 1))
+fi
+
+echo -n "  Stop hook prunes timestamp-stale state with no session ID... "
 FOREIGN_LEGACY_ROOT=$(mktemp -d "$HOOK_TMP_BASE/gopher-ai-stop-hook-foreign-legacy.XXXXXX")
 FOREIGN_LEGACY_STATE="$FOREIGN_LEGACY_ROOT/.local/state/start-issue-309.loop.local.json"
 FOREIGN_LEGACY_TRANSCRIPT="$FOREIGN_LEGACY_ROOT/foreign-session.jsonl"
 mkdir -p "$(dirname "$FOREIGN_LEGACY_STATE")"
 printf '%s\n' '{"schema_version":2,"owner_workflow":"start-issue","loop_name":"start-issue-309","iteration":1,"max_iterations":50,"completion_promise":"COMPLETE","terminal_promises":["COMPLETE","INCOMPLETE"],"components":{},"phase":"implementing","original_prompt":"issue 309","started_at":"2000-01-01T00:00:00Z","session_id":""}' > "$FOREIGN_LEGACY_STATE"
 printf '%s\n' '{"role":"assistant","message":{"content":[{"type":"text","text":"Unrelated session output."}]}}' > "$FOREIGN_LEGACY_TRANSCRIPT"
-FOREIGN_LEGACY_BEFORE=$(cksum "$FOREIGN_LEGACY_STATE")
 FOREIGN_LEGACY_OUTPUT=$(
   cd "$FOREIGN_LEGACY_ROOT"
   jq -n --arg transcript "$FOREIGN_LEGACY_TRANSCRIPT" --arg session "foreign-session" \
     '{transcript_path: $transcript, session_id: $session}' | "$CORE_STOP_HOOK"
 )
-if [ -z "$FOREIGN_LEGACY_OUTPUT" ] &&
-   [ "$FOREIGN_LEGACY_BEFORE" = "$(cksum "$FOREIGN_LEGACY_STATE")" ]; then
+if [ -z "$FOREIGN_LEGACY_OUTPUT" ] && [ ! -e "$FOREIGN_LEGACY_STATE" ]; then
   echo "OK"
 else
   echo "FAIL"
@@ -1039,20 +1058,40 @@ else
   ERRORS=$((ERRORS + 1))
 fi
 
-echo -n "  Stop hook claims an empty session ID from owner transcript evidence... "
+echo -n "  Stop hook never claims an empty session ID from transcript evidence... "
 OWNER_CLAIM_ROOT=$(mktemp -d "$HOOK_TMP_BASE/gopher-ai-stop-hook-owner-claim.XXXXXX")
 OWNER_CLAIM_STATE="$OWNER_CLAIM_ROOT/.local/state/ship.loop.local.json"
 OWNER_CLAIM_TRANSCRIPT="$OWNER_CLAIM_ROOT/transcript.jsonl"
 mkdir -p "$(dirname "$OWNER_CLAIM_STATE")"
 printf '%s\n' '{"schema_version":2,"owner_workflow":"ship","loop_name":"ship","iteration":1,"max_iterations":50,"completion_promise":"SHIPPED","terminal_promises":["SHIPPED","INCOMPLETE"],"components":{},"phase":"ci-watch","original_prompt":"ship","session_id":""}' > "$OWNER_CLAIM_STATE"
 printf '%s\n' '{"role":"user","message":{"content":[{"type":"tool_result","content":"Loop initialized: ship\nOutput <done>SHIPPED</done> when all completion criteria are met."}]}}' > "$OWNER_CLAIM_TRANSCRIPT"
+OWNER_CLAIM_BEFORE=$(cksum "$OWNER_CLAIM_STATE")
 OWNER_CLAIM_OUTPUT=$(
   cd "$OWNER_CLAIM_ROOT"
   jq -n --arg transcript "$OWNER_CLAIM_TRANSCRIPT" --arg session "owner-session" \
     '{transcript_path: $transcript, session_id: $session}' | "$CORE_STOP_HOOK"
 )
-if printf '%s\n' "$OWNER_CLAIM_OUTPUT" | jq -e '.decision == "block"' >/dev/null 2>&1 &&
-   jq -e '.iteration == 2 and .session_id == "owner-session"' "$OWNER_CLAIM_STATE" >/dev/null 2>&1; then
+if [ -z "$OWNER_CLAIM_OUTPUT" ] &&
+   [ "$OWNER_CLAIM_BEFORE" = "$(cksum "$OWNER_CLAIM_STATE")" ]; then
+  echo "OK"
+else
+  echo "FAIL"
+  ERRORS=$((ERRORS + 1))
+fi
+
+echo -n "  Stop hook prunes timestamp-stale state before ownership handling... "
+STALE_SESSION_ROOT=$(mktemp -d "$HOOK_TMP_BASE/gopher-ai-stop-hook-stale-session.XXXXXX")
+STALE_SESSION_STATE="$STALE_SESSION_ROOT/.local/state/e2e-verify-2052.loop.local.json"
+STALE_SESSION_TRANSCRIPT="$STALE_SESSION_ROOT/owner-session.jsonl"
+mkdir -p "$(dirname "$STALE_SESSION_STATE")"
+printf '%s\n' '{"schema_version":2,"owner_workflow":"e2e-verify","loop_name":"e2e-verify-2052","iteration":28,"max_iterations":30,"completion_promise":"VERIFIED","terminal_promises":["VERIFIED","E2E_FAIL","INCOMPLETE"],"components":{},"phase":"completed","original_prompt":"verify","started_at":"2000-01-01T00:00:00Z","session_id":"owner-session"}' > "$STALE_SESSION_STATE"
+printf '%s\n' '{"role":"assistant","message":{"content":[{"type":"text","text":"Unrelated session output."}]}}' > "$STALE_SESSION_TRANSCRIPT"
+STALE_SESSION_OUTPUT=$(
+  cd "$STALE_SESSION_ROOT"
+  jq -n --arg transcript "$STALE_SESSION_TRANSCRIPT" --arg session "owner-session" \
+    '{transcript_path: $transcript, session_id: $session}' | "$CORE_STOP_HOOK"
+)
+if [ -z "$STALE_SESSION_OUTPUT" ] && [ ! -e "$STALE_SESSION_STATE" ]; then
   echo "OK"
 else
   echo "FAIL"
@@ -1076,14 +1115,14 @@ else
   ERRORS=$((ERRORS + 1))
 fi
 
-echo -n "  Stop hook filters concurrent loops by transcript ownership before ambiguity checks... "
+echo -n "  Stop hook filters concurrent loops by session ownership before ambiguity checks... "
 CONCURRENT_ROOT=$(mktemp -d "$HOOK_TMP_BASE/gopher-ai-stop-hook-concurrent.XXXXXX")
 CONCURRENT_STATE_DIR="$CONCURRENT_ROOT/.local/state"
 CONCURRENT_OWNER_STATE="$CONCURRENT_STATE_DIR/start-issue-309.loop.local.json"
 CONCURRENT_FOREIGN_STATE="$CONCURRENT_STATE_DIR/ship.loop.local.json"
 CONCURRENT_TRANSCRIPT="$CONCURRENT_ROOT/transcript.jsonl"
 mkdir -p "$CONCURRENT_STATE_DIR"
-printf '%s\n' '{"schema_version":2,"owner_workflow":"start-issue","loop_name":"start-issue-309","iteration":1,"max_iterations":50,"completion_promise":"COMPLETE","terminal_promises":["COMPLETE","INCOMPLETE"],"components":{},"phase":"implementing","original_prompt":"issue 309","session_id":""}' > "$CONCURRENT_OWNER_STATE"
+printf '%s\n' '{"schema_version":2,"owner_workflow":"start-issue","loop_name":"start-issue-309","iteration":1,"max_iterations":50,"completion_promise":"COMPLETE","terminal_promises":["COMPLETE","INCOMPLETE"],"components":{},"phase":"implementing","original_prompt":"issue 309","session_id":"owner-session"}' > "$CONCURRENT_OWNER_STATE"
 printf '%s\n' '{"schema_version":2,"owner_workflow":"ship","loop_name":"ship","iteration":7,"max_iterations":50,"completion_promise":"SHIPPED","terminal_promises":["SHIPPED","INCOMPLETE"],"components":{},"phase":"ci-watch","original_prompt":"ship","session_id":"foreign-session"}' > "$CONCURRENT_FOREIGN_STATE"
 printf '%s\n' '{"role":"user","message":{"content":[{"type":"tool_result","content":"Loop initialized: start-issue-309"}]}}' > "$CONCURRENT_TRANSCRIPT"
 CONCURRENT_FOREIGN_BEFORE=$(cksum "$CONCURRENT_FOREIGN_STATE")
@@ -1105,8 +1144,8 @@ echo -n "  Stop hook fails closed for the live duplicate-loop shape... "
 DUPLICATE_ROOT=$(mktemp -d "$HOOK_TMP_BASE/gopher-ai-stop-hook-duplicates.XXXXXX")
 DUPLICATE_STATE_DIR="$DUPLICATE_ROOT/.local/state"
 mkdir -p "$DUPLICATE_STATE_DIR"
-printf '%s\n' '{"loop_name":"start-issue-301","iteration":1,"max_iterations":50,"completion_promise":"COMPLETE","phase":"implementing","original_prompt":"issue 301","session_id":""}' > "$DUPLICATE_STATE_DIR/start-issue-301.loop.local.json"
-printf '%s\n' '{"loop_name":"direct-smoke","iteration":1,"max_iterations":10,"completion_promise":"DONE","phase":"testing","original_prompt":"smoke","session_id":""}' > "$DUPLICATE_STATE_DIR/direct-smoke.loop.local.json"
+printf '%s\n' '{"loop_name":"start-issue-301","iteration":1,"max_iterations":50,"completion_promise":"COMPLETE","phase":"implementing","original_prompt":"issue 301","session_id":"owner-session"}' > "$DUPLICATE_STATE_DIR/start-issue-301.loop.local.json"
+printf '%s\n' '{"loop_name":"direct-smoke","iteration":1,"max_iterations":10,"completion_promise":"DONE","phase":"testing","original_prompt":"smoke","session_id":"owner-session"}' > "$DUPLICATE_STATE_DIR/direct-smoke.loop.local.json"
 DUPLICATE_OWNER_BEFORE=$(cksum "$DUPLICATE_STATE_DIR/start-issue-301.loop.local.json")
 DUPLICATE_STRAY_BEFORE=$(cksum "$DUPLICATE_STATE_DIR/direct-smoke.loop.local.json")
 DUPLICATE_TRANSCRIPT="$DUPLICATE_ROOT/transcript.jsonl"
@@ -1116,7 +1155,8 @@ printf '%s\n' \
   > "$DUPLICATE_TRANSCRIPT"
 DUPLICATE_OUTPUT=$(
   cd "$DUPLICATE_ROOT"
-  printf '%s\n' "{\"transcript_path\":\"$DUPLICATE_TRANSCRIPT\"}" | "$CORE_STOP_HOOK"
+  jq -n --arg transcript "$DUPLICATE_TRANSCRIPT" --arg session "owner-session" \
+    '{transcript_path: $transcript, session_id: $session}' | "$CORE_STOP_HOOK"
 )
 if printf '%s\n' "$DUPLICATE_OUTPUT" | jq -e '
     .decision == "block" and
@@ -1137,14 +1177,15 @@ PROMISE_ROOT=$(mktemp -d "$HOOK_TMP_BASE/gopher-ai-stop-hook-promises.XXXXXX")
 PROMISE_STATE="$PROMISE_ROOT/.local/state/e2e-verify-42.loop.local.json"
 PROMISE_TRANSCRIPT="$PROMISE_ROOT/transcript.jsonl"
 mkdir -p "$(dirname "$PROMISE_STATE")"
-printf '%s\n' '{"schema_version":2,"owner_workflow":"e2e-verify","loop_name":"e2e-verify-42","iteration":1,"max_iterations":30,"completion_promise":"VERIFIED","terminal_promises":["VERIFIED","E2E_FAIL","INCOMPLETE"],"components":{},"phase":"e2e-testing","original_prompt":"verify","session_id":""}' > "$PROMISE_STATE"
+printf '%s\n' '{"schema_version":2,"owner_workflow":"e2e-verify","loop_name":"e2e-verify-42","iteration":1,"max_iterations":30,"completion_promise":"VERIFIED","terminal_promises":["VERIFIED","E2E_FAIL","INCOMPLETE"],"components":{},"phase":"e2e-testing","original_prompt":"verify","session_id":"owner-session"}' > "$PROMISE_STATE"
 printf '%s\n' \
   '{"role":"user","message":{"content":[{"type":"tool_result","content":"Loop initialized: e2e-verify-42"}]}}' \
   '{"role":"assistant","message":{"content":[{"type":"text","text":"<done>E2E_FAIL</done>"}]}}' \
   > "$PROMISE_TRANSCRIPT"
 PROMISE_BLOCK=$(
   cd "$PROMISE_ROOT"
-  printf '%s\n' "{\"transcript_path\":\"$PROMISE_TRANSCRIPT\"}" | "$CORE_STOP_HOOK"
+  jq -n --arg transcript "$PROMISE_TRANSCRIPT" --arg session "owner-session" \
+    '{transcript_path: $transcript, session_id: $session}' | "$CORE_STOP_HOOK"
 )
 PROMISE_BLOCK_OK=false
 if printf '%s\n' "$PROMISE_BLOCK" | jq -e '.decision == "block"' >/dev/null 2>&1 &&
@@ -1158,7 +1199,8 @@ fi
 )
 PROMISE_COMPLETE=$(
   cd "$PROMISE_ROOT"
-  printf '%s\n' "{\"transcript_path\":\"$PROMISE_TRANSCRIPT\"}" | "$CORE_STOP_HOOK"
+  jq -n --arg transcript "$PROMISE_TRANSCRIPT" --arg session "owner-session" \
+    '{transcript_path: $transcript, session_id: $session}' | "$CORE_STOP_HOOK"
 )
 if [ "$PROMISE_BLOCK_OK" = true ] && [ -z "$PROMISE_COMPLETE" ] && [ ! -e "$PROMISE_STATE" ]; then
   echo "OK"
@@ -1172,12 +1214,13 @@ INVALID_ROOT=$(mktemp -d "$HOOK_TMP_BASE/gopher-ai-stop-hook-invalid.XXXXXX")
 INVALID_STATE="$INVALID_ROOT/.local/state/ship.loop.local.json"
 INVALID_TRANSCRIPT="$INVALID_ROOT/transcript.jsonl"
 mkdir -p "$(dirname "$INVALID_STATE")"
-printf '%s\n' '{"schema_version":2,"owner_workflow":"ship","loop_name":"ship","iteration":1,"max_iterations":50,"completion_promise":"FOREIGN","terminal_promises":["SHIPPED","INCOMPLETE"],"components":{},"phase":"pushing","original_prompt":"ship","session_id":""}' > "$INVALID_STATE"
+printf '%s\n' '{"schema_version":2,"owner_workflow":"ship","loop_name":"ship","iteration":1,"max_iterations":50,"completion_promise":"FOREIGN","terminal_promises":["SHIPPED","INCOMPLETE"],"components":{},"phase":"pushing","original_prompt":"ship","session_id":"owner-session"}' > "$INVALID_STATE"
 printf '%s\n' '{"role":"user","message":{"content":[{"type":"tool_result","content":"Loop initialized: ship"}]}}' > "$INVALID_TRANSCRIPT"
 INVALID_BEFORE=$(cksum "$INVALID_STATE")
 INVALID_OUTPUT=$(
   cd "$INVALID_ROOT"
-  jq -n --arg transcript "$INVALID_TRANSCRIPT" '{transcript_path: $transcript}' | "$CORE_STOP_HOOK"
+  jq -n --arg transcript "$INVALID_TRANSCRIPT" --arg session "owner-session" \
+    '{transcript_path: $transcript, session_id: $session}' | "$CORE_STOP_HOOK"
 )
 if printf '%s\n' "$INVALID_OUTPUT" | jq -e '
     .decision == "block" and
@@ -1196,11 +1239,12 @@ LEGACY_SHIP_ROOT=$(mktemp -d "$HOOK_TMP_BASE/gopher-ai-stop-hook-legacy-ship.XXX
 LEGACY_SHIP_STATE="$LEGACY_SHIP_ROOT/.local/state/ship.loop.local.json"
 LEGACY_SHIP_TRANSCRIPT="$LEGACY_SHIP_ROOT/transcript.jsonl"
 mkdir -p "$(dirname "$LEGACY_SHIP_STATE")"
-printf '%s\n' '{"loop_name":"ship","iteration":1,"max_iterations":50,"completion_promise":"SHIPPED","phase":"ci-watch","args":"--no-merge","head_sha":"abc123","original_prompt":"ship","session_id":""}' > "$LEGACY_SHIP_STATE"
+printf '%s\n' '{"loop_name":"ship","iteration":1,"max_iterations":50,"completion_promise":"SHIPPED","phase":"ci-watch","args":"--no-merge","head_sha":"abc123","original_prompt":"ship","session_id":"owner-session"}' > "$LEGACY_SHIP_STATE"
 printf '%s\n' '{"role":"user","message":{"content":[{"type":"tool_result","content":"Loop initialized: ship"}]}}' > "$LEGACY_SHIP_TRANSCRIPT"
 LEGACY_SHIP_OUTPUT=$(
   cd "$LEGACY_SHIP_ROOT"
-  jq -n --arg transcript "$LEGACY_SHIP_TRANSCRIPT" '{transcript_path: $transcript}' | "$CORE_STOP_HOOK"
+  jq -n --arg transcript "$LEGACY_SHIP_TRANSCRIPT" --arg session "owner-session" \
+    '{transcript_path: $transcript, session_id: $session}' | "$CORE_STOP_HOOK"
 )
 LEGACY_REENTRY=$(
   cd "$LEGACY_SHIP_ROOT"

--- a/scripts/test-hooks.sh
+++ b/scripts/test-hooks.sh
@@ -1117,25 +1117,28 @@ else
   ERRORS=$((ERRORS + 1))
 fi
 
-echo -n "  Loop setup backfills instance proof for legacy ownerless state... "
+echo -n "  Loop setup refuses proofless legacy ownerless re-entry... "
 LEGACY_BACKFILL_ROOT=$(mktemp -d "$HOOK_TMP_BASE/gopher-ai-stop-hook-legacy-backfill.XXXXXX")
 LEGACY_BACKFILL_STATE="$LEGACY_BACKFILL_ROOT/.local/state/ship.loop.local.json"
 LEGACY_BACKFILL_TRANSCRIPT="$LEGACY_BACKFILL_ROOT/transcript.jsonl"
 mkdir -p "$(dirname "$LEGACY_BACKFILL_STATE")"
 printf '%s\n' \
-  '{"role":"user","message":{"content":[{"type":"tool_result","content":"Loop initialized: ship\nOutput <done>SHIPPED</done> when all completion criteria are met."}]}}' \
+  '{"role":"assistant","message":{"content":[{"type":"text","text":"Unrelated session output."}]}}' \
   > "$LEGACY_BACKFILL_TRANSCRIPT"
 jq -n \
   --arg started_at "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
   --arg worktree_path "$LEGACY_BACKFILL_ROOT" \
   '{schema_version:2,owner_workflow:"ship",loop_name:"ship",iteration:1,max_iterations:50,completion_promise:"SHIPPED",terminal_promises:["SHIPPED","INCOMPLETE"],components:{},phase:"ci-watch",original_prompt:"ship",started_at:$started_at,session_id:"",session_worktree_path:$worktree_path,worktree_path:$worktree_path}' \
   > "$LEGACY_BACKFILL_STATE"
+LEGACY_BACKFILL_BEFORE=$(cksum "$LEGACY_BACKFILL_STATE")
+set +e
 LEGACY_BACKFILL_SETUP_OUTPUT=$(
   cd "$LEGACY_BACKFILL_ROOT"
   env -u CLAUDE_SESSION_ID "$ROOT_DIR/shared/scripts/setup-loop.sh" \
-    "ship" "SHIPPED" 50 "ci-watch" '{}' "$LEGACY_BACKFILL_STATE" '["SHIPPED","INCOMPLETE"]'
+    "ship" "SHIPPED" 50 "ci-watch" '{}' "$LEGACY_BACKFILL_STATE" '["SHIPPED","INCOMPLETE"]' 2>&1
 )
-LEGACY_BACKFILL_INSTANCE=$(jq -r '.loop_instance_id // empty' "$LEGACY_BACKFILL_STATE")
+LEGACY_BACKFILL_STATUS=$?
+set -e
 jq -n --arg content "$LEGACY_BACKFILL_SETUP_OUTPUT" \
   '{role:"user",message:{content:[{type:"tool_result",content:$content}]}}' \
   >> "$LEGACY_BACKFILL_TRANSCRIPT"
@@ -1144,10 +1147,10 @@ LEGACY_BACKFILL_STOP_OUTPUT=$(
   jq -n --arg transcript "$LEGACY_BACKFILL_TRANSCRIPT" --arg session "owner-session" \
     '{transcript_path: $transcript, session_id: $session}' | "$CORE_STOP_HOOK"
 )
-if [ -n "$LEGACY_BACKFILL_INSTANCE" ] &&
-   printf '%s\n' "$LEGACY_BACKFILL_SETUP_OUTPUT" | grep -Fq "Loop initialized: ship [$LEGACY_BACKFILL_INSTANCE]" &&
-   printf '%s\n' "$LEGACY_BACKFILL_STOP_OUTPUT" | jq -e '.decision == "block"' >/dev/null 2>&1 &&
-   jq -e '.iteration == 2 and .session_id == "owner-session"' "$LEGACY_BACKFILL_STATE" >/dev/null 2>&1; then
+if [ "$LEGACY_BACKFILL_STATUS" -ne 0 ] &&
+   printf '%s\n' "$LEGACY_BACKFILL_SETUP_OUTPUT" | grep -Fq "cannot safely re-enter legacy ownerless loop 'ship'" &&
+   [ "$LEGACY_BACKFILL_BEFORE" = "$(cksum "$LEGACY_BACKFILL_STATE")" ] &&
+   [ -z "$LEGACY_BACKFILL_STOP_OUTPUT" ]; then
   echo "OK"
 else
   echo "FAIL"

--- a/scripts/test-hooks.sh
+++ b/scripts/test-hooks.sh
@@ -1117,6 +1117,43 @@ else
   ERRORS=$((ERRORS + 1))
 fi
 
+echo -n "  Loop setup backfills instance proof for legacy ownerless state... "
+LEGACY_BACKFILL_ROOT=$(mktemp -d "$HOOK_TMP_BASE/gopher-ai-stop-hook-legacy-backfill.XXXXXX")
+LEGACY_BACKFILL_STATE="$LEGACY_BACKFILL_ROOT/.local/state/ship.loop.local.json"
+LEGACY_BACKFILL_TRANSCRIPT="$LEGACY_BACKFILL_ROOT/transcript.jsonl"
+mkdir -p "$(dirname "$LEGACY_BACKFILL_STATE")"
+printf '%s\n' \
+  '{"role":"user","message":{"content":[{"type":"tool_result","content":"Loop initialized: ship\nOutput <done>SHIPPED</done> when all completion criteria are met."}]}}' \
+  > "$LEGACY_BACKFILL_TRANSCRIPT"
+jq -n \
+  --arg started_at "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+  --arg worktree_path "$LEGACY_BACKFILL_ROOT" \
+  '{schema_version:2,owner_workflow:"ship",loop_name:"ship",iteration:1,max_iterations:50,completion_promise:"SHIPPED",terminal_promises:["SHIPPED","INCOMPLETE"],components:{},phase:"ci-watch",original_prompt:"ship",started_at:$started_at,session_id:"",session_worktree_path:$worktree_path,worktree_path:$worktree_path}' \
+  > "$LEGACY_BACKFILL_STATE"
+LEGACY_BACKFILL_SETUP_OUTPUT=$(
+  cd "$LEGACY_BACKFILL_ROOT"
+  env -u CLAUDE_SESSION_ID "$ROOT_DIR/shared/scripts/setup-loop.sh" \
+    "ship" "SHIPPED" 50 "ci-watch" '{}' "$LEGACY_BACKFILL_STATE" '["SHIPPED","INCOMPLETE"]'
+)
+LEGACY_BACKFILL_INSTANCE=$(jq -r '.loop_instance_id // empty' "$LEGACY_BACKFILL_STATE")
+jq -n --arg content "$LEGACY_BACKFILL_SETUP_OUTPUT" \
+  '{role:"user",message:{content:[{type:"tool_result",content:$content}]}}' \
+  >> "$LEGACY_BACKFILL_TRANSCRIPT"
+LEGACY_BACKFILL_STOP_OUTPUT=$(
+  cd "$LEGACY_BACKFILL_ROOT"
+  jq -n --arg transcript "$LEGACY_BACKFILL_TRANSCRIPT" --arg session "owner-session" \
+    '{transcript_path: $transcript, session_id: $session}' | "$CORE_STOP_HOOK"
+)
+if [ -n "$LEGACY_BACKFILL_INSTANCE" ] &&
+   printf '%s\n' "$LEGACY_BACKFILL_SETUP_OUTPUT" | grep -Fq "Loop initialized: ship [$LEGACY_BACKFILL_INSTANCE]" &&
+   printf '%s\n' "$LEGACY_BACKFILL_STOP_OUTPUT" | jq -e '.decision == "block"' >/dev/null 2>&1 &&
+   jq -e '.iteration == 2 and .session_id == "owner-session"' "$LEGACY_BACKFILL_STATE" >/dev/null 2>&1; then
+  echo "OK"
+else
+  echo "FAIL"
+  ERRORS=$((ERRORS + 1))
+fi
+
 echo -n "  Stop hook ignores ownerless state without transcript initialization evidence... "
 UNCLAIMED_ROOT=$(mktemp -d "$HOOK_TMP_BASE/gopher-ai-stop-hook-unclaimed.XXXXXX")
 UNCLAIMED_STATE="$UNCLAIMED_ROOT/.local/state/ship.loop.local.json"

--- a/scripts/test-ship-e2e-gate.sh
+++ b/scripts/test-ship-e2e-gate.sh
@@ -474,12 +474,13 @@ git -C "$HEADLESS_TMP" add validated.txt
 cp "$STOP_HOOK" "$HEADLESS_TMP/hooks/stop-hook.sh"
 cp "$LOOP_LIB" "$HEADLESS_TMP/lib/loop-state.sh"
 cat > "$HEADLESS_TMP/.local/state/ship.loop.local.json" <<'EOF'
-{"loop_name":"ship","iteration":1,"max_iterations":50,"completion_promise":"SHIPPED","phase":"reviewing","original_prompt":"ship"}
+{"loop_name":"ship","iteration":1,"max_iterations":50,"completion_promise":"SHIPPED","phase":"reviewing","original_prompt":"ship","session_id":"owner-session"}
 EOF
 HEADLESS_TRANSCRIPT="$HEADLESS_TMP/transcript.jsonl"
 printf '%s\n' '{"role":"user","message":{"content":[{"type":"tool_result","content":"Loop initialized: ship"}]}}' > "$HEADLESS_TRANSCRIPT"
 HEADLESS_OUTPUT=$(cd "$HEADLESS_TMP" && \
-  jq -n --arg transcript "$HEADLESS_TRANSCRIPT" '{transcript_path: $transcript}' | bash hooks/stop-hook.sh)
+  jq -n --arg transcript "$HEADLESS_TRANSCRIPT" --arg session "owner-session" \
+    '{transcript_path: $transcript, session_id: $session}' | bash hooks/stop-hook.sh)
 HEADLESS_STATE=$(jq -c '{phase,review_result,review_skip_reason}' \
   "$HEADLESS_TMP/.local/state/ship.loop.local.json")
 rm -rf "$HEADLESS_TMP"
@@ -606,10 +607,12 @@ cp "$ROOT_DIR/plugins/go-workflow/lib/loop-state.sh" "$FRESH_PLUGIN_ROOT/lib/loo
 cp "$ROOT_DIR/plugins/go-workflow/scripts/setup-loop.sh" "$FRESH_PLUGIN_ROOT/scripts/setup-loop.sh"
 cp "$RESUME_MESSAGES" "$FRESH_PLUGIN_ROOT/lib/ship/resume-messages.json"
 chmod +x "$FRESH_PLUGIN_ROOT/scripts/setup-loop.sh"
+FRESH_SHIP_TRANSCRIPT="$FRESH_SHIP_ROOT/transcript.jsonl"
+printf '%s\n' '{"role":"user","message":{"content":[{"type":"tool_result","content":"Loop initialized: ship"}]}}' > "$FRESH_SHIP_TRANSCRIPT"
 
 set +e
 FRESH_START_OUTPUT=$(cd "$FRESH_SHIP_ROOT" && \
-  CLAUDE_PLUGIN_ROOT="$FRESH_PLUGIN_ROOT" CALLER_LOOP_STATE_FILE="" CALLER_WORKFLOW_STATE_PATH="" ARGUMENTS="" \
+  CLAUDE_PLUGIN_ROOT="$FRESH_PLUGIN_ROOT" CLAUDE_SESSION_ID="owner-session" CALLER_LOOP_STATE_FILE="" CALLER_WORKFLOW_STATE_PATH="" ARGUMENTS="" \
   bash -c '
     gh() { printf "%s\n" "example/project"; }
     source "$1"
@@ -642,10 +645,9 @@ if [ "$FRESH_START_STATUS" -ne 0 ] ||
   fail "fresh standalone ship must initialize its canonical schema-v2 owner state"
 fi
 
-FRESH_SHIP_TRANSCRIPT="$FRESH_SHIP_ROOT/transcript.jsonl"
-printf '%s\n' '{"role":"user","message":{"content":[{"type":"tool_result","content":"Loop initialized: ship"}]}}' > "$FRESH_SHIP_TRANSCRIPT"
 FRESH_STOP_OUTPUT=$(cd "$FRESH_SHIP_ROOT" && \
-  jq -n --arg transcript "$FRESH_SHIP_TRANSCRIPT" '{transcript_path: $transcript}' | bash "$STOP_HOOK")
+  jq -n --arg transcript "$FRESH_SHIP_TRANSCRIPT" --arg session "owner-session" \
+    '{transcript_path: $transcript, session_id: $session}' | bash "$STOP_HOOK")
 printf '%s\n' '#!/bin/bash' 'exit 97' > "$FRESH_PLUGIN_ROOT/scripts/setup-loop.sh"
 chmod +x "$FRESH_PLUGIN_ROOT/scripts/setup-loop.sh"
 
@@ -691,12 +693,13 @@ LEGACY_SHIP_TRANSCRIPT="$LEGACY_SHIP_TMP/transcript.jsonl"
 jq -n \
   --arg original_repo_root "$LEGACY_SHIP_TMP" \
   --arg worktree_path "$LEGACY_SHIP_TMP" \
-  '{loop_name:"ship",iteration:4,max_iterations:50,completion_promise:"SHIPPED",phase:"ci-watch",original_prompt:"ship",session_id:"",awaiting_driver_input:false,driver_input_reason:"",phase_messages:{"ci-watch":"Resume exact-head CI."},original_repo_root:$original_repo_root,worktree_path:$worktree_path,repo_slug:"example/project",pass:2,pr_number:"302",head_sha:"legacy-head"}' \
+  '{loop_name:"ship",iteration:4,max_iterations:50,completion_promise:"SHIPPED",phase:"ci-watch",original_prompt:"ship",session_id:"owner-session",awaiting_driver_input:false,driver_input_reason:"",phase_messages:{"ci-watch":"Resume exact-head CI."},original_repo_root:$original_repo_root,worktree_path:$worktree_path,repo_slug:"example/project",pass:2,pr_number:"302",head_sha:"legacy-head"}' \
   > "$LEGACY_SHIP_STATE"
 printf '%s\n' '{"role":"user","message":{"content":[{"type":"tool_result","content":"Loop initialized: ship"}]}}' > "$LEGACY_SHIP_TRANSCRIPT"
 
 LEGACY_STOP_OUTPUT=$(cd "$LEGACY_SHIP_TMP" && \
-  jq -n --arg transcript "$LEGACY_SHIP_TRANSCRIPT" '{transcript_path: $transcript}' | bash "$STOP_HOOK")
+  jq -n --arg transcript "$LEGACY_SHIP_TRANSCRIPT" --arg session "owner-session" \
+    '{transcript_path: $transcript, session_id: $session}' | bash "$STOP_HOOK")
 
 if ! printf '%s\n' "$LEGACY_STOP_OUTPUT" | jq -e \
   '.decision == "block" and ((.reason // "") | length > 0)' >/dev/null 2>&1; then
@@ -765,7 +768,7 @@ for LEGACY_LINK_ATTEMPT in 1 2 3 4 5; do
   LEGACY_LINK_CANONICAL="$LEGACY_LINK_ROOT/.local/state/ship.loop.local.json"
   mkdir -p "$(dirname "$LEGACY_LINK_STATE")"
   jq -n \
-    '{loop_name:"ship",iteration:7,max_iterations:50,completion_promise:"SHIPPED",phase:"ci-watch",original_prompt:"ship",session_id:"",awaiting_driver_input:false,driver_input_reason:"",phase_messages:{"ci-watch":"Resume linked-worktree CI."},pass:3,pr_number:"302",head_sha:"linked-legacy-head"}' \
+    '{loop_name:"ship",iteration:7,max_iterations:50,completion_promise:"SHIPPED",phase:"ci-watch",original_prompt:"ship",session_id:"owner-session",awaiting_driver_input:false,driver_input_reason:"",phase_messages:{"ci-watch":"Resume linked-worktree CI."},pass:3,pr_number:"302",head_sha:"linked-legacy-head"}' \
     > "$LEGACY_LINK_STATE"
 
   set +e

--- a/shared/hooks/stop-hook.sh
+++ b/shared/hooks/stop-hook.sh
@@ -69,6 +69,21 @@ block_stop() {
     '{"decision": "block", "reason": $reason, "systemMessage": $msg}'
 }
 
+transcript_proves_loop_initialization() {
+  local state_file="$1"
+  local loop_name
+
+  [ -n "$CURRENT_SESSION_ID" ] &&
+    [ -n "$TRANSCRIPT_PATH" ] &&
+    [ -f "$TRANSCRIPT_PATH" ] || return 1
+
+  loop_name=$(jq -r '.loop_name // empty' "$state_file" 2>/dev/null)
+  [ -n "$loop_name" ] || return 1
+
+  grep -Fq -- "Loop initialized: $loop_name\\n" "$TRANSCRIPT_PATH" ||
+    grep -Fq -- "Loop initialized: $loop_name\"" "$TRANSCRIPT_PATH"
+}
+
 session_owns_loop_state() {
   local state_file="$1"
   local stored_session_id
@@ -85,9 +100,12 @@ session_owns_loop_state() {
     [ "$stored_session_worktree_path" = "$CURRENT_WORKTREE_PATH" ] || return 1
   fi
 
-  [ -n "$stored_session_id" ] &&
-    [ -n "$CURRENT_SESSION_ID" ] &&
-    [ "$stored_session_id" = "$CURRENT_SESSION_ID" ]
+  if [ -n "$stored_session_id" ]; then
+    [ -n "$CURRENT_SESSION_ID" ] && [ "$stored_session_id" = "$CURRENT_SESSION_ID" ]
+    return
+  fi
+
+  transcript_proves_loop_initialization "$state_file"
 }
 
 state_is_stale_for_transcript() {
@@ -362,17 +380,17 @@ STATE_FILES=$(find_active_loops)
 OWNED_STATE_FILES=""
 while IFS= read -r CANDIDATE_STATE_FILE; do
   [ -n "$CANDIDATE_STATE_FILE" ] || continue
+  if state_has_stale_worktree "$CANDIDATE_STATE_FILE"; then
+    loop_log "stop-hook: pruning stale loop state '$CANDIDATE_STATE_FILE'"
+    cleanup_loop "$CANDIDATE_STATE_FILE"
+    continue
+  fi
   if state_has_explicit_session_mismatch "$CANDIDATE_STATE_FILE"; then
     loop_log "stop-hook: current session does not own loop state '$CANDIDATE_STATE_FILE', skipping"
     continue
   fi
   if state_is_stale_for_transcript "$CANDIDATE_STATE_FILE"; then
     loop_log "stop-hook: pruning timestamp-stale loop state '$CANDIDATE_STATE_FILE'"
-    cleanup_loop "$CANDIDATE_STATE_FILE"
-    continue
-  fi
-  if state_has_stale_worktree "$CANDIDATE_STATE_FILE"; then
-    loop_log "stop-hook: pruning stale loop state '$CANDIDATE_STATE_FILE'"
     cleanup_loop "$CANDIDATE_STATE_FILE"
     continue
   fi
@@ -441,6 +459,11 @@ if ! read_loop_state "$STATE_FILE" '[]' 2>/dev/null; then
   exit 0
 fi
 
+STORED_SESSION_ID=$(jq -r '.session_id // empty' "$STATE_FILE")
+if [ -z "$STORED_SESSION_ID" ] && [ -n "$CURRENT_SESSION_ID" ]; then
+  set_loop_field "$STATE_FILE" "session_id" "$CURRENT_SESSION_ID" '[]'
+  loop_log "stop-hook: claimed loop state '$STATE_FILE' for session '$CURRENT_SESSION_ID'"
+fi
 STORED_SESSION_WORKTREE_PATH=$(jq -r '.session_worktree_path // empty' "$STATE_FILE")
 if [ -z "$STORED_SESSION_WORKTREE_PATH" ]; then
   set_loop_field "$STATE_FILE" "session_worktree_path" "$CURRENT_WORKTREE_PATH" '[]'

--- a/shared/hooks/stop-hook.sh
+++ b/shared/hooks/stop-hook.sh
@@ -113,6 +113,16 @@ state_is_stale_for_transcript() {
     [ "$transcript_birth" -gt "$loop_epoch" ]
 }
 
+state_has_explicit_session_mismatch() {
+  local state_file="$1"
+  local stored_session_id
+
+  stored_session_id=$(jq -r '.session_id // empty' "$state_file" 2>/dev/null)
+  [ -n "$stored_session_id" ] &&
+    [ -n "$CURRENT_SESSION_ID" ] &&
+    [ "$stored_session_id" != "$CURRENT_SESSION_ID" ]
+}
+
 state_has_stale_worktree() {
   local state_file="$1"
   local field
@@ -352,6 +362,10 @@ STATE_FILES=$(find_active_loops)
 OWNED_STATE_FILES=""
 while IFS= read -r CANDIDATE_STATE_FILE; do
   [ -n "$CANDIDATE_STATE_FILE" ] || continue
+  if state_has_explicit_session_mismatch "$CANDIDATE_STATE_FILE"; then
+    loop_log "stop-hook: current session does not own loop state '$CANDIDATE_STATE_FILE', skipping"
+    continue
+  fi
   if state_is_stale_for_transcript "$CANDIDATE_STATE_FILE"; then
     loop_log "stop-hook: pruning timestamp-stale loop state '$CANDIDATE_STATE_FILE'"
     cleanup_loop "$CANDIDATE_STATE_FILE"

--- a/shared/hooks/stop-hook.sh
+++ b/shared/hooks/stop-hook.sh
@@ -17,6 +17,10 @@ set -euo pipefail
 HOOK_INPUT=$(cat)
 
 # Extract transcript path from hook input
+STOP_HOOK_ACTIVE=$(echo "$HOOK_INPUT" | jq -r '.stop_hook_active // false' 2>/dev/null)
+if [ "$STOP_HOOK_ACTIVE" = "true" ]; then
+  exit 0
+fi
 TRANSCRIPT_PATH=$(echo "$HOOK_INPUT" | jq -r '.transcript_path // empty' 2>/dev/null)
 CURRENT_SESSION_ID=$(echo "$HOOK_INPUT" | jq -r '.session_id // empty' 2>/dev/null)
 HOOK_CWD=$(echo "$HOOK_INPUT" | jq -r '.cwd // empty' 2>/dev/null)
@@ -65,26 +69,15 @@ block_stop() {
     '{"decision": "block", "reason": $reason, "systemMessage": $msg}'
 }
 
-transcript_owns_loop() {
-  local loop_name="$1"
-
-  [ -n "$loop_name" ] &&
-    [ -n "$TRANSCRIPT_PATH" ] &&
-    [ -f "$TRANSCRIPT_PATH" ] &&
-    grep -Fq -- "Loop initialized: $loop_name" "$TRANSCRIPT_PATH"
-}
-
 session_owns_loop_state() {
   local state_file="$1"
   local stored_session_id
   local stored_session_worktree_path
-  local loop_name
 
   [ -f "$state_file" ] && [ -r "$state_file" ] && jq empty "$state_file" 2>/dev/null || return 1
 
   stored_session_id=$(jq -r '.session_id // empty' "$state_file" 2>/dev/null)
   stored_session_worktree_path=$(jq -r '.session_worktree_path // empty' "$state_file" 2>/dev/null)
-  loop_name=$(jq -r '.loop_name // empty' "$state_file" 2>/dev/null)
 
   if [ -n "$stored_session_worktree_path" ]; then
     [ -d "$stored_session_worktree_path" ] || return 1
@@ -92,12 +85,32 @@ session_owns_loop_state() {
     [ "$stored_session_worktree_path" = "$CURRENT_WORKTREE_PATH" ] || return 1
   fi
 
-  if [ -n "$stored_session_id" ]; then
-    [ -n "$CURRENT_SESSION_ID" ] && [ "$stored_session_id" = "$CURRENT_SESSION_ID" ]
-    return
+  [ -n "$stored_session_id" ] &&
+    [ -n "$CURRENT_SESSION_ID" ] &&
+    [ "$stored_session_id" = "$CURRENT_SESSION_ID" ]
+}
+
+state_is_stale_for_transcript() {
+  local state_file="$1"
+  local started_at
+  local transcript_birth
+  local loop_epoch
+
+  [ -n "$TRANSCRIPT_PATH" ] && [ -f "$TRANSCRIPT_PATH" ] || return 1
+  started_at=$(jq -r '.started_at // empty' "$state_file" 2>/dev/null)
+  [ -n "$started_at" ] || return 1
+
+  if [[ "${OSTYPE:-}" == "darwin"* ]]; then
+    transcript_birth=$(stat -f %B "$TRANSCRIPT_PATH" 2>/dev/null || echo "0")
+    loop_epoch=$(date -j -f "%Y-%m-%dT%H:%M:%SZ" "$started_at" +%s 2>/dev/null || echo "0")
+  else
+    transcript_birth=$(stat -c %W "$TRANSCRIPT_PATH" 2>/dev/null || echo "0")
+    loop_epoch=$(date -d "$started_at" +%s 2>/dev/null || echo "0")
   fi
 
-  transcript_owns_loop "$loop_name"
+  [ "$loop_epoch" -gt 0 ] &&
+    [ "$transcript_birth" -gt 0 ] &&
+    [ "$transcript_birth" -gt "$loop_epoch" ]
 }
 
 state_has_stale_worktree() {
@@ -339,6 +352,11 @@ STATE_FILES=$(find_active_loops)
 OWNED_STATE_FILES=""
 while IFS= read -r CANDIDATE_STATE_FILE; do
   [ -n "$CANDIDATE_STATE_FILE" ] || continue
+  if state_is_stale_for_transcript "$CANDIDATE_STATE_FILE"; then
+    loop_log "stop-hook: pruning timestamp-stale loop state '$CANDIDATE_STATE_FILE'"
+    cleanup_loop "$CANDIDATE_STATE_FILE"
+    continue
+  fi
   if state_has_stale_worktree "$CANDIDATE_STATE_FILE"; then
     loop_log "stop-hook: pruning stale loop state '$CANDIDATE_STATE_FILE'"
     cleanup_loop "$CANDIDATE_STATE_FILE"
@@ -409,11 +427,6 @@ if ! read_loop_state "$STATE_FILE" '[]' 2>/dev/null; then
   exit 0
 fi
 
-STORED_SESSION_ID=$(jq -r '.session_id // empty' "$STATE_FILE")
-if [ -z "$STORED_SESSION_ID" ] && [ -n "$CURRENT_SESSION_ID" ]; then
-  set_loop_field "$STATE_FILE" "session_id" "$CURRENT_SESSION_ID" '[]'
-  loop_log "stop-hook: claimed loop state '$STATE_FILE' for session '$CURRENT_SESSION_ID'"
-fi
 STORED_SESSION_WORKTREE_PATH=$(jq -r '.session_worktree_path // empty' "$STATE_FILE")
 if [ -z "$STORED_SESSION_WORKTREE_PATH" ]; then
   set_loop_field "$STATE_FILE" "session_worktree_path" "$CURRENT_WORKTREE_PATH" '[]'

--- a/shared/hooks/stop-hook.sh
+++ b/shared/hooks/stop-hook.sh
@@ -115,8 +115,15 @@ state_is_stale_for_transcript() {
   local started_at
   local transcript_birth
   local loop_epoch
+  local loop_instance_id
+  local stored_session_id
 
   [ -n "$TRANSCRIPT_PATH" ] && [ -f "$TRANSCRIPT_PATH" ] || return 1
+  stored_session_id=$(jq -r '.session_id // empty' "$state_file" 2>/dev/null)
+  loop_instance_id=$(jq -r '.loop_instance_id // empty' "$state_file" 2>/dev/null)
+  if [ -z "$stored_session_id" ] && [ -n "$loop_instance_id" ]; then
+    return 1
+  fi
   started_at=$(jq -r '.started_at // empty' "$state_file" 2>/dev/null)
   [ -n "$started_at" ] || return 1
 

--- a/shared/hooks/stop-hook.sh
+++ b/shared/hooks/stop-hook.sh
@@ -71,6 +71,7 @@ block_stop() {
 
 transcript_proves_loop_initialization() {
   local state_file="$1"
+  local loop_instance_id
   local loop_name
 
   [ -n "$CURRENT_SESSION_ID" ] &&
@@ -78,10 +79,11 @@ transcript_proves_loop_initialization() {
     [ -f "$TRANSCRIPT_PATH" ] || return 1
 
   loop_name=$(jq -r '.loop_name // empty' "$state_file" 2>/dev/null)
-  [ -n "$loop_name" ] || return 1
+  loop_instance_id=$(jq -r '.loop_instance_id // empty' "$state_file" 2>/dev/null)
+  [ -n "$loop_name" ] && [ -n "$loop_instance_id" ] || return 1
 
-  grep -Fq -- "Loop initialized: $loop_name\\n" "$TRANSCRIPT_PATH" ||
-    grep -Fq -- "Loop initialized: $loop_name\"" "$TRANSCRIPT_PATH"
+  grep -Fq -- "Loop initialized: $loop_name [$loop_instance_id]\\n" "$TRANSCRIPT_PATH" ||
+    grep -Fq -- "Loop initialized: $loop_name [$loop_instance_id]\"" "$TRANSCRIPT_PATH"
 }
 
 session_owns_loop_state() {

--- a/shared/scripts/setup-loop.sh
+++ b/shared/scripts/setup-loop.sh
@@ -19,6 +19,11 @@ fi
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 source "$SCRIPT_DIR/../lib/loop-state.sh"
 
+new_loop_instance_id() {
+  local created_at="$1"
+  printf '%s-%s-%s%s\n' "$created_at" "$$" "$RANDOM" "$RANDOM"
+}
+
 SAFE_LOOP_NAME=$(printf '%s\n' "$LOOP_NAME" | sed 's/[^a-zA-Z0-9_-]/-/g')
 OWNER_STATE_DIR=$(loop_state_directory)
 mkdir -p "$OWNER_STATE_DIR"
@@ -87,7 +92,19 @@ if [ -f "$STATE_FILE" ]; then
       "$LOOP_NAME" >&2
     exit 1
   fi
-  printf "Loop already active: %s\n" "$LOOP_NAME"
+  STORED_SESSION_ID=$(jq -r '.session_id // empty' "$STATE_FILE")
+  STORED_LOOP_INSTANCE_ID=$(jq -r '.loop_instance_id // empty' "$STATE_FILE")
+  if [ -z "$STORED_SESSION_ID" ] && [ -z "$STORED_LOOP_INSTANCE_ID" ]; then
+    LEGACY_STARTED_AT=$(jq -r '.started_at // empty' "$STATE_FILE")
+    if [ -z "$LEGACY_STARTED_AT" ]; then
+      LEGACY_STARTED_AT=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+    fi
+    STORED_LOOP_INSTANCE_ID=$(new_loop_instance_id "$LEGACY_STARTED_AT")
+    set_loop_field "$STATE_FILE" "loop_instance_id" "$STORED_LOOP_INSTANCE_ID" '[]'
+    printf 'Loop initialized: %s [%s]\n' "$LOOP_NAME" "$STORED_LOOP_INSTANCE_ID"
+  else
+    printf "Loop already active: %s\n" "$LOOP_NAME"
+  fi
   exit 0
 fi
 
@@ -101,7 +118,7 @@ SESSION_ID="${CLAUDE_SESSION_ID:-}"
 WORKTREE_PATH=$(resolve_loop_worktree_root)
 SESSION_WORKTREE_PATH="$WORKTREE_PATH"
 STARTED_AT=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
-LOOP_INSTANCE_ID="${STARTED_AT}-$$-${RANDOM}${RANDOM}"
+LOOP_INSTANCE_ID=$(new_loop_instance_id "$STARTED_AT")
 
 MAX_ITER_JSON="null"
 if [ -n "$MAX_ITERATIONS" ]; then

--- a/shared/scripts/setup-loop.sh
+++ b/shared/scripts/setup-loop.sh
@@ -100,6 +100,8 @@ fi
 SESSION_ID="${CLAUDE_SESSION_ID:-}"
 WORKTREE_PATH=$(resolve_loop_worktree_root)
 SESSION_WORKTREE_PATH="$WORKTREE_PATH"
+STARTED_AT=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+LOOP_INSTANCE_ID="${STARTED_AT}-$$-${RANDOM}${RANDOM}"
 
 MAX_ITER_JSON="null"
 if [ -n "$MAX_ITERATIONS" ]; then
@@ -131,7 +133,8 @@ jq -n \
   --arg completion_promise "$COMPLETION_PROMISE" \
   --argjson terminal_promises "$TERMINAL_PROMISES_JSON" \
   --arg phase "$INITIAL_PHASE" \
-  --arg started_at "$(date -u +"%Y-%m-%dT%H:%M:%SZ")" \
+  --arg started_at "$STARTED_AT" \
+  --arg loop_instance_id "$LOOP_INSTANCE_ID" \
   --arg session_id "$SESSION_ID" \
   --arg session_worktree_path "$SESSION_WORKTREE_PATH" \
   --arg worktree_path "$WORKTREE_PATH" \
@@ -147,6 +150,7 @@ jq -n \
     phase: $phase,
     bot_review_baseline: "",
     started_at: $started_at,
+    loop_instance_id: $loop_instance_id,
     session_id: $session_id,
     session_worktree_path: $session_worktree_path,
     worktree_path: $worktree_path,
@@ -156,5 +160,5 @@ jq -n \
     components: {}
   }' > "$TMP_FILE" && mv "$TMP_FILE" "$STATE_FILE"
 
-printf 'Loop initialized: %s\n' "$LOOP_NAME"
+printf 'Loop initialized: %s [%s]\n' "$LOOP_NAME" "$LOOP_INSTANCE_ID"
 printf 'Output <done>%s</done> when all completion criteria are met.\n' "$COMPLETION_PROMISE"

--- a/shared/scripts/setup-loop.sh
+++ b/shared/scripts/setup-loop.sh
@@ -95,16 +95,11 @@ if [ -f "$STATE_FILE" ]; then
   STORED_SESSION_ID=$(jq -r '.session_id // empty' "$STATE_FILE")
   STORED_LOOP_INSTANCE_ID=$(jq -r '.loop_instance_id // empty' "$STATE_FILE")
   if [ -z "$STORED_SESSION_ID" ] && [ -z "$STORED_LOOP_INSTANCE_ID" ]; then
-    LEGACY_STARTED_AT=$(jq -r '.started_at // empty' "$STATE_FILE")
-    if [ -z "$LEGACY_STARTED_AT" ]; then
-      LEGACY_STARTED_AT=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
-    fi
-    STORED_LOOP_INSTANCE_ID=$(new_loop_instance_id "$LEGACY_STARTED_AT")
-    set_loop_field "$STATE_FILE" "loop_instance_id" "$STORED_LOOP_INSTANCE_ID" '[]'
-    printf 'Loop initialized: %s [%s]\n' "$LOOP_NAME" "$STORED_LOOP_INSTANCE_ID"
-  else
-    printf "Loop already active: %s\n" "$LOOP_NAME"
+    printf "Error: cannot safely re-enter legacy ownerless loop '%s'; cancel it and restart.\n" \
+      "$LOOP_NAME" >&2
+    exit 1
   fi
+  printf "Loop already active: %s\n" "$LOOP_NAME"
   exit 0
 fi
 


### PR DESCRIPTION
## Summary

- stop repeated Stop-hook blocking once Claude marks the hook active
- require exact session ownership or instance-specific transcript proof before loop state can influence a Stop event
- preserve explicitly foreign and fresh instance-backed ownerless workflows while pruning definitive missing-worktree and safe legacy timestamp-stale state
- fail proofless legacy ownerless setup re-entry closed without mutating state or minting ownership proof
- cover direct hook behavior and ship stop-boundary integration across same-session, foreign-session, ownerless, and stale-state cases

## Test Plan

- `./scripts/test-hooks.sh`
- `./scripts/test-ship-e2e-gate.sh`
- authoritative `gate.run` command from `detent.yaml`

Fixes #388