### PR TITLE
test(review): invoke planner through Bash

### DIFF
--- a/scripts/test-review-plan.sh
+++ b/scripts/test-review-plan.sh
@@ -10,6 +10,8 @@ fail() { echo "FAIL: $1" >&2; exit 1; }
 assert_contains() { case "$1" in *"$2"*) ;; *) fail "$3 (missing: $2)" ;; esac; }
 assert_not_contains() { case "$1" in *"$2"*) fail "$3 (unexpected: $2)" ;; *) ;; esac; }
 
+test -x "$PLANNER" || fail "review planner is missing or not executable"
+
 new_repo() {
   local repo="$1"
   mkdir -p "$repo"

--- a/scripts/test-review-plan.sh
+++ b/scripts/test-review-plan.sh
@@ -24,7 +24,7 @@ new_repo() {
 run_plan() {
   local repo="$1"
   shift
-  (cd "$repo" && "$PLANNER" --base HEAD^ "$@")
+  (cd "$repo" && /bin/bash "$PLANNER" --base HEAD^ "$@")
 }
 
 echo "=== Adaptive Review Planner Tests ==="


### PR DESCRIPTION
## Summary

- invoke the adaptive review planner through the system Bash interpreter inside command substitution
- preserve the existing review-plan fixtures and behavioral assertions

## Test Plan

- run the adaptive review-plan suite under `/bin/bash` 3.2
- run the adaptive review-plan suite under Homebrew Bash 5.3
- run the authoritative repository validation gate from `detent.yaml`

Fixes #404
