### PR TITLE
fix(ci): make latest Codex lane non-blocking

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -11,6 +11,7 @@ jobs:
     name: 'Codex compatibility (${{ matrix.lane }}: ${{ matrix.codex-version }})'
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    continue-on-error: ${{ !matrix.blocking }}
     strategy:
       fail-fast: false
       matrix:
@@ -18,9 +19,11 @@ jobs:
           - lane: minimum
             codex-version: '0.146.0'
             expected-version: '0.146.0'
+            blocking: true
           - lane: current
             codex-version: latest
             expected-version: ''
+            blocking: false
     steps:
       - uses: actions/checkout@v7
 

--- a/scripts/test-codex-compatibility-lanes.sh
+++ b/scripts/test-codex-compatibility-lanes.sh
@@ -20,15 +20,21 @@ expected_lanes = [
     "lane" => "minimum",
     "codex-version" => "0.146.0",
     "expected-version" => "0.146.0",
+    "blocking" => true,
   },
   {
     "lane" => "current",
     "codex-version" => "latest",
     "expected-version" => "",
+    "blocking" => false,
   },
 ]
 actual_lanes = job.dig("strategy", "matrix", "include")
 abort "Codex compatibility matrix does not define minimum and current lanes" unless actual_lanes == expected_lanes
+
+unless job["continue-on-error"] == "${{ !matrix.blocking }}"
+  abort "Codex compatibility job does not limit allowed failures to the current lane"
+end
 
 name = job.fetch("name", "")
 abort "Codex compatibility job name does not identify its lane" unless name.include?("${{ matrix.lane }}")


### PR DESCRIPTION
## Summary

- mark the pinned Codex compatibility lane as blocking
- allow failures only for the moving latest-version canary
- enforce the matrix policy with the compatibility-lane regression test

## Test Plan

- `/bin/bash scripts/test-codex-compatibility-lanes.sh`
- authoritative `gate.run` command from `detent.yaml`
- `actionlint .github/workflows/integration-tests.yml`

Fixes #410