### PR TITLE
test: separate Tailwind MCP install and response timeouts

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -43,7 +43,18 @@ jobs:
       - name: Validate platform capability matrix
         run: python3 ./scripts/test-platform-capabilities.py
 
+      - name: Install pinned Tailwind MCP server
+        timeout-minutes: 3
+        env:
+          TAILWIND_MCP_INSTALL_ROOT: ${{ runner.temp }}/gopher-ai-tailwind-mcp-install
+          npm_config_cache: ${{ runner.temp }}/gopher-ai-tailwind-mcp-npm-cache
+        run: npm install --prefix "$TAILWIND_MCP_INSTALL_ROOT" --no-save --package-lock=false "tailwindcss-mcp-server@0.1.1"
+
       - name: Probe declared Tailwind MCP tools
+        timeout-minutes: 2
+        env:
+          TAILWIND_MCP_INSTALL_ROOT: ${{ runner.temp }}/gopher-ai-tailwind-mcp-install
+          npm_config_cache: ${{ runner.temp }}/gopher-ai-tailwind-mcp-npm-cache
         run: node ./scripts/test-tailwind-mcp-server.mjs
 
       - name: Probe all-plugin qualified Codex skill names

--- a/scripts/test-codex-compatibility-lanes.sh
+++ b/scripts/test-codex-compatibility-lanes.sh
@@ -6,10 +6,12 @@ SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
 WORKFLOW="$ROOT_DIR/.github/workflows/integration-tests.yml"
 LIFECYCLE_TEST="$ROOT_DIR/scripts/test-codex-plugin-lifecycle.sh"
+TAILWIND_MCP_PROBE="$ROOT_DIR/scripts/test-tailwind-mcp-server.mjs"
 
-ruby -ryaml - "$WORKFLOW" "$LIFECYCLE_TEST" <<'RUBY'
+ruby -ryaml - "$WORKFLOW" "$LIFECYCLE_TEST" "$TAILWIND_MCP_PROBE" <<'RUBY'
 workflow = YAML.safe_load(File.read(ARGV.fetch(0)), aliases: true)
 lifecycle_source = File.read(ARGV.fetch(1))
+tailwind_mcp_probe_source = File.read(ARGV.fetch(2))
 job = workflow.dig("jobs", "test-codex-plugin-lifecycle")
 abort "missing Codex lifecycle job" unless job
 
@@ -44,6 +46,25 @@ unless lifecycle&.dig("env", "CODEX_LIFECYCLE_EXPECTED_VERSION") == expected_ver
   abort "Codex lifecycle expectation does not use the matrix value"
 end
 
