### PR TITLE
chore: release v1.10.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,14 +6,14 @@
   },
   "metadata": {
     "description": "Go-specific and general-purpose AI coding assistant plugins - by Gopher Guides",
-    "version": "1.9.0"
+    "version": "1.10.0"
   },
   "plugins": [
     {
       "name": "go-workflow",
       "source": "./plugins/go-workflow",
       "description": "Issue-to-PR workflow automation with worktree management",
-      "version": "1.9.0",
+      "version": "1.10.0",
       "keywords": [
         "workflow",
         "github",
@@ -26,7 +26,7 @@
       "name": "go-dev",
       "source": "./plugins/go-dev",
       "description": "Go-specific development tools with best practices",
-      "version": "1.9.0",
+      "version": "1.10.0",
       "keywords": [
         "go",
         "testing",
@@ -39,7 +39,7 @@
       "name": "productivity",
       "source": "./plugins/productivity",
       "description": "Standup reports and git productivity helpers",
-      "version": "1.9.0",
+      "version": "1.10.0",
       "keywords": [
         "standup",
         "changelog",
@@ -52,7 +52,7 @@
       "name": "gopher-guides",
       "source": "./plugins/gopher-guides",
       "description": "Go best practices guidance powered by Gopher Guides training materials",
-      "version": "1.9.0",
+      "version": "1.10.0",
       "keywords": [
         "go",
         "training",
@@ -64,7 +64,7 @@
       "name": "llm-tools",
       "source": "./plugins/llm-tools",
       "description": "Multi-LLM integration for second opinions and task delegation",
-      "version": "1.9.0",
+      "version": "1.10.0",
       "keywords": [
         "llm",
         "openai",
@@ -81,7 +81,7 @@
       "name": "go-web",
       "source": "./plugins/go-web",
       "description": "Opinionated Go web app scaffolding with Templ + HTMX + Alpine.js + Tailwind",
-      "version": "1.9.0",
+      "version": "1.10.0",
       "keywords": [
         "go",
         "web",
@@ -97,7 +97,7 @@
       "name": "tailwind",
       "source": "./plugins/tailwind",
       "description": "Tailwind CSS v4 tools for initialization, auditing, migration, and optimization",
-      "version": "1.9.0",
+      "version": "1.10.0",
       "keywords": [
         "tailwind",
         "css",

--- a/plugins/go-dev/.claude-plugin/plugin.json
+++ b/plugins/go-dev/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "go-dev",
   "description": "Go-specific development tools with idiomatic best practices",
-  "version": "1.9.0",
+  "version": "1.10.0",
   "author": {
     "name": "Gopher Guides",
     "email": "support@gopherguides.com"

--- a/plugins/go-dev/.codex-plugin/plugin.json
+++ b/plugins/go-dev/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "go-dev",
-  "version": "1.9.0",
+  "version": "1.10.0",
   "description": "Go-specific development tools with idiomatic best practices",
   "author": {
     "name": "Gopher Guides",

--- a/plugins/go-web/.claude-plugin/plugin.json
+++ b/plugins/go-web/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "go-web",
   "description": "Opinionated Go web app scaffolding with Templ + HTMX + Alpine.js + Tailwind",
-  "version": "1.9.0",
+  "version": "1.10.0",
   "author": {
     "name": "Gopher Guides",
     "email": "support@gopherguides.com"

--- a/plugins/go-web/.codex-plugin/plugin.json
+++ b/plugins/go-web/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "go-web",
-  "version": "1.9.0",
+  "version": "1.10.0",
   "description": "Opinionated Go web app scaffolding with Templ + HTMX + Alpine.js + Tailwind",
   "author": {
     "name": "Gopher Guides",

--- a/plugins/go-workflow/.claude-plugin/plugin.json
+++ b/plugins/go-workflow/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "go-workflow",
   "description": "Issue-to-PR workflow automation with git worktree management",
-  "version": "1.9.0",
+  "version": "1.10.0",
   "author": {
     "name": "Gopher Guides",
     "email": "support@gopherguides.com"

--- a/plugins/go-workflow/.codex-plugin/plugin.json
+++ b/plugins/go-workflow/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "go-workflow",
-  "version": "1.9.0",
+  "version": "1.10.0",
   "description": "Issue-to-PR workflow automation with git worktree management",
   "author": {
     "name": "Gopher Guides",

--- a/plugins/gopher-guides/.claude-plugin/plugin.json
+++ b/plugins/gopher-guides/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "gopher-guides",
   "description": "Gopher Guides training materials integrated into Claude",
-  "version": "1.9.0",
+  "version": "1.10.0",
   "author": {
     "name": "Gopher Guides",
     "email": "support@gopherguides.com"

--- a/plugins/gopher-guides/.codex-plugin/plugin.json
+++ b/plugins/gopher-guides/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "gopher-guides",
-  "version": "1.9.0",
+  "version": "1.10.0",
   "description": "Gopher Guides training materials integration",
   "author": {
     "name": "Gopher Guides",

--- a/plugins/llm-tools/.claude-plugin/plugin.json
+++ b/plugins/llm-tools/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "llm-tools",
   "description": "Multi-LLM integration for second opinions and task delegation",
-  "version": "1.9.0",
+  "version": "1.10.0",
   "author": {
     "name": "Gopher Guides",
     "email": "support@gopherguides.com"

--- a/plugins/llm-tools/.codex-plugin/plugin.json
+++ b/plugins/llm-tools/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "llm-tools",
-  "version": "1.9.0",
+  "version": "1.10.0",
   "description": "Multi-LLM integration for second opinions and task delegation",
   "author": {
     "name": "Gopher Guides",

--- a/plugins/productivity/.claude-plugin/plugin.json
+++ b/plugins/productivity/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "productivity",
   "description": "Standup reports, changelogs, and git productivity helpers",
-  "version": "1.9.0",
+  "version": "1.10.0",
   "author": {
     "name": "Gopher Guides",
     "email": "support@gopherguides.com"

--- a/plugins/tailwind/.claude-plugin/plugin.json
+++ b/plugins/tailwind/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "tailwind",
   "description": "Tailwind CSS v4 tools for initialization, auditing, migration, and optimization",
-  "version": "1.9.0",
+  "version": "1.10.0",
   "author": {
     "name": "Gopher Guides",
     "email": "support@gopherguides.com"

--- a/plugins/tailwind/.codex-plugin/plugin.json
+++ b/plugins/tailwind/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "tailwind",
-  "version": "1.9.0",
+  "version": "1.10.0",
   "description": "Tailwind CSS v4 tools for initialization, auditing, migration, and optimization",
   "author": {
     "name": "Gopher Guides",


### PR DESCRIPTION
## Summary

- bump the marketplace and all Claude and Codex plugin manifests to v1.10.0
- prepare the 44 PR-based changes since v1.9.0 for publication
- package the Codex plugin and Gemini extension distributions

## Test Plan

- authoritative release gate from `detent.yaml`
- `./scripts/build-universal.sh`
- verify all packaged Codex and Gemini manifests report v1.10.0
- verify both builder-produced release archives and their SHA-256 checksums