### PR TITLE
chore(detent): default to Astra low reasoning

### DIFF
--- a/detent.yaml
+++ b/detent.yaml
@@ -261,3 +261,16 @@ schedule_ownership:
     enabled: true
     key: gopher-ai
     repository: gopherguides/gopher-ai
+
+agents:
+    model_selection:
+        preset: sol_first
+        normal_model: gpt-6-astra
+        complex_model: gpt-6-astra
+        levels:
+            normal:
+                effort: low
+            complex:
+                effort: medium
+            very_complex:
+                effort: high


### PR DESCRIPTION
## Summary

Use Codex Astra (`gpt-6-astra`) with low effort for ordinary work, medium for moderately difficult work, and high for the hardest work. Align Detent defaults and applicable admission guidance with that policy while preserving explicit operator issue overrides.

## Test Plan

- Validated YAML and resolved all three model/effort levels with Detent’s config parser and policy validator.
- `git diff --check` passed.
- No application logic, data schema, or UI changes.
