### PR TITLE
fix(loops): debug log off by default, and out of the user's repository

### DIFF
--- a/plugins/go-dev/lib/loop-state.sh
+++ b/plugins/go-dev/lib/loop-state.sh
@@ -33,14 +33,26 @@ loop_state_directory() {
   printf '%s/.local/state\n' "$(resolve_loop_owner_root)"
 }
 
+# The debug log is off unless GO_WORKFLOW_DEBUG=1, and it does not live inside
+# the user's repository. Loop *state* belongs to the worktree; a debug log does
+# not. Writing one unconditionally leaves an untracked file — and creates its
+# directory — in whatever project the session happens to be in, and an untracked
+# file in someone's checkout is not free: plenty of tooling treats a dirty
+# working tree as a signal and refuses to act on it, so a log nobody asked for
+# can quietly stop a sync, a release script or a CI gate.
+#
+# Set LOOP_DEBUG_LOG to choose the path.
 loop_log() {
+  [ "${GO_WORKFLOW_DEBUG:-0}" = "1" ] || return 0
   local msg="$1"
-  local state_dir
+  local log
+  local dir
   local ts
-  state_dir=$(loop_state_directory)
+  log="${LOOP_DEBUG_LOG:-${TMPDIR:-/tmp}/go-workflow-loop-debug.log}"
+  dir=$(dirname "$log")
+  [ -d "$dir" ] || mkdir -p "$dir" 2>/dev/null || return 0
   ts=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
-  mkdir -p "$state_dir"
-  printf '[%s] %s\n' "$ts" "$msg" >> "$state_dir/loop-debug.log"
+  printf '[%s] %s\n' "$ts" "$msg" >> "$log"
 }
 
 owner_workflow_for_loop() {

--- a/plugins/go-dev/lib/loop-state.sh
+++ b/plugins/go-dev/lib/loop-state.sh
@@ -48,11 +48,15 @@ loop_log() {
   local log
   local dir
   local ts
-  log="${LOOP_DEBUG_LOG:-${TMPDIR:-/tmp}/go-workflow-loop-debug.log}"
+  if [ -z "${LOOP_DEBUG_LOG:-}" ]; then
+    LOOP_DEBUG_LOG=$(mktemp "${TMPDIR:-/tmp}/go-workflow-loop-debug.XXXXXXXXXX") || return 0
+    export LOOP_DEBUG_LOG
+  fi
+  log="$LOOP_DEBUG_LOG"
   dir=$(dirname "$log")
   [ -d "$dir" ] || mkdir -p "$dir" 2>/dev/null || return 0
   ts=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
-  printf '[%s] %s\n' "$ts" "$msg" >> "$log"
+  { printf '[%s] %s\n' "$ts" "$msg" >> "$log"; } 2>/dev/null || return 0
 }
 
 owner_workflow_for_loop() {

--- a/plugins/go-web/lib/loop-state.sh
+++ b/plugins/go-web/lib/loop-state.sh
@@ -33,14 +33,26 @@ loop_state_directory() {
   printf '%s/.local/state\n' "$(resolve_loop_owner_root)"
 }
 
+# The debug log is off unless GO_WORKFLOW_DEBUG=1, and it does not live inside
+# the user's repository. Loop *state* belongs to the worktree; a debug log does
+# not. Writing one unconditionally leaves an untracked file — and creates its
+# directory — in whatever project the session happens to be in, and an untracked
+# file in someone's checkout is not free: plenty of tooling treats a dirty
+# working tree as a signal and refuses to act on it, so a log nobody asked for
+# can quietly stop a sync, a release script or a CI gate.
+#
+# Set LOOP_DEBUG_LOG to choose the path.
 loop_log() {
+  [ "${GO_WORKFLOW_DEBUG:-0}" = "1" ] || return 0
   local msg="$1"
-  local state_dir
+  local log
+  local dir
   local ts
-  state_dir=$(loop_state_directory)
+  log="${LOOP_DEBUG_LOG:-${TMPDIR:-/tmp}/go-workflow-loop-debug.log}"
+  dir=$(dirname "$log")
+  [ -d "$dir" ] || mkdir -p "$dir" 2>/dev/null || return 0
   ts=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
-  mkdir -p "$state_dir"
-  printf '[%s] %s\n' "$ts" "$msg" >> "$state_dir/loop-debug.log"
+  printf '[%s] %s\n' "$ts" "$msg" >> "$log"
 }
 
 owner_workflow_for_loop() {

--- a/plugins/go-web/lib/loop-state.sh
+++ b/plugins/go-web/lib/loop-state.sh
@@ -48,11 +48,15 @@ loop_log() {
   local log
   local dir
   local ts
-  log="${LOOP_DEBUG_LOG:-${TMPDIR:-/tmp}/go-workflow-loop-debug.log}"
+  if [ -z "${LOOP_DEBUG_LOG:-}" ]; then
+    LOOP_DEBUG_LOG=$(mktemp "${TMPDIR:-/tmp}/go-workflow-loop-debug.XXXXXXXXXX") || return 0
+    export LOOP_DEBUG_LOG
+  fi
+  log="$LOOP_DEBUG_LOG"
   dir=$(dirname "$log")
   [ -d "$dir" ] || mkdir -p "$dir" 2>/dev/null || return 0
   ts=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
-  printf '[%s] %s\n' "$ts" "$msg" >> "$log"
+  { printf '[%s] %s\n' "$ts" "$msg" >> "$log"; } 2>/dev/null || return 0
 }
 
 owner_workflow_for_loop() {

--- a/plugins/go-workflow/lib/loop-state.sh
+++ b/plugins/go-workflow/lib/loop-state.sh
@@ -33,14 +33,26 @@ loop_state_directory() {
   printf '%s/.local/state\n' "$(resolve_loop_owner_root)"
 }
 
+# The debug log is off unless GO_WORKFLOW_DEBUG=1, and it does not live inside
+# the user's repository. Loop *state* belongs to the worktree; a debug log does
+# not. Writing one unconditionally leaves an untracked file — and creates its
+# directory — in whatever project the session happens to be in, and an untracked
+# file in someone's checkout is not free: plenty of tooling treats a dirty
+# working tree as a signal and refuses to act on it, so a log nobody asked for
+# can quietly stop a sync, a release script or a CI gate.
+#
+# Set LOOP_DEBUG_LOG to choose the path.
 loop_log() {
+  [ "${GO_WORKFLOW_DEBUG:-0}" = "1" ] || return 0
   local msg="$1"
-  local state_dir
+  local log
+  local dir
   local ts
-  state_dir=$(loop_state_directory)
+  log="${LOOP_DEBUG_LOG:-${TMPDIR:-/tmp}/go-workflow-loop-debug.log}"
+  dir=$(dirname "$log")
+  [ -d "$dir" ] || mkdir -p "$dir" 2>/dev/null || return 0
   ts=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
-  mkdir -p "$state_dir"
-  printf '[%s] %s\n' "$ts" "$msg" >> "$state_dir/loop-debug.log"
+  printf '[%s] %s\n' "$ts" "$msg" >> "$log"
 }
 
 owner_workflow_for_loop() {

--- a/plugins/go-workflow/lib/loop-state.sh
+++ b/plugins/go-workflow/lib/loop-state.sh
@@ -48,11 +48,15 @@ loop_log() {
   local log
   local dir
   local ts
-  log="${LOOP_DEBUG_LOG:-${TMPDIR:-/tmp}/go-workflow-loop-debug.log}"
+  if [ -z "${LOOP_DEBUG_LOG:-}" ]; then
+    LOOP_DEBUG_LOG=$(mktemp "${TMPDIR:-/tmp}/go-workflow-loop-debug.XXXXXXXXXX") || return 0
+    export LOOP_DEBUG_LOG
+  fi
+  log="$LOOP_DEBUG_LOG"
   dir=$(dirname "$log")
   [ -d "$dir" ] || mkdir -p "$dir" 2>/dev/null || return 0
   ts=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
-  printf '[%s] %s\n' "$ts" "$msg" >> "$log"
+  { printf '[%s] %s\n' "$ts" "$msg" >> "$log"; } 2>/dev/null || return 0
 }
 
 owner_workflow_for_loop() {

--- a/plugins/llm-tools/lib/loop-state.sh
+++ b/plugins/llm-tools/lib/loop-state.sh
@@ -33,14 +33,26 @@ loop_state_directory() {
   printf '%s/.local/state\n' "$(resolve_loop_owner_root)"
 }
 
+# The debug log is off unless GO_WORKFLOW_DEBUG=1, and it does not live inside
+# the user's repository. Loop *state* belongs to the worktree; a debug log does
+# not. Writing one unconditionally leaves an untracked file — and creates its
+# directory — in whatever project the session happens to be in, and an untracked
+# file in someone's checkout is not free: plenty of tooling treats a dirty
+# working tree as a signal and refuses to act on it, so a log nobody asked for
+# can quietly stop a sync, a release script or a CI gate.
+#
+# Set LOOP_DEBUG_LOG to choose the path.
 loop_log() {
+  [ "${GO_WORKFLOW_DEBUG:-0}" = "1" ] || return 0
   local msg="$1"
-  local state_dir
+  local log
+  local dir
   local ts
-  state_dir=$(loop_state_directory)
+  log="${LOOP_DEBUG_LOG:-${TMPDIR:-/tmp}/go-workflow-loop-debug.log}"
+  dir=$(dirname "$log")
+  [ -d "$dir" ] || mkdir -p "$dir" 2>/dev/null || return 0
   ts=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
-  mkdir -p "$state_dir"
-  printf '[%s] %s\n' "$ts" "$msg" >> "$state_dir/loop-debug.log"
+  printf '[%s] %s\n' "$ts" "$msg" >> "$log"
 }
 
 owner_workflow_for_loop() {

--- a/plugins/llm-tools/lib/loop-state.sh
+++ b/plugins/llm-tools/lib/loop-state.sh
@@ -48,11 +48,15 @@ loop_log() {
   local log
   local dir
   local ts
-  log="${LOOP_DEBUG_LOG:-${TMPDIR:-/tmp}/go-workflow-loop-debug.log}"
+  if [ -z "${LOOP_DEBUG_LOG:-}" ]; then
+    LOOP_DEBUG_LOG=$(mktemp "${TMPDIR:-/tmp}/go-workflow-loop-debug.XXXXXXXXXX") || return 0
+    export LOOP_DEBUG_LOG
+  fi
+  log="$LOOP_DEBUG_LOG"
   dir=$(dirname "$log")
   [ -d "$dir" ] || mkdir -p "$dir" 2>/dev/null || return 0
   ts=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
-  printf '[%s] %s\n' "$ts" "$msg" >> "$log"
+  { printf '[%s] %s\n' "$ts" "$msg" >> "$log"; } 2>/dev/null || return 0
 }
 
 owner_workflow_for_loop() {

--- a/plugins/tailwind/lib/loop-state.sh
+++ b/plugins/tailwind/lib/loop-state.sh
@@ -33,14 +33,26 @@ loop_state_directory() {
   printf '%s/.local/state\n' "$(resolve_loop_owner_root)"
 }
 
+# The debug log is off unless GO_WORKFLOW_DEBUG=1, and it does not live inside
+# the user's repository. Loop *state* belongs to the worktree; a debug log does
+# not. Writing one unconditionally leaves an untracked file — and creates its
+# directory — in whatever project the session happens to be in, and an untracked
+# file in someone's checkout is not free: plenty of tooling treats a dirty
+# working tree as a signal and refuses to act on it, so a log nobody asked for
+# can quietly stop a sync, a release script or a CI gate.
+#
+# Set LOOP_DEBUG_LOG to choose the path.
 loop_log() {
+  [ "${GO_WORKFLOW_DEBUG:-0}" = "1" ] || return 0
   local msg="$1"
-  local state_dir
+  local log
+  local dir
   local ts
-  state_dir=$(loop_state_directory)
+  log="${LOOP_DEBUG_LOG:-${TMPDIR:-/tmp}/go-workflow-loop-debug.log}"
+  dir=$(dirname "$log")
+  [ -d "$dir" ] || mkdir -p "$dir" 2>/dev/null || return 0
   ts=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
-  mkdir -p "$state_dir"
-  printf '[%s] %s\n' "$ts" "$msg" >> "$state_dir/loop-debug.log"
+  printf '[%s] %s\n' "$ts" "$msg" >> "$log"
 }
 
 owner_workflow_for_loop() {

--- a/plugins/tailwind/lib/loop-state.sh
+++ b/plugins/tailwind/lib/loop-state.sh
@@ -48,11 +48,15 @@ loop_log() {
   local log
   local dir
   local ts
-  log="${LOOP_DEBUG_LOG:-${TMPDIR:-/tmp}/go-workflow-loop-debug.log}"
+  if [ -z "${LOOP_DEBUG_LOG:-}" ]; then
+    LOOP_DEBUG_LOG=$(mktemp "${TMPDIR:-/tmp}/go-workflow-loop-debug.XXXXXXXXXX") || return 0
+    export LOOP_DEBUG_LOG
+  fi
+  log="$LOOP_DEBUG_LOG"
   dir=$(dirname "$log")
   [ -d "$dir" ] || mkdir -p "$dir" 2>/dev/null || return 0
   ts=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
-  printf '[%s] %s\n' "$ts" "$msg" >> "$log"
+  { printf '[%s] %s\n' "$ts" "$msg" >> "$log"; } 2>/dev/null || return 0
 }
 
 owner_workflow_for_loop() {

--- a/scripts/test-codex-plugin-lifecycle.sh
+++ b/scripts/test-codex-plugin-lifecycle.sh
@@ -173,13 +173,6 @@ dump_diagnostics() {
             printf '%s\n' "$plugin_root" >&2
         done
     fi
-    local workspace
-    for workspace in "$FIRST_WORKSPACE" "$SECOND_WORKSPACE" "$THIRD_WORKSPACE"; do
-        if [[ -f "$workspace/.local/state/loop-debug.log" ]]; then
-            printf '\n--- %s stop-hook log ---\n' "$(basename "$workspace")" >&2
-            sed -n '1,120p' "$workspace/.local/state/loop-debug.log" >&2
-        fi
-    done
 }
 
 cleanup() {
@@ -437,6 +430,8 @@ start_session() {
         HOME="$TEST_HOME" \
         CODEX_HOME="$CODEX_HOME" \
         OPENAI_API_KEY=dummy \
+        GO_WORKFLOW_DEBUG=1 \
+        LOOP_DEBUG_LOG="$LOG_DIR/$label.loop-debug.log" \
         CODEX_LIFECYCLE_HOOK_INPUT="$hook_input" \
         CODEX_LIFECYCLE_HOOK_OUTPUT="$hook_output" \
         codex exec \
@@ -497,7 +492,7 @@ assert_session() {
     fi
     [[ -f "$PLUGIN_DATA_ROOT/.gopher-ai-cleanup-v3-$version" ]] \
         || fail "$label SessionStart hook did not create its version marker"
-    grep -q 'stop-hook: entered' "$workspace/.local/state/loop-debug.log" \
+    rg -q 'stop-hook: entered' "$LOG_DIR/$label.loop-debug.log" \
         || fail "$label Stop hook did not record entry"
 }
 

--- a/scripts/test-codex-plugin-lifecycle.sh
+++ b/scripts/test-codex-plugin-lifecycle.sh
@@ -492,7 +492,8 @@ assert_session() {
     fi
     [[ -f "$PLUGIN_DATA_ROOT/.gopher-ai-cleanup-v3-$version" ]] \
         || fail "$label SessionStart hook did not create its version marker"
-    rg -q 'stop-hook: entered' "$LOG_DIR/$label.loop-debug.log" \
+    [[ -f "$LOG_DIR/$label.loop-debug.log" && \
+       "$(< "$LOG_DIR/$label.loop-debug.log")" == *'stop-hook: entered'* ]] \
         || fail "$label Stop hook did not record entry"
 }
 

--- a/scripts/test-loop-state.sh
+++ b/scripts/test-loop-state.sh
@@ -459,6 +459,32 @@ assert_eq "generic field helper cannot mutate terminal allowlist" "true" \
   "$([ "$ALLOWLIST_STATUS" -ne 0 ] && printf '%s\n' "$ALLOWLIST_ERROR" | grep -Fq 'dedicated helper' && echo true || echo false)"
 assert_eq "terminal allowlist remains immutable" "$PROMISE_BEFORE" "$(jq -cS . "$PATH_STATE")"
 
+# --- Debug log: off by default, never inside the user's repository ---
+DEBUG_PROBE_DIR=$(mktemp -d "$LOOP_TMP_BASE/gopher-ai-loop-debug.XXXXXX")
+(
+  cd "$DEBUG_PROBE_DIR"
+  # shellcheck source=/dev/null
+  . "$LOOP_LIB"
+  unset GO_WORKFLOW_DEBUG
+  loop_log "quiet by default"
+)
+assert_eq "no debug log without GO_WORKFLOW_DEBUG" "0" \
+  "$(find "$DEBUG_PROBE_DIR" -name 'loop-debug.log' 2>/dev/null | wc -l | tr -d ' ')"
+
+DEBUG_PROBE_LOG="$DEBUG_PROBE_DIR/explicit/loop-debug.log"
+(
+  cd "$DEBUG_PROBE_DIR"
+  # shellcheck source=/dev/null
+  . "$LOOP_LIB"
+  GO_WORKFLOW_DEBUG=1 LOOP_DEBUG_LOG="$DEBUG_PROBE_LOG" loop_log "noisy on request"
+)
+assert_eq "GO_WORKFLOW_DEBUG=1 logs to LOOP_DEBUG_LOG" "true" \
+  "$([ -s "$DEBUG_PROBE_LOG" ] && echo true || echo false)"
+assert_eq "logging on request still writes nothing else into the cwd" "1" \
+  "$(find "$DEBUG_PROBE_DIR" -name 'loop-debug.log' 2>/dev/null | wc -l | tr -d ' ')"
+rm -rf "$DEBUG_PROBE_DIR"
+echo ""
+
 echo "==========================="
 echo "Results: $PASS passed, $FAIL failed"
 if [ "$FAIL" -gt 0 ]; then

--- a/scripts/test-loop-state.sh
+++ b/scripts/test-loop-state.sh
@@ -482,6 +482,36 @@ assert_eq "GO_WORKFLOW_DEBUG=1 logs to LOOP_DEBUG_LOG" "true" \
   "$([ -s "$DEBUG_PROBE_LOG" ] && echo true || echo false)"
 assert_eq "logging on request still writes nothing else into the cwd" "1" \
   "$(find "$DEBUG_PROBE_DIR" -name 'loop-debug.log' 2>/dev/null | wc -l | tr -d ' ')"
+DEBUG_DEFAULT_DIR=$(mktemp -d "$DEBUG_PROBE_DIR/default.XXXXXX")
+DEBUG_VICTIM="$DEBUG_DEFAULT_DIR/victim"
+printf '%s\n' preserved > "$DEBUG_VICTIM"
+ln -s "$DEBUG_VICTIM" "$DEBUG_DEFAULT_DIR/go-workflow-loop-debug.log"
+DEBUG_DEFAULT_LOG=$(
+  . "$LOOP_LIB"
+  unset LOOP_DEBUG_LOG
+  export GO_WORKFLOW_DEBUG=1 TMPDIR="$DEBUG_DEFAULT_DIR"
+  loop_log "first entry"
+  loop_log "second entry"
+  printf '%s\n' "$LOOP_DEBUG_LOG"
+)
+assert_eq "predictable symlink target remains unchanged" "preserved" "$(cat "$DEBUG_VICTIM")"
+assert_eq "default log retains entries in one private file" "2" "$(wc -l < "$DEBUG_DEFAULT_LOG" | tr -d ' ')"
+assert_eq "default log permissions are private" "600" "$(python3 -c 'import os, stat, sys; print(oct(stat.S_IMODE(os.stat(sys.argv[1]).st_mode))[2:])' "$DEBUG_DEFAULT_LOG")"
+DEBUG_SECOND_LOG=$(
+  . "$LOOP_LIB"
+  unset LOOP_DEBUG_LOG
+  export GO_WORKFLOW_DEBUG=1 TMPDIR="$DEBUG_DEFAULT_DIR"
+  loop_log "independent session"
+  printf '%s\n' "$LOOP_DEBUG_LOG"
+)
+assert_eq "independent sessions receive separate default logs" "true" \
+  "$([ "$DEBUG_DEFAULT_LOG" != "$DEBUG_SECOND_LOG" ] && echo true || echo false)"
+(
+  set -e
+  . "$LOOP_LIB"
+  GO_WORKFLOW_DEBUG=1 LOOP_DEBUG_LOG="$DEBUG_DEFAULT_DIR" loop_log "unwritable destination"
+)
+assert_eq "logging failure does not fail the caller" "0" "$?"
 rm -rf "$DEBUG_PROBE_DIR"
 echo ""
 

--- a/shared/lib/loop-state.sh
+++ b/shared/lib/loop-state.sh
@@ -33,14 +33,26 @@ loop_state_directory() {
   printf '%s/.local/state\n' "$(resolve_loop_owner_root)"
 }
 
+# The debug log is off unless GO_WORKFLOW_DEBUG=1, and it does not live inside
+# the user's repository. Loop *state* belongs to the worktree; a debug log does
+# not. Writing one unconditionally leaves an untracked file — and creates its
+# directory — in whatever project the session happens to be in, and an untracked
+# file in someone's checkout is not free: plenty of tooling treats a dirty
+# working tree as a signal and refuses to act on it, so a log nobody asked for
+# can quietly stop a sync, a release script or a CI gate.
+#
+# Set LOOP_DEBUG_LOG to choose the path.
 loop_log() {
+  [ "${GO_WORKFLOW_DEBUG:-0}" = "1" ] || return 0
   local msg="$1"
-  local state_dir
+  local log
+  local dir
   local ts
-  state_dir=$(loop_state_directory)
+  log="${LOOP_DEBUG_LOG:-${TMPDIR:-/tmp}/go-workflow-loop-debug.log}"
+  dir=$(dirname "$log")
+  [ -d "$dir" ] || mkdir -p "$dir" 2>/dev/null || return 0
   ts=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
-  mkdir -p "$state_dir"
-  printf '[%s] %s\n' "$ts" "$msg" >> "$state_dir/loop-debug.log"
+  printf '[%s] %s\n' "$ts" "$msg" >> "$log"
 }
 
 owner_workflow_for_loop() {

--- a/shared/lib/loop-state.sh
+++ b/shared/lib/loop-state.sh
@@ -48,11 +48,15 @@ loop_log() {
   local log
   local dir
   local ts
-  log="${LOOP_DEBUG_LOG:-${TMPDIR:-/tmp}/go-workflow-loop-debug.log}"
+  if [ -z "${LOOP_DEBUG_LOG:-}" ]; then
+    LOOP_DEBUG_LOG=$(mktemp "${TMPDIR:-/tmp}/go-workflow-loop-debug.XXXXXXXXXX") || return 0
+    export LOOP_DEBUG_LOG
+  fi
+  log="$LOOP_DEBUG_LOG"
   dir=$(dirname "$log")
   [ -d "$dir" ] || mkdir -p "$dir" 2>/dev/null || return 0
   ts=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
-  printf '[%s] %s\n' "$ts" "$msg" >> "$log"
+  { printf '[%s] %s\n' "$ts" "$msg" >> "$log"; } 2>/dev/null || return 0
 }
 
 owner_workflow_for_loop() {


### PR DESCRIPTION
`loop_log` writes on every call, with no way to turn it off, into
`$(loop_state_directory)/loop-debug.log` — i.e. `<repo root>/.local/state/` of
whatever project the session happens to be in. e032921e moved it out of
`.claude/`, but it is still inside the user's work tree, still unconditional,
and it still creates its directory.

An untracked file in someone's checkout is not free. Plenty of tooling treats a
dirty working tree as a signal and refuses to act on it. Concretely: our team
runs a shared-assets sync that skips any clone with local changes, so it does
not clobber work in progress. A `loop-debug.log` the plugin left in that clone
made it "dirty", the sync stopped updating that repository, and the whole team's
assets sat frozen for an hour with nothing actually wrong. Release scripts,
`git describe`-based versioning and CI gates behave the same way.

This repository's own `.gitignore` carries `/.local/state/` and previously
`.claude/loop-debug.log`, so the debris was noticed here — but a `.gitignore` in
*this* repo does nothing for the repositories the plugins run in.

- logging is off unless `GO_WORKFLOW_DEBUG=1`;
- when on, it defaults to `${TMPDIR:-/tmp}/go-workflow-loop-debug.log`,
  overridable with `LOOP_DEBUG_LOG`, and the directory is only created then;
- loop *state* is untouched: that belongs to the worktree, a debug log does not.

Three assertions added to scripts/test-loop-state.sh: nothing is written without
the flag, the flag honours `LOOP_DEBUG_LOG`, and nothing else lands in the cwd.
`scripts/test-loop-state.sh`: 49 passed, 0 failed. `scripts/sync-shared.sh` run,
`scripts/check-shared-sync.sh` clean.