### PR TITLE
config(detent): default to Codex Sol at high effort

### DIFF
--- a/detent.yaml
+++ b/detent.yaml
@@ -270,12 +270,12 @@ schedule_ownership:
 agents:
     model_selection:
         preset: sol_first
-        normal_model: gpt-6-astra
-        complex_model: gpt-6-astra
+        normal_model: gpt-5.6-sol
+        complex_model: gpt-5.6-sol
         levels:
             normal:
-                effort: low
+                effort: high
             complex:
-                effort: low
+                effort: high
             very_complex:
-                effort: low
+                effort: high


### PR DESCRIPTION
## Summary

Revert the 2026-09-08 Astra-low rollout in this repo's Detent config.

- `detent.yaml`: `normal_model`/`complex_model` move from `gpt-6-astra` to `gpt-5.6-sol` and every `model_selection` complexity level moves from `effort: low` to `effort: high`. `preset: sol_first` is kept.

This repo carries no effort rubric prose, so there is no doc change.

## Test Plan

- [x] Config applied live on corys-mac-studio; reloaded with no validation error. No application code change.