+tailwind_install = steps.find { |step| step["name"] == "Install pinned Tailwind MCP server" }
+expected_tailwind_env = {
+  "TAILWIND_MCP_INSTALL_ROOT" => "${{ runner.temp }}/gopher-ai-tailwind-mcp-install",
+  "npm_config_cache" => "${{ runner.temp }}/gopher-ai-tailwind-mcp-npm-cache",
+}
+expected_tailwind_install = 'npm install --prefix "$TAILWIND_MCP_INSTALL_ROOT" --no-save --package-lock=false "tailwindcss-mcp-server@0.1.1"'
+abort "Tailwind MCP install must have its own three-minute timeout" unless tailwind_install&.fetch("timeout-minutes", nil) == 3
+abort "Tailwind MCP install does not use the isolated runner paths" unless tailwind_install&.fetch("env", nil) == expected_tailwind_env
+abort "Tailwind MCP install does not use the pinned package" unless tailwind_install&.fetch("run", "") == expected_tailwind_install
+
+tailwind_probe = steps.find { |step| step["name"] == "Probe declared Tailwind MCP tools" }
+abort "Tailwind MCP probe must have its own two-minute timeout" unless tailwind_probe&.fetch("timeout-minutes", nil) == 2
+abort "Tailwind MCP probe does not reuse the isolated install" unless tailwind_probe&.fetch("env", nil) == expected_tailwind_env
+abort "Tailwind MCP probe command changed unexpectedly" unless tailwind_probe&.fetch("run", "") == "node ./scripts/test-tailwind-mcp-server.mjs"
+abort "Tailwind MCP install must run before the protocol probe" unless steps.index(tailwind_install) < steps.index(tailwind_probe)
+abort "Tailwind MCP probe lacks a named response timeout" unless tailwind_mcp_probe_source.include?("const responseTimeoutMs = 30000;")
+abort "Tailwind MCP requests do not use the response timeout" unless tailwind_mcp_probe_source.include?("}, responseTimeoutMs);")
+abort "Tailwind MCP probe does not resolve the preinstalled server binary" unless tailwind_mcp_probe_source.include?("async function resolveServerLaunch(packageSpec)")
+
 expected_probes = [
   "./scripts/test-codex-plugin-lifecycle.sh",
   "python3 ./scripts/test-codex-default-mode-input.py",
@@ -64,5 +85,23 @@ unless missing_source.empty?
   abort "Codex lifecycle version contract is incomplete: #{missing_source.join(', ')}"
 end
 RUBY
+
+MISSING_INSTALL_ROOT="${TMPDIR:-/tmp}/gopher-ai-tailwind-mcp-missing-$$"
+if missing_install_output=$(
+    TAILWIND_MCP_INSTALL_ROOT="$MISSING_INSTALL_ROOT" \
+        node "$TAILWIND_MCP_PROBE" 2>&1
+); then
+    printf 'Tailwind MCP probe unexpectedly accepted a missing preinstall.\n' >&2
+    exit 1
+fi
+if [[ "$missing_install_output" != *"FAIL: Tailwind MCP installation is not ready:"* ]]; then
+    printf 'Tailwind MCP probe did not distinguish installation readiness failure.\n%s\n' \
+        "$missing_install_output" >&2
+    exit 1
+fi
+if [[ "$missing_install_output" == *"timed out waiting for server/discover"* ]]; then
+    printf 'Tailwind MCP installation failure leaked into the response timeout.\n' >&2
+    exit 1
+fi
 
 printf 'Codex compatibility lane tests passed.\n'

--- a/scripts/test-tailwind-mcp-server.mjs
+++ b/scripts/test-tailwind-mcp-server.mjs
@@ -11,6 +11,7 @@ const claudeManifestPath = resolve(root, "plugins/tailwind/.claude-plugin/plugin
 const mcpManifestPath = resolve(root, "plugins/tailwind/.mcp.json");
 const protocolVersion = "2026-07-28";
 const legacyProtocolVersion = "2024-11-05";
+const responseTimeoutMs = 30000;
 
 function assert(condition, message) {
   if (!condition) {
@@ -20,6 +21,40 @@ function assert(condition, message) {
 
 async function readJson(path) {
   return JSON.parse(await readFile(path, "utf8"));
+}
+
+async function resolveServerLaunch(packageSpec) {
+  const installRoot = process.env.TAILWIND_MCP_INSTALL_ROOT;
+  if (!installRoot) {
+    return {
+      command: serverConfig.command,
+      args: serverConfig.args,
+      cwd: root,
+    };
+  }
+
+  const versionSeparator = packageSpec.lastIndexOf("@");
+  const packageName = packageSpec.slice(0, versionSeparator);
+  const expectedVersion = packageSpec.slice(versionSeparator + 1);
+  const packageRoot = resolve(installRoot, "node_modules", packageName);
+  const installedPackage = await readJson(resolve(packageRoot, "package.json"));
+
+  assert(
+    installedPackage.version === expectedVersion,
+    `preinstalled ${packageName} version ${installedPackage.version} does not match ${expectedVersion}`,
+  );
+
+  const binaryPath =
+    typeof installedPackage.bin === "string"
+      ? installedPackage.bin
+      : installedPackage.bin?.["tailwindcss-server"];
+  assert(binaryPath, `preinstalled ${packageName} does not declare tailwindcss-server`);
+
+  return {
+    command: process.execPath,
+    args: [resolve(packageRoot, binaryPath)],
+    cwd: root,
+  };
 }
 
 const [capabilityMatrix, claudeManifest, mcpManifest] = await Promise.all([
@@ -64,13 +99,18 @@ assert(
   "tailwindcss-mcp-server must use an explicit semantic version",
 );
 
+const serverLaunch = await resolveServerLaunch(packageSpec).catch((error) => {
+  process.stderr.write(`FAIL: Tailwind MCP installation is not ready: ${error.message}\n`);
+  process.exit(1);
+});
+
 const tempRoot =
   process.env.TMPDIR ?? process.env.TMP ?? process.env.TEMP ?? "/tmp";
 const npmCache =
   process.env.npm_config_cache ??
   resolve(tempRoot, "gopher-ai-tailwind-mcp-npm-cache");
-const child = spawn(serverConfig.command, serverConfig.args, {
-  cwd: root,
+const child = spawn(serverLaunch.command, serverLaunch.args, {
+  cwd: serverLaunch.cwd,
   env: {
     ...process.env,
     npm_config_cache: npmCache,
@@ -148,7 +188,7 @@ function request(id, method, params) {
     const timer = setTimeout(() => {
       pending.delete(String(id));
       rejectRequest(new Error(`timed out waiting for ${method}`));
-    }, 30000);
+    }, responseTimeoutMs);
 
     pending.set(String(id), {
       resolve: resolveRequest,


### PR DESCRIPTION
## Summary

- install the pinned Tailwind MCP server into isolated runner storage under its own three-minute budget
- launch the exact preinstalled package binary only after validating its version and declared executable
- retain the independent 30-second JSON-RPC response budget, modern discovery, legacy fallback, and exact declared-tool assertions
- distinguish missing installation readiness from protocol non-response in compatibility regression coverage

## Test Plan

- verify the compatibility workflow contract and missing-install diagnostic
- install `tailwindcss-mcp-server@0.1.1` with a fresh isolated cache and run the real stdio discovery/tool-list probe
- validate Node syntax, shell syntax, whitespace, shared-file synchronization, and sensitive-data patterns
- run the complete Integration Tests workflow on the current pull-request head

Fixes #403
