### PR TITLE
fix(review): invoke planner through bash

### DIFF
--- a/plugins/go-workflow/lib/review-planning.md
+++ b/plugins/go-workflow/lib/review-planning.md
@@ -13,7 +13,7 @@ REVIEW_PLAN_ARGS=(
 if [ -n "${SCOPE_HINT:-}" ]; then
   REVIEW_PLAN_ARGS+=(--scope "$SCOPE_HINT")
 fi
-REVIEW_PLAN=$("<PLUGIN_ROOT>/scripts/review-plan.sh" "${REVIEW_PLAN_ARGS[@]}")
+REVIEW_PLAN=$(/bin/bash "<PLUGIN_ROOT>/scripts/review-plan.sh" "${REVIEW_PLAN_ARGS[@]}")
 printf '%s\n' "$REVIEW_PLAN"
 REVIEW_PLAN_MODE=$(printf '%s\n' "$REVIEW_PLAN" | sed -n 's/^REVIEW_PLAN_MODE=//p')
 REVIEW_PLAN_REQUIRES_INPUT=$(printf '%s\n' "$REVIEW_PLAN" | sed -n 's/^REVIEW_PLAN_REQUIRES_INPUT=//p')

--- a/scripts/test-decision-gates.sh
+++ b/scripts/test-decision-gates.sh
@@ -119,6 +119,10 @@ assert_contains "$review_capacity" "higher-capacity backend" "review planning ca
 assert_contains "$review_capacity" "explicitly selected backend" "review planning can override explicit backend intent"
 assert_contains "$review_capacity" "baseline coverage cannot be narrowed" "review planning can waive coverage"
 
+review_runtime=$(file_text "$REVIEW_PLAN")
+assert_contains "$review_runtime" "REVIEW_PLAN=\$(/bin/bash \"<PLUGIN_ROOT>/scripts/review-plan.sh\"" "review planner does not use /bin/bash at runtime"
+assert_not_contains "$review_runtime" "REVIEW_PLAN=\$(\"<PLUGIN_ROOT>/scripts/review-plan.sh\"" "review planner still executes directly at runtime"
+
 dirty_ship=$(section_text "$SHIP" "## 3. Detect Context" "## 4. Prerequisite Check")
 assert_contains "$dirty_ship" "unambiguously in scope" "dirty ship cannot identify owned changes"
 assert_contains "$dirty_ship" "Preserve unrelated changes" "dirty ship can capture unrelated changes"


### PR DESCRIPTION
## Summary

- Invoke the adaptive review planner through the known-compatible /bin/bash interpreter at runtime.
- Add a focused decision-gate regression that requires the explicit interpreter and rejects the former direct invocation.
- Preserve executable-bit and direct-execution coverage for the planner.

Fixes #408

## Test Plan

- bash scripts/test-decision-gates.sh
- bash scripts/test-review-plan.sh
- Exact gate.run command from detent.yaml