### PR TITLE
fix(hooks): sync the active commit worktree

### DIFF
--- a/githooks/pre-commit
+++ b/githooks/pre-commit
@@ -6,23 +6,15 @@
 
 set -euo pipefail
 
-SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
-
-# Handle both symlink (from .git/hooks) and direct execution
-if [ -L "$0" ]; then
-  # Running as symlink from .git/hooks
-  ROOT_DIR="$(cd "$SCRIPT_DIR/../.." && pwd)"
-else
-  # Running directly from githooks/
-  ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
-fi
+ROOT_DIR="$(git rev-parse --show-toplevel)"
+cd "$ROOT_DIR"
 
 # Check if any shared files were modified
 SHARED_CHANGED=$(git diff --cached --name-only | grep -E "^shared/" || true)
 
 if [ -n "$SHARED_CHANGED" ]; then
   echo "Shared files changed, running sync..."
-  "$ROOT_DIR/scripts/sync-shared.sh"
+  /bin/bash "$ROOT_DIR/scripts/sync-shared.sh"
 
   # Stage the synced files
   # Note: Only go-workflow has hooks/ — other plugins only get scripts/, lib/, and commands/
@@ -40,10 +32,13 @@ if [ -n "$SHARED_CHANGED" ]; then
     plugins/tailwind/scripts \
     plugins/tailwind/lib \
     plugins/tailwind/commands/cancel-loop.md \
+    plugins/llm-tools/scripts \
+    plugins/llm-tools/lib \
+    plugins/llm-tools/commands/cancel-loop.md \
     2>/dev/null || true
 
   echo "Synced files staged for commit."
 fi
 
 # Verify sync is correct
-"$ROOT_DIR/scripts/check-shared-sync.sh"
+/bin/bash "$ROOT_DIR/scripts/check-shared-sync.sh"

--- a/scripts/test-hooks.sh
+++ b/scripts/test-hooks.sh
@@ -14,6 +14,57 @@ esac
 
 ERRORS=0
 
+run_commit_worktree_tests() (
+  unset GIT_DIR GIT_WORK_TREE GIT_INDEX_FILE GIT_COMMON_DIR
+  local fixture primary linked mode before plugin output
+  fixture=$(mktemp -d "$HOOK_TMP_BASE/gopher-ai-commit-worktree.XXXXXX")
+  primary="$fixture/primary checkout"
+  linked="$fixture/linked checkout"
+  mkdir -p "$primary"
+  git -C "$ROOT_DIR" archive HEAD shared plugins scripts githooks | tar -x -C "$primary"
+  cp "$ROOT_DIR/githooks/pre-commit" "$primary/githooks/pre-commit"
+  git -C "$primary" init -qb main
+  git -C "$primary" config user.name "Hook Tests"
+  git -C "$primary" config user.email hooks@example.com
+  git -C "$primary" -c core.hooksPath=/dev/null add .
+  git -C "$primary" -c core.hooksPath=/dev/null commit -qm initial
+  git -C "$primary" worktree add -qb linked "$linked"
+  printf '%s\n' primary-staged > "$primary/sentinel"
+  git -C "$primary" add sentinel
+  printf '%s\n' primary-unstaged >> "$primary/sentinel"
+  before=$(git -C "$primary" diff HEAD --binary)
+  for mode in absolute symlink; do
+    echo "  Installed $mode hook commits only the active worktree..."
+    if [ "$mode" = absolute ]; then
+      git -C "$primary" config core.hooksPath "$primary/githooks"
+    else
+      git -C "$primary" config --unset core.hooksPath
+      /bin/bash "$primary/scripts/install-hooks.sh" >/dev/null
+    fi
+    printf '\n%s\n' "$mode" >> "$linked/shared/commands/cancel-loop.md"
+    git -C "$linked" add shared/commands/cancel-loop.md
+    output=$(git -C "$linked" commit -qm "$mode sync" 2>&1) || {
+      printf '%s\n' "$output"
+      return 1
+    }
+    [ "$before" = "$(git -C "$primary" diff HEAD --binary)" ] || return 1
+    [ "sentinel" = "$(git -C "$primary" diff --cached --name-only)" ] || return 1
+    [ -z "$(git -C "$linked" status --porcelain)" ] || return 1
+    for plugin in go-workflow go-web go-dev tailwind llm-tools; do
+      git -C "$linked" show "HEAD:plugins/$plugin/commands/cancel-loop.md" > "$fixture/committed"
+      cmp "$linked/shared/commands/cancel-loop.md" "$fixture/committed" || return 1
+    done
+    /bin/bash "$linked/scripts/check-shared-sync.sh" >/dev/null || return 1
+  done
+)
+
+if [ "${1:-}" = "--commit-worktree-only" ]; then
+  run_commit_worktree_tests
+  exit $?
+fi
+
+run_commit_worktree_tests || ERRORS=$((ERRORS + 1))
+
 run_runtime_location_tests() {
   local worktree_state="$ROOT_DIR/plugins/go-workflow/scripts/worktree-state.sh"
   local pre_tool_hook="$ROOT_DIR/plugins/go-workflow/hooks/pre-tool-use.sh"


### PR DESCRIPTION
## Summary

Fixes #418

The installed pre-commit hook now resolves the committing worktree from Git context, so linked-worktree commits synchronize, stage, and verify their own files while preserving the primary checkout. Synced llm-tools copies are now included in staging alongside the other loop plugins. Helpers run through Bash for managed-worker compatibility.

## Test Plan

- Regression red/green with real linked-worktree commits using an absolute hooksPath and the installer-created symlink, including paths with spaces and staged/unstaged primary changes.
- Verify all five plugins contain committed synced copies and the linked worktree is clean afterward.
- Full configured Detent validation gate passed; managed Darwin compiled demo Go tests without executing them.
- Hook ShellCheck and whitespace validation passed.

The first gate run hit an unrelated intermittent guidance assertion; unchanged focused reruns and the full retry passed. Tracked separately in #419.
