### PR TITLE
fix(config): default Astra effort to low

### DIFF
--- a/detent.yaml
+++ b/detent.yaml
@@ -271,6 +271,6 @@ agents:
             normal:
                 effort: low
             complex:
-                effort: medium
+                effort: low
             very_complex:
-                effort: high
+                effort: low


### PR DESCRIPTION
Automatic complexity tiers and issue rubrics escalated routine implementation to medium/high effort, increasing token use. Default Astra to low across configured tiers and require a concrete written reason for escalation wherever this repository defines an effort rubric.

Validation: Detent startup preflight passes on the host after applying the configuration changes; git diff --check passes. This change is limited to configuration and agent guidance.
