### PR TITLE
fix(tests): stabilize llm-tools guidance assertions

### DIFF
--- a/scripts/test-llm-tools-codex-skills.sh
+++ b/scripts/test-llm-tools-codex-skills.sh
@@ -35,7 +35,7 @@ frontmatter() {
 matches() {
   local pattern="$1"
 
-  awk -v pattern="$pattern" '$0 ~ pattern { found = 1; exit } END { exit found ? 0 : 1 }'
+  awk -v pattern="$pattern" '$0 ~ pattern { found = 1 } END { exit found ? 0 : 1 }'
 }
 
 section_text() {


### PR DESCRIPTION
## Summary

Make the llm-tools guidance matcher consume its entire input under pipefail. Early matches previously closed the pipe and could make valid guidance fail with SIGPIPE or hide forbidden-command matches.

Fixes #419

## Test Plan

- Reproduced exit 141 with an early match followed by 100,000 padding lines; fixed matcher returns 0 and still rejects absent patterns.
- Passed 30 consecutive focused llm-tools Codex skill test runs.
- Passed the full authoritative `gate.run` from `detent.yaml`.
